### PR TITLE
Add looping file source based MXL writer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,7 @@ endif()
 
 add_subdirectory(lib)
 add_subdirectory(tools)
-
+add_subdirectory(utils)
 
 find_package(Doxygen)
 

--- a/README.md
+++ b/README.md
@@ -44,17 +44,11 @@ A utility that continuously loops through MPEG-TS files to generate video grains
 
 This application requires the `looping_filesrc` GStreamer plugin located in `utils/gst-looping-filesrc/`. 
 
-**Installation Options:**
+After building the plugin successfully, set the GST_PLUGIN_PATH environment variable to enable GStreamer to locate and load the plugin.
 
-1. **System Installation (Recommended):**
-   ```bash
-   cmake --install .
-   ```
-
-2. **Development Setup:**
-   ```bash
-   export GST_PLUGIN_PATH="./build/Linux-GCC-Release/utils/gst-looping-filesrc:${GST_PLUGIN_PATH}"
-   ```
+```bash
+export GST_PLUGIN_PATH="./build/Linux-GCC-Release/utils/gst-looping-filesrc:${GST_PLUGIN_PATH}"
+```
 
 **Verify Installation:**
 ```bash

--- a/README.md
+++ b/README.md
@@ -36,6 +36,43 @@ In order to encourage broad industry adoption, the European Broadcasting Union (
 - [Building options](docs/Building.md)
 - [Tools](docs/Tools.md)
 
+### mxl-gst-looping-filesrc
+
+A utility that continuously loops through MPEG-TS files to generate video grains to push into MXL flows.
+
+#### Prerequisites
+
+This application requires the `looping_filesrc` GStreamer plugin located in `utils/gst-looping-filesrc/`. 
+
+**Installation Options:**
+
+1. **System Installation (Recommended):**
+   ```bash
+   cmake --install .
+   ```
+
+2. **Development Setup:**
+   ```bash
+   export GST_PLUGIN_PATH="./build/Linux-GCC-Release/utils/gst-looping-filesrc:${GST_PLUGIN_PATH}"
+   ```
+
+**Verify Installation:**
+```bash
+gst-inspect-1.0 looping_filesrc
+```
+
+#### Usage
+
+```bash
+mxl-gst-looping-filesrc [OPTIONS]
+
+Options:
+  -h,--help                     Print this help message and exit
+  -d,--domain TEXT:DIR REQUIRED   MXL domain directory
+  -i,--input TEXT:FILE REQUIRED   Input MPEG-TS file to loop
+```
+
+
 ## License
 
 This code is covered by the [Apache v2 license](./LICENSE.txt)

--- a/tools/mxl-gst/CMakeLists.txt
+++ b/tools/mxl-gst/CMakeLists.txt
@@ -87,6 +87,37 @@ if (gstreamer_FOUND)
                 PkgConfig::gstreamer-video
         )
 
+    add_executable(mxl-gst-looping-filesrc)
+    target_compile_features(mxl-gst-looping-filesrc
+        PRIVATE
+        cxx_std_20
+    )
+    set_target_properties(mxl-gst-looping-filesrc
+        PROPERTIES
+        POSITION_INDEPENDENT_CODE ON
+        VISIBILITY_INLINES_HIDDEN ON
+        C_VISIBILITY_PRESET hidden
+        CXX_VISIBILITY_PRESET hidden
+        C_EXTENSIONS OFF
+        CXX_EXTENSIONS OFF
+    )
+    target_sources(mxl-gst-looping-filesrc
+        PRIVATE
+        looping_filesrc.cpp
+    )
+
+    target_link_libraries(mxl-gst-looping-filesrc
+        PRIVATE
+        mxl
+        stduuid
+        CLI11::CLI11
+        spdlog::spdlog
+        PkgConfig::gstreamer
+        PkgConfig::gstreamer-app
+        PkgConfig::gstreamer-video
+    )
+
+
     # Not really a fan of having this relative to the binary,
     # we should leave this at the default.
     set_target_properties(mxl-gst-videosink mxl-gst-videotestsrc

--- a/tools/mxl-gst/CMakeLists.txt
+++ b/tools/mxl-gst/CMakeLists.txt
@@ -104,6 +104,8 @@ if (gstreamer_FOUND)
     target_sources(mxl-gst-looping-filesrc
         PRIVATE
         looping_filesrc.cpp
+        ../../lib/src/internal/FlowParser.cpp
+        ../../lib/src/internal/PathUtils.cpp
     )
 
     target_link_libraries(mxl-gst-looping-filesrc
@@ -120,13 +122,13 @@ if (gstreamer_FOUND)
 
     # Not really a fan of having this relative to the binary,
     # we should leave this at the default.
-    set_target_properties(mxl-gst-videosink mxl-gst-videotestsrc
+    set_target_properties(mxl-gst-videosink mxl-gst-videotestsrc mxl-gst-looping-filesrc
             PROPERTIES
                 INSTALL_RPATH "$ORIGIN/../lib"
         )
 
     # Install targets
-    install(TARGETS mxl-gst-videosink mxl-gst-videotestsrc
+    install(TARGETS mxl-gst-videosink mxl-gst-videotestsrc mxl-gst-looping-filesrc
             COMPONENT ${PROJECT_NAME}-tools
             RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         )

--- a/tools/mxl-gst/looping_filesrc.cpp
+++ b/tools/mxl-gst/looping_filesrc.cpp
@@ -105,14 +105,14 @@ public:
             " ! video/x-raw,format=v210,colorimetry=BT709"
             " ! queue"
             " ! appsink name=appSinkVideo"
-            " emit-signals=true"
+            " emit-signals=false"
             " max-buffers=20"
             " drop=false"
             " sync=true";
 
         GError* error = nullptr;
         pipeline = gst_parse_launch(pipelineDesc.c_str(), &error);
-        if (!pipeline)
+        if (!pipeline || error)
         {
             MXL_ERROR("Failed to create pipeline: {}", error->message);
             g_error_free(error);
@@ -362,7 +362,8 @@ private:
                     GstClockTime pts = GST_BUFFER_PTS(buffer);
                     if (GST_CLOCK_TIME_IS_VALID(pts))
                     {
-                        int64_t frame = currentFrame++;
+                        int64_t frame [[maybe_unused]]
+                        = currentFrame++;
                         MXL_TRACE("Video frame received.  Frame {}, pts (ms) {}, duratio (ms) {}",
                             frame,
                             pts / GST_MSECOND,
@@ -439,11 +440,6 @@ int main(int argc, char* argv[])
     // Set up signal handlers for graceful shutdown
     std::signal(SIGINT, signal_handler);
     std::signal(SIGTERM, signal_handler);
-
-    // Initialize logging in the current app (initialisation in the mxl shared object is done in the createinstance function).
-    auto console = spdlog::stdout_color_mt("console");
-    spdlog::set_default_logger(console);
-    spdlog::cfg::load_env_levels("MXL_LOG_LEVEL");
 
     //
     // Command line argument parsing

--- a/tools/mxl-gst/looping_filesrc.cpp
+++ b/tools/mxl-gst/looping_filesrc.cpp
@@ -362,9 +362,9 @@ private:
                     GstClockTime pts = GST_BUFFER_PTS(buffer);
                     if (GST_CLOCK_TIME_IS_VALID(pts))
                     {
-                        int64_t frame [[maybe_unused]]
-                        = currentFrame++;
-                        MXL_TRACE("Video frame received.  Frame {}, pts (ms) {}, duratio (ms) {}",
+                        [[maybe_unused]]
+                        int64_t frame = currentFrame++;
+                        MXL_TRACE("Video frame received.  Frame {}, pts (ms) {}, duration (ms) {}",
                             frame,
                             pts / GST_MSECOND,
                             GST_BUFFER_DURATION(buffer) / GST_MSECOND);
@@ -463,7 +463,7 @@ int main(int argc, char* argv[])
 
     // Simple scope guard to ensure GStreamer is de-initialized.
     // Replace with std::scope_exit when widely available ( C++23 )
-    auto onExit = std::unique_ptr<void, std::function<void(void*)>>(nullptr, [](void*) { gst_deinit(); });
+    auto onExit = std::unique_ptr<void, void (*)(void*)>(nullptr, [](void*) { gst_deinit(); });
 
     //
     // Create the Player and open the input uri
@@ -481,7 +481,6 @@ int main(int argc, char* argv[])
     if (!player->start())
     {
         MXL_ERROR("Failed to start the player");
-        gst_deinit();
         return -1;
     }
 
@@ -498,9 +497,6 @@ int main(int argc, char* argv[])
 
     // Release the player
     player.reset();
-
-    // Release gstreamer resources.
-    gst_deinit();
 
     return 0;
 }

--- a/tools/mxl-gst/looping_filesrc.cpp
+++ b/tools/mxl-gst/looping_filesrc.cpp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: Apache-2.0
+
 #include <climits>
 #include <csignal>
 #include <atomic>

--- a/tools/mxl-gst/looping_filesrc.cpp
+++ b/tools/mxl-gst/looping_filesrc.cpp
@@ -1,0 +1,515 @@
+#include <csignal>
+#include <filesystem>
+#include <atomic>
+#include <thread>
+#include <memory>
+#include <climits>
+#include <uuid.h>
+#include <CLI/CLI.hpp>
+#include <gst/app/gstappsink.h>
+#include <gst/gst.h>
+#include <picojson/picojson.h>
+#include <spdlog/cfg/env.h>
+#include <spdlog/sinks/stdout_color_sinks.h>
+#include <mxl/flow.h>
+#include <mxl/mxl.h>
+#include <mxl/time.h>
+#include "../../lib/src/internal/Logging.hpp"
+
+namespace fs = std::filesystem;
+
+std::sig_atomic_t volatile g_exit_requested = 0;
+
+void signal_handler(int in_signal)
+{
+    switch (in_signal)
+    {
+        case SIGINT:  MXL_INFO("Received SIGINT, exiting..."); break;
+        case SIGTERM: MXL_INFO("Received SIGTERM, exiting..."); break;
+        default:      MXL_INFO("Received signal {}, exiting...", in_signal); break;
+    }
+    g_exit_requested = 1;
+}
+
+class LoopingFilePlayer
+{
+public:
+    LoopingFilePlayer(std::string in_domain)
+        : domain(std::move(in_domain))
+    {
+        // Create the MXL domain directory if it doesn't exist
+        if (!fs::exists(domain))
+        {
+            try
+            {
+                fs::create_directories(domain);
+                MXL_DEBUG("Created MXL domain directory: {}", domain);
+            }
+            catch (fs::filesystem_error const& e)
+            {
+                MXL_ERROR("Error creating domain directory: {}", e.what());
+                throw;
+            }
+        }
+
+        // Create the MXL SDK instance
+        mxlInstance = mxlCreateInstance(domain.c_str(), nullptr);
+        if (!mxlInstance)
+        {
+            throw std::runtime_error("Failed to create MXL instance");
+        }
+    }
+
+    ~LoopingFilePlayer()
+    {
+        // Join threads if they were created
+        if (videoThreadPtr && videoThreadPtr->joinable())
+        {
+            videoThreadPtr->join();
+        }
+
+        if (pipeline)
+        {
+            gst_element_set_state(pipeline, GST_STATE_NULL);
+            gst_object_unref(pipeline);
+        }
+
+        if (mxlInstance)
+        {
+            if (flowWriterVideo)
+            {
+                mxlReleaseFlowWriter(mxlInstance, flowWriterVideo);
+                auto id = uuids::to_string(videoFlowId);
+                mxlDestroyFlow(mxlInstance, id.c_str());
+            }
+
+            mxlDestroyInstance(mxlInstance);
+        }
+    }
+
+    bool open(std::string const& in_uri)
+    {
+        uri = in_uri;
+        MXL_DEBUG("Opening URI: {}", uri);
+
+        //
+        // Create the gstreamer pipeline
+        //
+        
+        std::string pipelineDesc = "looping_filesrc location=" + in_uri + 
+                                   " ! tsdemux"
+                                   " ! decodebin"
+                                   " ! videorate"
+                                   " ! videoconvert"
+                                   " ! video/x-raw,format=v210,colorimetry=BT709"
+                                   " ! queue"
+                                   " ! appsink name=appSinkVideo"
+                                   " emit-signals=true"
+                                   " max-buffers=20"
+                                   " drop=false"
+                                   " sync=true";
+                                   
+        GError* error = nullptr;
+        pipeline = gst_parse_launch(pipelineDesc.c_str(), &error);
+        if (!pipeline)
+        {
+            MXL_ERROR("Failed to create pipeline: {}", error->message);
+            g_error_free(error);
+            return false;
+        }
+
+        auto bus = gst_element_get_bus(pipeline);
+
+        gst_element_set_state(pipeline, GST_STATE_PAUSED);
+
+        bool negotiated = false;
+        while (!negotiated)
+        {
+            GstMessage* in_msg = gst_bus_timed_pop_filtered(
+                bus, GST_CLOCK_TIME_NONE, static_cast<GstMessageType>(GST_MESSAGE_ASYNC_DONE | GST_MESSAGE_ERROR | GST_MESSAGE_EOS));
+
+            if (!in_msg)
+            {
+                continue;
+            }
+
+            switch (GST_MESSAGE_TYPE(in_msg))
+            {
+                case GST_MESSAGE_ASYNC_DONE: negotiated = true; break;
+                case GST_MESSAGE_ERROR:      {
+                    GError* err;
+                    gchar* debug;
+                    gst_message_parse_error(in_msg, &err, &debug);
+                    MXL_ERROR("Pipeline error: {} ", err->message);
+                    g_error_free(err);
+                    g_free(debug);
+                    break;
+                }
+                default: break;
+            }
+            gst_message_unref(in_msg);
+        }
+        gst_object_unref(bus);
+
+        appSinkVideo = gst_bin_get_by_name(GST_BIN(pipeline), "appSinkVideo");
+
+        if (!appSinkVideo)
+        {
+            MXL_ERROR("No video appsink found");
+            return false;
+        }
+
+        if (appSinkVideo != nullptr)
+        {
+            MXL_DEBUG("Creating MXL flow for video...");
+
+            // Get negotiated caps from appsink's pad
+            GstPad* pad = gst_element_get_static_pad(appSinkVideo, "sink");
+            GstCaps* caps = gst_pad_get_current_caps(pad);
+            int width = 0, height = 0, fps_n = 0, fps_d = 1;
+            gchar const* interlace_mode = nullptr;
+            gchar const* colorimetry = nullptr;
+
+            if (caps)
+            {
+                GstStructure* s = gst_caps_get_structure(caps, 0);
+                interlace_mode = gst_structure_get_string(s, "interlace-mode");
+                colorimetry = gst_structure_get_string(s, "colorimetry");
+
+                gst_structure_get_int(s, "width", &width);
+                gst_structure_get_int(s, "height", &height);
+
+                if (width <= 0 || height <= 0)
+                {
+                    MXL_ERROR("Invalid width or height in caps");
+                    gst_caps_unref(caps);
+                    gst_object_unref(pad);
+                    return false;
+                }
+
+                if (!gst_structure_get_fraction(s, "framerate", &fps_n, &fps_d))
+                {
+                    MXL_ERROR("Failed to get framerate from caps");
+                    gst_caps_unref(caps);
+                    gst_object_unref(pad);
+                    return false;
+                }
+
+                if (fps_n <= 0 || fps_d <= 0)
+                {
+                    MXL_ERROR("Invalid framerate in caps {}/{}", fps_n, fps_d);
+                    gst_caps_unref(caps);
+                    gst_object_unref(pad);
+                    return false;
+                }
+                else if (fps_n == 0 && fps_d == 1)
+                {
+                    MXL_ERROR("Invalid framerate in caps {}/{}.  This potentially signals that the video stream is VFR (variable frame rate) which "
+                              "is unsupported by this application.",
+                        fps_n,
+                        fps_d);
+                    gst_caps_unref(caps);
+                    gst_object_unref(pad);
+                    return false;
+                }
+
+                if (!interlace_mode)
+                {
+                    MXL_ERROR("Failed to get interlace mode from caps. Assuming progressive.");
+                }
+
+                if (!g_str_equal(interlace_mode, "progressive"))
+                {
+                    // TODO : Handle interlaced video
+                    MXL_ERROR("Unsupported interlace mode.  Interpreting as progressive.");
+                }
+
+                // This assumes square pixels, bt709, sdr.  TODO read from caps.
+                gst_caps_unref(caps);
+            }
+            else
+            {
+                MXL_ERROR("Failed to get caps from appsink pad");
+                gst_object_unref(pad);
+                return false;
+            }
+
+            gst_object_unref(pad);
+
+            std::string flowDef;
+            videoGrainRate = Rational{fps_n, fps_d};
+            videoFlowId = createVideoFlowJson(uri, width, height, videoGrainRate, true, colorimetry, flowDef);
+
+            FlowInfo flowInfo;
+            auto res = mxlCreateFlow(mxlInstance, flowDef.c_str(), nullptr, &flowInfo);
+            if (res != MXL_STATUS_OK)
+            {
+                MXL_ERROR("Failed to create flow: {}", (int)res);
+                return false;
+            }
+
+            res = mxlCreateFlowWriter(mxlInstance, uuids::to_string(videoFlowId).c_str(), nullptr, &flowWriterVideo);
+            if (res != MXL_STATUS_OK)
+            {
+                MXL_ERROR("Failed to create flow writer: {}", (int)res);
+                return false;
+            }
+
+            MXL_INFO("Video flow : {}", uuids::to_string(videoFlowId));
+        }
+
+        return true;
+    }
+
+    bool start()
+    {
+        //
+        // Start the pipeline
+        //
+        gst_element_set_state(pipeline, GST_STATE_PLAYING);
+        running = true;
+
+        //
+        // Create the video thread to pull samples from the appsink
+        //
+        videoThreadPtr = appSinkVideo ? std::make_unique<std::thread>(&LoopingFilePlayer::videoThread, this) : nullptr;
+
+        return true;
+    }
+
+    void stop()
+    {
+        running = false;
+    }
+
+    bool isRunning() const
+    {
+        return running;
+    }
+
+private:
+    static uuids::uuid createVideoFlowJson(std::string const& in_uri, int in_width, int in_height, Rational in_rate, bool in_progressive,
+        std::string const& in_colorspace, std::string& out_flowDef)
+    {
+        picojson::object root;
+
+        std::string label = "Video flow for " + in_uri;
+
+        root["description"] = picojson::value(label);
+
+        auto id = uuids::uuid_system_generator{}();
+        root["id"] = picojson::value(uuids::to_string(id));
+        root["tags"] = picojson::value(picojson::object());
+        root["format"] = picojson::value("urn:x-nmos:format:video");
+        root["label"] = picojson::value(label);
+        root["parents"] = picojson::value(picojson::array());
+        root["media_type"] = picojson::value("video/v210");
+
+        picojson::object grain_rate;
+        grain_rate["numerator"] = picojson::value(static_cast<double>(in_rate.numerator));
+        grain_rate["denominator"] = picojson::value(static_cast<double>(in_rate.denominator));
+        root["grain_rate"] = picojson::value(grain_rate);
+
+        root["frame_width"] = picojson::value(static_cast<double>(in_width));
+        root["frame_height"] = picojson::value(static_cast<double>(in_height));
+        root["interlace_mode"] = picojson::value(in_progressive ? "progressive" : "interlaced_tff"); // todo. handle bff.
+        root["colorspace"] = picojson::value(in_colorspace);
+
+        picojson::array components;
+        auto add_component = [&](std::string const& name, int w, int h)
+        {
+            picojson::object comp;
+            comp["name"] = picojson::value(name);
+            comp["width"] = picojson::value(static_cast<double>(w));
+            comp["height"] = picojson::value(static_cast<double>(h));
+            comp["bit_depth"] = picojson::value(10.0);
+            components.emplace_back(comp);
+        };
+
+        add_component("Y", in_width, in_height);
+        add_component("Cb", in_width / 2, in_height);
+        add_component("Cr", in_width / 2, in_height);
+
+        root["components"] = picojson::value(components);
+
+        out_flowDef = picojson::value(root).serialize(true);
+        return id;
+    }
+
+
+
+    void videoThread()
+    {
+        while (running)
+        {
+            
+            auto sample = gst_app_sink_try_pull_sample(GST_APP_SINK(appSinkVideo), 100'000'000);
+            if (sample)
+            {
+
+                uint64_t grainIndex = mxlGetCurrentHeadIndex(&videoGrainRate);
+                if (lastVideoGrainIndex == 0)
+                {
+                    lastVideoGrainIndex = grainIndex;
+                }
+                else if (grainIndex != lastVideoGrainIndex + 1)
+                {
+                    MXL_WARN("Video skipped grain index. Expected {}, got {}", lastVideoGrainIndex + 1, grainIndex);
+                }
+
+                lastVideoGrainIndex = grainIndex;
+
+
+                auto buffer = gst_sample_get_buffer(sample);
+                if (buffer)
+                {   
+                    GstClockTime pts = GST_BUFFER_PTS(buffer);
+                    if (GST_CLOCK_TIME_IS_VALID(pts))
+                    {
+                        int64_t frame = currentFrame++;
+                        MXL_TRACE("Video frame received.  Frame {}, pts (ms) {}, duratio (ms) {}",
+                            frame,
+                            pts / GST_MSECOND,
+                            GST_BUFFER_DURATION(buffer) / GST_MSECOND);
+                    }
+                }
+
+                GstMapInfo map;
+                if (gst_buffer_map(buffer, &map, GST_MAP_READ))
+                {
+                    /// Open the grain.
+                    GrainInfo gInfo;
+                    uint8_t* mxl_buffer = nullptr;
+
+                    /// Open the grain for writing.
+                    if (mxlFlowWriterOpenGrain(flowWriterVideo, grainIndex, &gInfo, &mxl_buffer) != MXL_STATUS_OK)
+                    {
+                        MXL_ERROR("Failed to open grain at index '{}'", grainIndex);
+                        break;
+                    }
+
+                    gInfo.commitedSize = map.size;
+                    ::memcpy(mxl_buffer, map.data, map.size);
+
+                    if (mxlFlowWriterCommitGrain(flowWriterVideo, &gInfo) != MXL_STATUS_OK)
+                    {
+                        MXL_ERROR("Failed to open grain at index '{}'", grainIndex);
+                        break;
+                    }
+
+                    gst_buffer_unmap(buffer, &map);
+                }
+
+                auto ns = mxlGetNsUntilHeadIndex(grainIndex, &videoGrainRate);
+                mxlSleepForNs(ns);
+
+                gst_sample_unref(sample);
+            }
+            else{
+                MXL_WARN("No sample received while pulling from appsink");
+            }
+        }
+    }
+
+
+
+    // The URI GST PlayBin will use to play the video
+    std::string uri;
+    // The MXL video flow id
+    uuids::uuid videoFlowId;
+    // Unique pointer to video processing thread
+    std::unique_ptr<std::thread> videoThreadPtr;
+    // The MXL domain
+    std::string domain;
+    // Video flow writer allocated by the MXL instance
+    ::mxlFlowWriter flowWriterVideo = nullptr;
+    // The MXL instance
+    ::mxlInstance mxlInstance = nullptr;
+
+    ::GstElement* pipeline = nullptr;
+    ::GstElement* appSinkVideo = nullptr;
+
+    // Keep a copy of the last video grain index
+    uint64_t lastVideoGrainIndex = 0;
+    // Running flag
+    std::atomic<bool> running{false};
+    // Current frame number
+    std::atomic<int64_t> currentFrame{0};
+    // The video grain rate
+    ::Rational videoGrainRate{0, 1};
+};
+
+int main(int argc, char* argv[])
+{
+    // Set up signal handlers for graceful shutdown
+    std::signal(SIGINT, signal_handler);
+    std::signal(SIGTERM, signal_handler);
+
+    // Initialize logging in the current app (initialisation in the mxl shared object is done in the createinstance function).
+    auto console = spdlog::stdout_color_mt("console");
+    spdlog::set_default_logger(console);
+    spdlog::cfg::load_env_levels("MXL_LOG_LEVEL");
+
+    //
+    // Command line argument parsing
+    //
+    std::string inputFile, domain;
+
+    CLI::App cli{"mxl-gst-looping-filesrc"};
+    auto domainOpt = cli.add_option("-d,--domain", domain, "The MXL domain directory")->required();
+    domainOpt->required(true);
+
+    auto inputOpt = cli.add_option("-i,--input", inputFile, "MPEGTS media file location")->required();
+    inputOpt->required(true);
+    inputOpt->check(CLI::ExistingFile);
+
+    CLI11_PARSE(cli, argc, argv);
+
+    //
+    // Initialize GStreamer
+    //
+    gst_init(&argc, &argv);
+
+    // Simple scope guard to ensure GStreamer is de-initialized.
+    // Replace with std::scope_exit when widely available ( C++23 )
+    auto onExit = std::unique_ptr<void, std::function<void(void*)>>(nullptr, [](void*) { gst_deinit(); });
+
+    //
+    // Create the Player and open the input uri
+    //
+    auto player = std::make_unique<LoopingFilePlayer>(domain);
+    if (!player->open(inputFile))
+    {
+        MXL_ERROR("Failed to open input file: {}", inputFile);
+        return -1;
+    }
+
+    //
+    // Start the player
+    //
+    if (!player->start())
+    {
+        MXL_ERROR("Failed to start the player");
+        gst_deinit();
+        return -1;
+    }
+
+    while (!g_exit_requested && player->isRunning())
+    {
+        // Wait for the player to finish
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+
+    if (player->isRunning())
+    {
+        player->stop();
+    }
+
+    // Release the player
+    player.reset();
+
+    // Release gstreamer resources.
+    gst_deinit();
+
+    return 0;
+} 

--- a/tools/mxl-gst/looping_filesrc.cpp
+++ b/tools/mxl-gst/looping_filesrc.cpp
@@ -1,19 +1,19 @@
-#include <csignal>
-#include <filesystem>
-#include <atomic>
-#include <thread>
-#include <memory>
 #include <climits>
+#include <csignal>
+#include <atomic>
+#include <filesystem>
+#include <memory>
+#include <thread>
 #include <uuid.h>
 #include <CLI/CLI.hpp>
 #include <gst/app/gstappsink.h>
 #include <gst/gst.h>
-#include <picojson/picojson.h>
-#include <spdlog/cfg/env.h>
-#include <spdlog/sinks/stdout_color_sinks.h>
 #include <mxl/flow.h>
 #include <mxl/mxl.h>
 #include <mxl/time.h>
+#include <picojson/picojson.h>
+#include <spdlog/cfg/env.h>
+#include <spdlog/sinks/stdout_color_sinks.h>
 #include "../../lib/src/internal/Logging.hpp"
 
 namespace fs = std::filesystem;
@@ -95,20 +95,21 @@ public:
         //
         // Create the gstreamer pipeline
         //
-        
-        std::string pipelineDesc = "looping_filesrc location=" + in_uri + 
-                                   " ! tsdemux"
-                                   " ! decodebin"
-                                   " ! videorate"
-                                   " ! videoconvert"
-                                   " ! video/x-raw,format=v210,colorimetry=BT709"
-                                   " ! queue"
-                                   " ! appsink name=appSinkVideo"
-                                   " emit-signals=true"
-                                   " max-buffers=20"
-                                   " drop=false"
-                                   " sync=true";
-                                   
+
+        std::string pipelineDesc =
+            "looping_filesrc location=" + in_uri +
+            " ! tsdemux"
+            " ! decodebin"
+            " ! videorate"
+            " ! videoconvert"
+            " ! video/x-raw,format=v210,colorimetry=BT709"
+            " ! queue"
+            " ! appsink name=appSinkVideo"
+            " emit-signals=true"
+            " max-buffers=20"
+            " drop=false"
+            " sync=true";
+
         GError* error = nullptr;
         pipeline = gst_parse_launch(pipelineDesc.c_str(), &error);
         if (!pipeline)
@@ -336,17 +337,13 @@ private:
         return id;
     }
 
-
-
     void videoThread()
     {
         while (running)
         {
-            
             auto sample = gst_app_sink_try_pull_sample(GST_APP_SINK(appSinkVideo), 100'000'000);
             if (sample)
             {
-
                 uint64_t grainIndex = mxlGetCurrentHeadIndex(&videoGrainRate);
                 if (lastVideoGrainIndex == 0)
                 {
@@ -359,10 +356,9 @@ private:
 
                 lastVideoGrainIndex = grainIndex;
 
-
                 auto buffer = gst_sample_get_buffer(sample);
                 if (buffer)
-                {   
+                {
                     GstClockTime pts = GST_BUFFER_PTS(buffer);
                     if (GST_CLOCK_TIME_IS_VALID(pts))
                     {
@@ -405,13 +401,12 @@ private:
 
                 gst_sample_unref(sample);
             }
-            else{
+            else
+            {
                 MXL_WARN("No sample received while pulling from appsink");
             }
         }
     }
-
-
 
     // The URI GST PlayBin will use to play the video
     std::string uri;
@@ -512,4 +507,4 @@ int main(int argc, char* argv[])
     gst_deinit();
 
     return 0;
-} 
+}

--- a/tools/mxl-gst/looping_filesrc.cpp
+++ b/tools/mxl-gst/looping_filesrc.cpp
@@ -344,7 +344,7 @@ private:
             auto sample = gst_app_sink_try_pull_sample(GST_APP_SINK(appSinkVideo), 100'000'000);
             if (sample)
             {
-                uint64_t grainIndex = mxlGetCurrentHeadIndex(&videoGrainRate);
+                uint64_t grainIndex = mxlGetCurrentIndex(&videoGrainRate);
                 if (lastVideoGrainIndex == 0)
                 {
                     lastVideoGrainIndex = grainIndex;
@@ -397,7 +397,7 @@ private:
                     gst_buffer_unmap(buffer, &map);
                 }
 
-                auto ns = mxlGetNsUntilHeadIndex(grainIndex, &videoGrainRate);
+                auto ns = mxlGetNsUntilIndex(grainIndex, &videoGrainRate);
                 mxlSleepForNs(ns);
 
                 gst_sample_unref(sample);

--- a/tools/mxl-gst/looping_filesrc.cpp
+++ b/tools/mxl-gst/looping_filesrc.cpp
@@ -401,9 +401,8 @@ private:
                 }
 
                 auto ns = mxlGetNsUntilIndex(grainIndex, &videoGrainRate);
-                mxlSleepForNs(ns);
-
                 gst_sample_unref(sample);
+                mxlSleepForNs(ns);
             }
             else
             {

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: 2025 Contributors to the Media eXchange Layer project.
+# SPDX-License-Identifier: Apache-2.0
+
 add_subdirectory(gst-looping-filesrc)

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(gst-looping-filesrc)

--- a/utils/gst-looping-filesrc/CMakeLists.txt
+++ b/utils/gst-looping-filesrc/CMakeLists.txt
@@ -17,6 +17,8 @@ cmake_minimum_required(VERSION 3.22)
 
 project(gst-looping-filesrc LANGUAGES C CXX)
 
+include(GNUInstallDirs)
+
 find_package(PkgConfig)
 
 pkg_check_modules(GST REQUIRED IMPORTED_TARGET gstreamer-1.0 gstreamer-base-1.0)
@@ -55,7 +57,7 @@ target_link_libraries(looping_filesrc PUBLIC
 
 set_target_properties(PROPERTIES PUBLIC_HEADER gst-looping-filesrc.h)
 
-set(GSTREAMER_PLUGIN_PATH /usr/lib/${CMAKE_SYSTEM_PROCESSOR}-linux-gnu/gstreamer-1.0/ CACHE PATH "Where to install the plugin")
+set(GSTREAMER_PLUGIN_PATH ${CMAKE_INSTALL_LIBDIR}/gstreamer-1.0 CACHE PATH "Where to install the plugin")
 message(STATUS "GSTREAMER_PLUGIN_PATH=\"${GSTREAMER_PLUGIN_PATH}\"")
 
 install(

--- a/utils/gst-looping-filesrc/CMakeLists.txt
+++ b/utils/gst-looping-filesrc/CMakeLists.txt
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.22)
+
+project(gst-looping-filesrc LANGUAGES C CXX)
+
+find_package(PkgConfig)
+
+pkg_check_modules(GST REQUIRED IMPORTED_TARGET gstreamer-1.0 gstreamer-base-1.0)
+
+add_library(looping_filesrc SHARED
+    gst-looping-filesrc.cpp
+    )
+
+if(MSVC)
+    # Force to always compile with W4
+    if(CMAKE_CXX_FLAGS MATCHES "/W[0-4]")
+	string(REGEX REPLACE "/W[0-4]" "/W4" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+    else()
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4")
+    endif()
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    target_compile_options(looping_filesrc PRIVATE
+	-Wall
+	-Wno-long-long
+	-pedantic
+	)
+endif()
+
+target_include_directories(looping_filesrc PUBLIC
+    .
+    )
+
+set_target_properties(looping_filesrc PROPERTIES
+    CXX_STANDARD 17
+    CXX_EXTENSIONS OFF
+    )
+
+target_link_libraries(looping_filesrc PUBLIC
+    PkgConfig::GST
+    )
+
+set_target_properties(PROPERTIES PUBLIC_HEADER gst-looping-filesrc.h)
+
+set(GSTREAMER_PLUGIN_PATH /usr/lib/${CMAKE_SYSTEM_PROCESSOR}-linux-gnu/gstreamer-1.0/ CACHE PATH "Where to install the plugin")
+message(STATUS "GSTREAMER_PLUGIN_PATH=\"${GSTREAMER_PLUGIN_PATH}\"")
+
+install(
+    TARGETS looping_filesrc
+    DESTINATION ${GSTREAMER_PLUGIN_PATH}
+    PUBLIC_HEADER
+    DESTINATION ${GSTREAMER_PLUGIN_PATH}/include)

--- a/utils/gst-looping-filesrc/CMakeLists.txt
+++ b/utils/gst-looping-filesrc/CMakeLists.txt
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: 2025 Contributors to the Media eXchange Layer project.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/utils/gst-looping-filesrc/LICENSE.txt
+++ b/utils/gst-looping-filesrc/LICENSE.txt
@@ -1,0 +1,191 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright (c) 2023-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/utils/gst-looping-filesrc/README.md
+++ b/utils/gst-looping-filesrc/README.md
@@ -1,0 +1,40 @@
+<!--
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+-->
+
+# gst-looping-filesrc
+
+Like GStreamer's `filesrc` but rewinds file to the beginning once EOF is reached.
+
+Please note that this will only work for video containers that support concatenation like MPEG transport layer (`*.ts`).
+Remember to update the pipeline for a input file on your computer!
+
+If you want to loop other containers you either need to seek the whole pipeline or implement the looping logic at the
+demuxer-level. The demuxer would need to correctly offset `dts`/`pts` for the repeating segments and rewind the filesrc
+to the beginning (or use this implementation that appears as a infinitely big file). The demuxer pulls buffers from
+any typ of filesrc.
+
+## Building
+
+```
+mkdir build
+cd build
+cmake -DCMAKE_BUILD_TYPE=Release ..
+make -j20
+```
+To use the built library must be in `GST_PLUGIN_PATH` or place in `/usr/lib/x86_64-linux-gnu/gstreamer-1.0/` or
+`/opt/nvidia/deepstream/deepstream/lib/gst-plugins` (when the latter has been enabled for GStreamer plugins).
+Using `sudo make install` will install to `/usr/lib/x86_64-linux-gnu/gstreamer-1.0/`.

--- a/utils/gst-looping-filesrc/README.md
+++ b/utils/gst-looping-filesrc/README.md
@@ -1,5 +1,6 @@
 <!--
 # SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: 2025 Contributors to the Media eXchange Layer project.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/utils/gst-looping-filesrc/gst-looping-filesrc.cpp
+++ b/utils/gst-looping-filesrc/gst-looping-filesrc.cpp
@@ -1,0 +1,280 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "gst-looping-filesrc.h"
+#include <algorithm>
+#include <cassert>
+#include <gst/base/gstbasesrc.h>
+#include <gstreamer-1.0/gst/gstinfo.h>
+
+GST_DEBUG_CATEGORY_STATIC(gst_looping_filesrc_debug);
+#define GST_CAT_DEFAULT gst_looping_filesrc_debug
+
+#define gst_looping_filesrc_parent_class parent_class
+G_DEFINE_TYPE(GstLoopingFileSrc, gst_looping_filesrc, GST_TYPE_BASE_SRC)
+
+enum {
+  PROP_0,
+  PROP_LOCATION,
+  PROP_LOOP,
+};
+
+#define PACKAGE "looping-filesrc"
+#define LOOPING_FILESRC_VERSION "0.1.0"
+#define LOOPING_FILESRC_DESCRIPTION "Loop a file"
+#define LOOPING_FILESRC_LICENSE "Apache-2.0"
+#define LOOPING_FILESRC_ORIGIN "http://nvidia.com"
+#define LOOPING_FILESRC_SOURCE "gst-looping-filesrc"
+
+#define LOCATION_DEFAULT ""
+#define LOOP_DEFAULT true
+
+namespace {
+
+static GstStaticPadTemplate srctemplate = GST_STATIC_PAD_TEMPLATE(
+    "src", GST_PAD_SRC, GST_PAD_ALWAYS, GST_STATIC_CAPS_ANY);
+
+void set_property(GObject *object, guint prop_id, const GValue *value,
+                  GParamSpec *pspec) {
+  GST_TRACE_OBJECT(object, __FUNCTION__);
+
+  GstLoopingFileSrc *filesrc = GST_LOOPING_FILESRC(object);
+
+  switch (prop_id) {
+  case PROP_LOCATION:
+    g_free(filesrc->location);
+    filesrc->location = g_strdup(g_value_get_string(value));
+    break;
+  case PROP_LOOP:
+    filesrc->loop = g_value_get_boolean(value);
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+  }
+}
+
+void get_property(GObject *object, guint prop_id, GValue *value,
+                  GParamSpec *pspec) {
+  GST_TRACE_OBJECT(object, __FUNCTION__);
+
+  GstLoopingFileSrc *filesrc = GST_LOOPING_FILESRC(object);
+
+  switch (prop_id) {
+  case PROP_LOCATION: {
+    g_value_set_string(value, filesrc->location);
+    break;
+  }
+  case PROP_LOOP: {
+    g_value_set_boolean(value, filesrc->loop);
+    break;
+  }
+  default: {
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+  }
+}
+
+void finalize(GObject *object) {
+  GST_TRACE_OBJECT(object, "finalize");
+
+  auto looping_filesrc = GST_LOOPING_FILESRC(object);
+  g_free(looping_filesrc->location);
+  if (looping_filesrc->file) {
+    fclose(looping_filesrc->file);
+  }
+  G_OBJECT_CLASS(parent_class)->finalize(object);
+}
+
+gboolean start(GstBaseSrc *basesrc) {
+  GST_TRACE_OBJECT(basesrc, "start");
+
+  auto *src = GST_LOOPING_FILESRC(basesrc);
+  GST_DEBUG_OBJECT(basesrc, "Opening file \"%s\"...", src->location);
+  src->file = fopen(src->location, "rb");
+  if (!src->file) {
+    GST_ERROR("Failed to open file \"%s\"", src->location);
+    return false;
+  }
+
+  fseek(src->file, 0, SEEK_END);
+  src->file_size = ftell(src->file);
+  fseek(src->file, 0, SEEK_SET);
+
+  gst_base_src_set_dynamic_size(basesrc, false);
+
+  return true;
+}
+
+gboolean stop(GstBaseSrc *basesrc) {
+  GST_TRACE_OBJECT(basesrc, "stop");
+
+  auto *src = GST_LOOPING_FILESRC(basesrc);
+  if (src->file) {
+    fclose(src->file);
+  }
+  src->file = nullptr;
+  src->file_size = 0;
+
+  return true;
+}
+
+gboolean is_seekable(GstBaseSrc *basesrc) { return false; }
+
+gboolean get_size(GstBaseSrc *basesrc, guint64 *size) {
+  GstLoopingFileSrc *looping_filesrc = GST_LOOPING_FILESRC(basesrc);
+
+  if (looping_filesrc->loop) {
+    return false;
+  } else {
+    *size = looping_filesrc->file_size;
+    return true;
+  }
+}
+
+GstFlowReturn fill(GstBaseSrc *basesrc, guint64 offset, guint size,
+                   GstBuffer *buf) {
+  GstMapInfo info;
+  GstLoopingFileSrc *src = GST_LOOPING_FILESRC(basesrc);
+  int rtn;
+  size_t read = 0;
+
+  GST_TRACE_OBJECT(basesrc, "fill (offset %zi, size %u)", offset, size);
+
+  if (!gst_buffer_map(buf, &info, GST_MAP_WRITE)) {
+    GST_ERROR("Failed to map buffer");
+    return GST_FLOW_ERROR;
+  }
+
+  rtn = fread(info.data, 1, size, src->file);
+  if (rtn < 0) {
+    GST_ERROR_OBJECT(basesrc, "Failed to read from file");
+    return GST_FLOW_ERROR;
+  }
+
+  read += rtn;
+  GST_DEBUG_OBJECT(basesrc, "Read %i bytes", rtn);
+
+  if (!src->loop && (guint)rtn != size) {
+    gst_buffer_unmap(buf, &info);
+    gst_buffer_resize(buf, 0, rtn);
+    if (rtn == 0) {
+      GST_DEBUG_OBJECT(basesrc, "End of file");
+      return GST_FLOW_EOS;
+    } else {
+      return GST_FLOW_OK;
+    }
+  }
+
+  while (src->loop && read < size) {
+
+    size_t diff = size - read;
+    GST_DEBUG_OBJECT(basesrc, "Trying to loop file. %zi bytes missing", diff);
+    rtn = fseek(src->file, 0, SEEK_SET);
+    if (rtn < 0) {
+      GST_ERROR("Failed to seek to the start of the file: %i", rtn);
+      return GST_FLOW_ERROR;
+    }
+
+    rtn = fread(info.data + read, 1, diff, src->file);
+    if (rtn < 0) {
+      GST_ERROR_OBJECT(basesrc, "Failed to read from file: %i", rtn);
+      return GST_FLOW_ERROR;
+    }
+    read += rtn;
+    GST_DEBUG_OBJECT(basesrc, "Read additional %i bytes", rtn);
+  }
+
+  gst_buffer_unmap(buf, &info);
+  GST_BUFFER_OFFSET(buf) = offset;
+  GST_BUFFER_OFFSET_END(buf) = offset + read;
+
+  return GST_FLOW_OK;
+}
+} // namespace
+
+static void gst_looping_filesrc_class_init(GstLoopingFileSrcClass *klass) {
+  GObjectClass *gobject_class;
+  GstElementClass *gstelement_class;
+  GstBaseSrcClass *gstbasesrc_class;
+
+  gobject_class = (GObjectClass *)klass;
+  gstelement_class = (GstElementClass *)klass;
+  gstbasesrc_class = (GstBaseSrcClass *)klass;
+
+  gobject_class->finalize = finalize;
+  gobject_class->set_property = set_property;
+  gobject_class->get_property = get_property;
+
+  gstbasesrc_class->start = start;
+  gstbasesrc_class->stop = stop;
+  gstbasesrc_class->is_seekable = is_seekable;
+  gstbasesrc_class->get_size = get_size;
+  gstbasesrc_class->fill = fill;
+
+  g_object_class_install_property(
+      gobject_class, PROP_LOCATION,
+      g_param_spec_string("location", "Location of file to loop",
+                          "Location of file to loop", LOCATION_DEFAULT,
+                          G_PARAM_READWRITE));
+  g_object_class_install_property(
+      gobject_class, PROP_LOOP,
+      g_param_spec_boolean("loop", "Whether to loop the file",
+                           "Whether to loop the file", LOOP_DEFAULT,
+                           G_PARAM_READWRITE));
+
+  gst_element_class_add_static_pad_template(gstelement_class, &srctemplate);
+  gst_element_class_set_details_simple(
+      gstelement_class, "looping-filesrc", "Generic",
+      "Like filesrc but will loop the input content",
+      "NVIDIA Corporation. See "
+      "https://developer.nvidia.com/holoscan-for-media");
+}
+
+static void gst_looping_filesrc_init(GstLoopingFileSrc *filesrc) {
+  auto basesrc = GST_BASE_SRC(filesrc);
+
+  filesrc->location = nullptr;
+  filesrc->file = nullptr;
+  filesrc->file_size = 0;
+  filesrc->loop = LOOP_DEFAULT;
+
+  gst_base_src_set_live(basesrc, false);
+  gst_base_src_set_automatic_eos(basesrc, false);
+  g_object_set(filesrc, "location", LOCATION_DEFAULT, NULL);
+}
+
+static gboolean plugin_init(GstPlugin *plugin) {
+  GST_DEBUG_CATEGORY_INIT(gst_looping_filesrc_debug, "looping_filesrc", 0,
+                          "Looping filesrc plugin");
+
+  return gst_element_register(plugin, "looping_filesrc", GST_RANK_NONE,
+                              gst_looping_filesrc_get_type());
+}
+
+GST_PLUGIN_DEFINE(GST_VERSION_MAJOR, GST_VERSION_MINOR, looping_filesrc,
+                  LOOPING_FILESRC_DESCRIPTION, plugin_init,
+                  LOOPING_FILESRC_VERSION, LOOPING_FILESRC_LICENSE, PACKAGE,
+                  LOOPING_FILESRC_ORIGIN)
+
+void gst_looping_filesrc_register_static() {
+  gst_plugin_register_static(GST_VERSION_MAJOR, GST_VERSION_MINOR,
+                             "looping_filesrc", LOOPING_FILESRC_DESCRIPTION,
+                             plugin_init, LOOPING_FILESRC_VERSION,
+                             LOOPING_FILESRC_LICENSE, LOOPING_FILESRC_SOURCE,
+                             PACKAGE, LOOPING_FILESRC_ORIGIN);
+}

--- a/utils/gst-looping-filesrc/gst-looping-filesrc.cpp
+++ b/utils/gst-looping-filesrc/gst-looping-filesrc.cpp
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: 2025 Contributors to the Media eXchange Layer project.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/utils/gst-looping-filesrc/gst-looping-filesrc.cpp
+++ b/utils/gst-looping-filesrc/gst-looping-filesrc.cpp
@@ -16,8 +16,8 @@
  */
 
 #include "gst-looping-filesrc.h"
-#include <algorithm>
 #include <cassert>
+#include <algorithm>
 #include <gst/base/gstbasesrc.h>
 #include <gstreamer-1.0/gst/gstinfo.h>
 
@@ -27,254 +27,277 @@ GST_DEBUG_CATEGORY_STATIC(gst_looping_filesrc_debug);
 #define gst_looping_filesrc_parent_class parent_class
 G_DEFINE_TYPE(GstLoopingFileSrc, gst_looping_filesrc, GST_TYPE_BASE_SRC)
 
-enum {
-  PROP_0,
-  PROP_LOCATION,
-  PROP_LOOP,
+enum
+{
+    PROP_0,
+    PROP_LOCATION,
+    PROP_LOOP,
 };
 
-#define PACKAGE "looping-filesrc"
-#define LOOPING_FILESRC_VERSION "0.1.0"
+#define PACKAGE                     "looping-filesrc"
+#define LOOPING_FILESRC_VERSION     "0.1.0"
 #define LOOPING_FILESRC_DESCRIPTION "Loop a file"
-#define LOOPING_FILESRC_LICENSE "Apache-2.0"
-#define LOOPING_FILESRC_ORIGIN "http://nvidia.com"
-#define LOOPING_FILESRC_SOURCE "gst-looping-filesrc"
+#define LOOPING_FILESRC_LICENSE     "Apache-2.0"
+#define LOOPING_FILESRC_ORIGIN      "http://nvidia.com"
+#define LOOPING_FILESRC_SOURCE      "gst-looping-filesrc"
 
 #define LOCATION_DEFAULT ""
-#define LOOP_DEFAULT true
+#define LOOP_DEFAULT     true
 
-namespace {
+namespace
+{
 
-static GstStaticPadTemplate srctemplate = GST_STATIC_PAD_TEMPLATE(
-    "src", GST_PAD_SRC, GST_PAD_ALWAYS, GST_STATIC_CAPS_ANY);
+    static GstStaticPadTemplate srctemplate = GST_STATIC_PAD_TEMPLATE("src", GST_PAD_SRC, GST_PAD_ALWAYS, GST_STATIC_CAPS_ANY);
 
-void set_property(GObject *object, guint prop_id, const GValue *value,
-                  GParamSpec *pspec) {
-  GST_TRACE_OBJECT(object, __FUNCTION__);
+    void set_property(GObject* object, guint prop_id, GValue const* value, GParamSpec* pspec)
+    {
+        GST_TRACE_OBJECT(object, __FUNCTION__);
 
-  GstLoopingFileSrc *filesrc = GST_LOOPING_FILESRC(object);
+        GstLoopingFileSrc* filesrc = GST_LOOPING_FILESRC(object);
 
-  switch (prop_id) {
-  case PROP_LOCATION:
-    g_free(filesrc->location);
-    filesrc->location = g_strdup(g_value_get_string(value));
-    break;
-  case PROP_LOOP:
-    filesrc->loop = g_value_get_boolean(value);
-    break;
-  default:
-    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
-  }
-}
-
-void get_property(GObject *object, guint prop_id, GValue *value,
-                  GParamSpec *pspec) {
-  GST_TRACE_OBJECT(object, __FUNCTION__);
-
-  GstLoopingFileSrc *filesrc = GST_LOOPING_FILESRC(object);
-
-  switch (prop_id) {
-  case PROP_LOCATION: {
-    g_value_set_string(value, filesrc->location);
-    break;
-  }
-  case PROP_LOOP: {
-    g_value_set_boolean(value, filesrc->loop);
-    break;
-  }
-  default: {
-    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
-    break;
-  }
-  }
-}
-
-void finalize(GObject *object) {
-  GST_TRACE_OBJECT(object, "finalize");
-
-  auto looping_filesrc = GST_LOOPING_FILESRC(object);
-  g_free(looping_filesrc->location);
-  if (looping_filesrc->file) {
-    fclose(looping_filesrc->file);
-  }
-  G_OBJECT_CLASS(parent_class)->finalize(object);
-}
-
-gboolean start(GstBaseSrc *basesrc) {
-  GST_TRACE_OBJECT(basesrc, "start");
-
-  auto *src = GST_LOOPING_FILESRC(basesrc);
-  GST_DEBUG_OBJECT(basesrc, "Opening file \"%s\"...", src->location);
-  src->file = fopen(src->location, "rb");
-  if (!src->file) {
-    GST_ERROR("Failed to open file \"%s\"", src->location);
-    return false;
-  }
-
-  fseek(src->file, 0, SEEK_END);
-  src->file_size = ftell(src->file);
-  fseek(src->file, 0, SEEK_SET);
-
-  gst_base_src_set_dynamic_size(basesrc, false);
-
-  return true;
-}
-
-gboolean stop(GstBaseSrc *basesrc) {
-  GST_TRACE_OBJECT(basesrc, "stop");
-
-  auto *src = GST_LOOPING_FILESRC(basesrc);
-  if (src->file) {
-    fclose(src->file);
-  }
-  src->file = nullptr;
-  src->file_size = 0;
-
-  return true;
-}
-
-gboolean is_seekable(GstBaseSrc *basesrc) { return false; }
-
-gboolean get_size(GstBaseSrc *basesrc, guint64 *size) {
-  GstLoopingFileSrc *looping_filesrc = GST_LOOPING_FILESRC(basesrc);
-
-  if (looping_filesrc->loop) {
-    return false;
-  } else {
-    *size = looping_filesrc->file_size;
-    return true;
-  }
-}
-
-GstFlowReturn fill(GstBaseSrc *basesrc, guint64 offset, guint size,
-                   GstBuffer *buf) {
-  GstMapInfo info;
-  GstLoopingFileSrc *src = GST_LOOPING_FILESRC(basesrc);
-  int rtn;
-  size_t read = 0;
-
-  GST_TRACE_OBJECT(basesrc, "fill (offset %zi, size %u)", offset, size);
-
-  if (!gst_buffer_map(buf, &info, GST_MAP_WRITE)) {
-    GST_ERROR("Failed to map buffer");
-    return GST_FLOW_ERROR;
-  }
-
-  rtn = fread(info.data, 1, size, src->file);
-  if (rtn < 0) {
-    GST_ERROR_OBJECT(basesrc, "Failed to read from file");
-    return GST_FLOW_ERROR;
-  }
-
-  read += rtn;
-  GST_DEBUG_OBJECT(basesrc, "Read %i bytes", rtn);
-
-  if (!src->loop && (guint)rtn != size) {
-    gst_buffer_unmap(buf, &info);
-    gst_buffer_resize(buf, 0, rtn);
-    if (rtn == 0) {
-      GST_DEBUG_OBJECT(basesrc, "End of file");
-      return GST_FLOW_EOS;
-    } else {
-      return GST_FLOW_OK;
-    }
-  }
-
-  while (src->loop && read < size) {
-
-    size_t diff = size - read;
-    GST_DEBUG_OBJECT(basesrc, "Trying to loop file. %zi bytes missing", diff);
-    rtn = fseek(src->file, 0, SEEK_SET);
-    if (rtn < 0) {
-      GST_ERROR("Failed to seek to the start of the file: %i", rtn);
-      return GST_FLOW_ERROR;
+        switch (prop_id)
+        {
+            case PROP_LOCATION:
+                g_free(filesrc->location);
+                filesrc->location = g_strdup(g_value_get_string(value));
+                break;
+            case PROP_LOOP: filesrc->loop = g_value_get_boolean(value); break;
+            default:        G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+        }
     }
 
-    rtn = fread(info.data + read, 1, diff, src->file);
-    if (rtn < 0) {
-      GST_ERROR_OBJECT(basesrc, "Failed to read from file: %i", rtn);
-      return GST_FLOW_ERROR;
+    void get_property(GObject* object, guint prop_id, GValue* value, GParamSpec* pspec)
+    {
+        GST_TRACE_OBJECT(object, __FUNCTION__);
+
+        GstLoopingFileSrc* filesrc = GST_LOOPING_FILESRC(object);
+
+        switch (prop_id)
+        {
+            case PROP_LOCATION: {
+                g_value_set_string(value, filesrc->location);
+                break;
+            }
+            case PROP_LOOP: {
+                g_value_set_boolean(value, filesrc->loop);
+                break;
+            }
+            default: {
+                G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+                break;
+            }
+        }
     }
-    read += rtn;
-    GST_DEBUG_OBJECT(basesrc, "Read additional %i bytes", rtn);
-  }
 
-  gst_buffer_unmap(buf, &info);
-  GST_BUFFER_OFFSET(buf) = offset;
-  GST_BUFFER_OFFSET_END(buf) = offset + read;
+    void finalize(GObject* object)
+    {
+        GST_TRACE_OBJECT(object, "finalize");
 
-  return GST_FLOW_OK;
-}
+        auto looping_filesrc = GST_LOOPING_FILESRC(object);
+        g_free(looping_filesrc->location);
+        if (looping_filesrc->file)
+        {
+            fclose(looping_filesrc->file);
+        }
+        G_OBJECT_CLASS(parent_class)->finalize(object);
+    }
+
+    gboolean start(GstBaseSrc* basesrc)
+    {
+        GST_TRACE_OBJECT(basesrc, "start");
+
+        auto* src = GST_LOOPING_FILESRC(basesrc);
+        GST_DEBUG_OBJECT(basesrc, "Opening file \"%s\"...", src->location);
+        src->file = fopen(src->location, "rb");
+        if (!src->file)
+        {
+            GST_ERROR("Failed to open file \"%s\"", src->location);
+            return false;
+        }
+
+        fseek(src->file, 0, SEEK_END);
+        src->file_size = ftell(src->file);
+        fseek(src->file, 0, SEEK_SET);
+
+        gst_base_src_set_dynamic_size(basesrc, false);
+
+        return true;
+    }
+
+    gboolean stop(GstBaseSrc* basesrc)
+    {
+        GST_TRACE_OBJECT(basesrc, "stop");
+
+        auto* src = GST_LOOPING_FILESRC(basesrc);
+        if (src->file)
+        {
+            fclose(src->file);
+        }
+        src->file = nullptr;
+        src->file_size = 0;
+
+        return true;
+    }
+
+    gboolean is_seekable(GstBaseSrc* basesrc)
+    {
+        return false;
+    }
+
+    gboolean get_size(GstBaseSrc* basesrc, guint64* size)
+    {
+        GstLoopingFileSrc* looping_filesrc = GST_LOOPING_FILESRC(basesrc);
+
+        if (looping_filesrc->loop)
+        {
+            return false;
+        }
+        else
+        {
+            *size = looping_filesrc->file_size;
+            return true;
+        }
+    }
+
+    GstFlowReturn fill(GstBaseSrc* basesrc, guint64 offset, guint size, GstBuffer* buf)
+    {
+        GstMapInfo info;
+        GstLoopingFileSrc* src = GST_LOOPING_FILESRC(basesrc);
+        int rtn;
+        size_t read = 0;
+
+        GST_TRACE_OBJECT(basesrc, "fill (offset %zi, size %u)", offset, size);
+
+        if (!gst_buffer_map(buf, &info, GST_MAP_WRITE))
+        {
+            GST_ERROR("Failed to map buffer");
+            return GST_FLOW_ERROR;
+        }
+
+        rtn = fread(info.data, 1, size, src->file);
+        if (rtn < 0)
+        {
+            GST_ERROR_OBJECT(basesrc, "Failed to read from file");
+            return GST_FLOW_ERROR;
+        }
+
+        read += rtn;
+        GST_DEBUG_OBJECT(basesrc, "Read %i bytes", rtn);
+
+        if (!src->loop && (guint)rtn != size)
+        {
+            gst_buffer_unmap(buf, &info);
+            gst_buffer_resize(buf, 0, rtn);
+            if (rtn == 0)
+            {
+                GST_DEBUG_OBJECT(basesrc, "End of file");
+                return GST_FLOW_EOS;
+            }
+            else
+            {
+                return GST_FLOW_OK;
+            }
+        }
+
+        while (src->loop && read < size)
+        {
+            size_t diff = size - read;
+            GST_DEBUG_OBJECT(basesrc, "Trying to loop file. %zi bytes missing", diff);
+            rtn = fseek(src->file, 0, SEEK_SET);
+            if (rtn < 0)
+            {
+                GST_ERROR("Failed to seek to the start of the file: %i", rtn);
+                return GST_FLOW_ERROR;
+            }
+
+            rtn = fread(info.data + read, 1, diff, src->file);
+            if (rtn < 0)
+            {
+                GST_ERROR_OBJECT(basesrc, "Failed to read from file: %i", rtn);
+                return GST_FLOW_ERROR;
+            }
+            read += rtn;
+            GST_DEBUG_OBJECT(basesrc, "Read additional %i bytes", rtn);
+        }
+
+        gst_buffer_unmap(buf, &info);
+        GST_BUFFER_OFFSET(buf) = offset;
+        GST_BUFFER_OFFSET_END(buf) = offset + read;
+
+        return GST_FLOW_OK;
+    }
 } // namespace
 
-static void gst_looping_filesrc_class_init(GstLoopingFileSrcClass *klass) {
-  GObjectClass *gobject_class;
-  GstElementClass *gstelement_class;
-  GstBaseSrcClass *gstbasesrc_class;
+static void gst_looping_filesrc_class_init(GstLoopingFileSrcClass* klass)
+{
+    GObjectClass* gobject_class;
+    GstElementClass* gstelement_class;
+    GstBaseSrcClass* gstbasesrc_class;
 
-  gobject_class = (GObjectClass *)klass;
-  gstelement_class = (GstElementClass *)klass;
-  gstbasesrc_class = (GstBaseSrcClass *)klass;
+    gobject_class = (GObjectClass*)klass;
+    gstelement_class = (GstElementClass*)klass;
+    gstbasesrc_class = (GstBaseSrcClass*)klass;
 
-  gobject_class->finalize = finalize;
-  gobject_class->set_property = set_property;
-  gobject_class->get_property = get_property;
+    gobject_class->finalize = finalize;
+    gobject_class->set_property = set_property;
+    gobject_class->get_property = get_property;
 
-  gstbasesrc_class->start = start;
-  gstbasesrc_class->stop = stop;
-  gstbasesrc_class->is_seekable = is_seekable;
-  gstbasesrc_class->get_size = get_size;
-  gstbasesrc_class->fill = fill;
+    gstbasesrc_class->start = start;
+    gstbasesrc_class->stop = stop;
+    gstbasesrc_class->is_seekable = is_seekable;
+    gstbasesrc_class->get_size = get_size;
+    gstbasesrc_class->fill = fill;
 
-  g_object_class_install_property(
-      gobject_class, PROP_LOCATION,
-      g_param_spec_string("location", "Location of file to loop",
-                          "Location of file to loop", LOCATION_DEFAULT,
-                          G_PARAM_READWRITE));
-  g_object_class_install_property(
-      gobject_class, PROP_LOOP,
-      g_param_spec_boolean("loop", "Whether to loop the file",
-                           "Whether to loop the file", LOOP_DEFAULT,
-                           G_PARAM_READWRITE));
+    g_object_class_install_property(gobject_class,
+        PROP_LOCATION,
+        g_param_spec_string("location", "Location of file to loop", "Location of file to loop", LOCATION_DEFAULT, G_PARAM_READWRITE));
+    g_object_class_install_property(gobject_class,
+        PROP_LOOP,
+        g_param_spec_boolean("loop", "Whether to loop the file", "Whether to loop the file", LOOP_DEFAULT, G_PARAM_READWRITE));
 
-  gst_element_class_add_static_pad_template(gstelement_class, &srctemplate);
-  gst_element_class_set_details_simple(
-      gstelement_class, "looping-filesrc", "Generic",
-      "Like filesrc but will loop the input content",
-      "NVIDIA Corporation. See "
-      "https://developer.nvidia.com/holoscan-for-media");
+    gst_element_class_add_static_pad_template(gstelement_class, &srctemplate);
+    gst_element_class_set_details_simple(gstelement_class,
+        "looping-filesrc",
+        "Generic",
+        "Like filesrc but will loop the input content",
+        "NVIDIA Corporation. See "
+        "https://developer.nvidia.com/holoscan-for-media");
 }
 
-static void gst_looping_filesrc_init(GstLoopingFileSrc *filesrc) {
-  auto basesrc = GST_BASE_SRC(filesrc);
+static void gst_looping_filesrc_init(GstLoopingFileSrc* filesrc)
+{
+    auto basesrc = GST_BASE_SRC(filesrc);
 
-  filesrc->location = nullptr;
-  filesrc->file = nullptr;
-  filesrc->file_size = 0;
-  filesrc->loop = LOOP_DEFAULT;
+    filesrc->location = nullptr;
+    filesrc->file = nullptr;
+    filesrc->file_size = 0;
+    filesrc->loop = LOOP_DEFAULT;
 
-  gst_base_src_set_live(basesrc, false);
-  gst_base_src_set_automatic_eos(basesrc, false);
-  g_object_set(filesrc, "location", LOCATION_DEFAULT, NULL);
+    gst_base_src_set_live(basesrc, false);
+    gst_base_src_set_automatic_eos(basesrc, false);
+    g_object_set(filesrc, "location", LOCATION_DEFAULT, NULL);
 }
 
-static gboolean plugin_init(GstPlugin *plugin) {
-  GST_DEBUG_CATEGORY_INIT(gst_looping_filesrc_debug, "looping_filesrc", 0,
-                          "Looping filesrc plugin");
+static gboolean plugin_init(GstPlugin* plugin)
+{
+    GST_DEBUG_CATEGORY_INIT(gst_looping_filesrc_debug, "looping_filesrc", 0, "Looping filesrc plugin");
 
-  return gst_element_register(plugin, "looping_filesrc", GST_RANK_NONE,
-                              gst_looping_filesrc_get_type());
+    return gst_element_register(plugin, "looping_filesrc", GST_RANK_NONE, gst_looping_filesrc_get_type());
 }
 
-GST_PLUGIN_DEFINE(GST_VERSION_MAJOR, GST_VERSION_MINOR, looping_filesrc,
-                  LOOPING_FILESRC_DESCRIPTION, plugin_init,
-                  LOOPING_FILESRC_VERSION, LOOPING_FILESRC_LICENSE, PACKAGE,
-                  LOOPING_FILESRC_ORIGIN)
+GST_PLUGIN_DEFINE(GST_VERSION_MAJOR, GST_VERSION_MINOR, looping_filesrc, LOOPING_FILESRC_DESCRIPTION, plugin_init, LOOPING_FILESRC_VERSION,
+    LOOPING_FILESRC_LICENSE, PACKAGE, LOOPING_FILESRC_ORIGIN)
 
-void gst_looping_filesrc_register_static() {
-  gst_plugin_register_static(GST_VERSION_MAJOR, GST_VERSION_MINOR,
-                             "looping_filesrc", LOOPING_FILESRC_DESCRIPTION,
-                             plugin_init, LOOPING_FILESRC_VERSION,
-                             LOOPING_FILESRC_LICENSE, LOOPING_FILESRC_SOURCE,
-                             PACKAGE, LOOPING_FILESRC_ORIGIN);
+void gst_looping_filesrc_register_static()
+{
+    gst_plugin_register_static(GST_VERSION_MAJOR,
+        GST_VERSION_MINOR,
+        "looping_filesrc",
+        LOOPING_FILESRC_DESCRIPTION,
+        plugin_init,
+        LOOPING_FILESRC_VERSION,
+        LOOPING_FILESRC_LICENSE,
+        LOOPING_FILESRC_SOURCE,
+        PACKAGE,
+        LOOPING_FILESRC_ORIGIN);
 }

--- a/utils/gst-looping-filesrc/gst-looping-filesrc.cpp
+++ b/utils/gst-looping-filesrc/gst-looping-filesrc.cpp
@@ -141,6 +141,7 @@ namespace
 
     gboolean is_seekable(GstBaseSrc* basesrc)
     {
+        (void)basesrc;
         return false;
     }
 
@@ -166,7 +167,7 @@ namespace
         int rtn;
         size_t read = 0;
 
-        GST_TRACE_OBJECT(basesrc, "fill (offset %zi, size %u)", offset, size);
+        GST_TRACE_OBJECT(basesrc, "fill (offset %" G_GUINT64_FORMAT ", size %u)", offset, size);
 
         if (!gst_buffer_map(buf, &info, GST_MAP_WRITE))
         {

--- a/utils/gst-looping-filesrc/gst-looping-filesrc.h
+++ b/utils/gst-looping-filesrc/gst-looping-filesrc.h
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: 2025 Contributors to the Media eXchange Layer project.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/utils/gst-looping-filesrc/gst-looping-filesrc.h
+++ b/utils/gst-looping-filesrc/gst-looping-filesrc.h
@@ -17,22 +17,22 @@
 
 #pragma once
 
+#include <stdio.h>
 #include <gst/base/gstbasesrc.h>
 #include <gst/gst.h>
-#include <stdio.h>
 
 G_BEGIN_DECLS
 
 #define GST_TYPE_LOOPING_FILESRC (gst_looping_filesrc_get_type())
-G_DECLARE_FINAL_TYPE(GstLoopingFileSrc, gst_looping_filesrc, GST,
-                     LOOPING_FILESRC, GstBaseSrc)
+G_DECLARE_FINAL_TYPE(GstLoopingFileSrc, gst_looping_filesrc, GST, LOOPING_FILESRC, GstBaseSrc)
 
-struct _GstLoopingFileSrc {
-  GstBaseSrc basesrc;
-  gchar* location;
-  bool loop;
-  FILE* file;
-  guint64 file_size;
+struct _GstLoopingFileSrc
+{
+    GstBaseSrc basesrc;
+    gchar* location;
+    bool loop;
+    FILE* file;
+    guint64 file_size;
 };
 
 void gst_looping_filesrc_register_static();

--- a/utils/gst-looping-filesrc/gst-looping-filesrc.h
+++ b/utils/gst-looping-filesrc/gst-looping-filesrc.h
@@ -1,0 +1,40 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <gst/base/gstbasesrc.h>
+#include <gst/gst.h>
+#include <stdio.h>
+
+G_BEGIN_DECLS
+
+#define GST_TYPE_LOOPING_FILESRC (gst_looping_filesrc_get_type())
+G_DECLARE_FINAL_TYPE(GstLoopingFileSrc, gst_looping_filesrc, GST,
+                     LOOPING_FILESRC, GstBaseSrc)
+
+struct _GstLoopingFileSrc {
+  GstBaseSrc basesrc;
+  gchar* location;
+  bool loop;
+  FILE* file;
+  guint64 file_size;
+};
+
+void gst_looping_filesrc_register_static();
+
+G_END_DECLS


### PR DESCRIPTION
Fixes #13 
This can do automatic height width and framerate negotiation from the filesrc.

I have done testing with a file having the following ffprobe


```
Input #0, mpegts, from 'workspace/dell.ts':
  Duration: 00:00:34.82, start: 1.426833, bitrate: 3459 kb/s
  Program 1
    Metadata:
      service_name    : Service01
      service_provider: FFmpeg
    Stream #0:0[0x100]: Video: h264 (High) ([27][0][0][0] / 0x001B), yuv420p(progressive), 1920x1080 [SAR 1:1 DAR 16:9], 60 fps, 60 tbr, 90k tbn, 120 tbc
    Stream #0:1[0x101]: Audio: opus (Opus / 0x7375704F), 48000 Hz, stereo, fltp

```
