### PR TITLE
Fix mermaid timing diagram in documentation

### DIFF
--- a/docs/timing.md
+++ b/docs/timing.md
@@ -33,7 +33,7 @@ The following table demonstrates the indexing logic for a 50/1 fps video flow st
 
 The following graph demonstrates a ring buffer where the head has wrapped around and is now at ring buffer index 2 (the time span between grain 3 and 7 in the table above).
 
-:::mermaid
+```mermaid
 flowchart LR
 
     A0["ring buffer index=0<br/>grain index=5<br/>ts=120'000'000ns"] --> A1[1]
@@ -43,9 +43,9 @@ flowchart LR
     A4["ring buffer index=4<br/>gi=4<br/>ts=100'000'000ns"] --> A0
 
     %% head
-    style A2 fill:#030,stroke:#333,stroke-width:2px
+    style A2 fill:#030,color:#eee,stroke:#333,stroke-width:2px
 
-:::
+```
 
 ### Converting a timestamp (ns since SMPTE ST 2059 epoch) to a grain index
 


### PR DESCRIPTION
* Replace ::: with ``` to let Github display the mermaid diagram
correctly.
* Set the head text color to make it visible.