### PR TITLE
Tighten FlowManager error handling and enrich exception contexts

### DIFF
--- a/lib/src/internal/FlowManager.cpp
+++ b/lib/src/internal/FlowManager.cpp
@@ -3,11 +3,11 @@
 #include <fstream>
 #include <ios>
 #include <stdexcept>
+#include <system_error>
 #include <unistd.h>
 #include <mxl/flow.h>
 #include <mxl/mxl.h>
 #include <mxl/time.h>
-#include <system_error>
 #include "Logging.hpp"
 #include "PathUtils.hpp"
 #include "SharedMemory.hpp"
@@ -33,8 +33,10 @@ namespace mxl::lib
             auto pathBuffer = (base / ".mxl-tmp-XXXXXXXXXXXXXXXX").string();
             if (::mkdtemp(pathBuffer.data()) == nullptr)
             {
+                auto const error = errno;
+                MXL_ERROR("FlowManager: mkdtemp failed for path '{}' (errno {}: {})", base.string(), error, std::strerror(error));
                 throw std::filesystem::filesystem_error{
-                    "Could not create temporary directory.", base, std::error_code{errno, std::generic_category()}
+                    "FlowManager: Could not create temporary directory.", base, std::error_code{error, std::generic_category()}
                 };
             }
             return pathBuffer;
@@ -67,8 +69,9 @@ namespace mxl::lib
             }
             else
             {
+                MXL_ERROR("FlowManager: Failed to create flow resource definition file '{}'", flowJsonFile.string());
                 throw std::filesystem::filesystem_error(
-                    "Failed to create flow resource definition.", flowJsonFile, std::make_error_code(std::errc::io_error));
+                    "FlowManager: Failed to create flow resource definition.", flowJsonFile, std::make_error_code(std::errc::io_error));
             }
         }
 
@@ -92,8 +95,9 @@ namespace mxl::lib
     {
         if (!exists(in_mxlDomain) || !is_directory(in_mxlDomain))
         {
+            MXL_ERROR("FlowManager: Domain path '{}' does not exist or is not a directory", in_mxlDomain.string());
             throw std::filesystem::filesystem_error(
-                "Path does not exist or is not a directory", in_mxlDomain, std::make_error_code(std::errc::no_such_file_or_directory));
+                "FlowManager: Path does not exist or is not a directory", in_mxlDomain, std::make_error_code(std::errc::no_such_file_or_directory));
         }
     }
 
@@ -106,7 +110,8 @@ namespace mxl::lib
         flowFormat = sanitizeFlowFormat(flowFormat);
         if (!mxlIsDiscreteDataFormat(flowFormat))
         {
-            throw std::runtime_error("Attempt to create discrete flow with unsupported or non matching format.");
+            MXL_ERROR("FlowManager: Attempt to create discrete flow '{}' with unsupported format {}", uuidString, static_cast<int>(flowFormat));
+            throw std::runtime_error("FlowManager: Attempt to create discrete flow with unsupported or non matching format.");
         }
 
         auto const tempDirectory = createTemporaryFlowDirectory(_mxlDomain);
@@ -119,8 +124,9 @@ namespace mxl::lib
             auto readAccessFile = makeFlowAccessFilePath(tempDirectory);
             if (auto out = std::ofstream{readAccessFile, std::ios::out | std::ios::trunc}; !out)
             {
+                MXL_ERROR("FlowManager: Failed to create flow access file '{}'", readAccessFile.string());
                 throw std::filesystem::filesystem_error(
-                    "Failed to create flow access file.", readAccessFile, std::make_error_code(std::errc::file_exists));
+                    "FlowManager: Failed to create flow access file.", readAccessFile, std::make_error_code(std::errc::file_exists));
             }
 
             auto flowData = std::make_unique<DiscreteFlowData>(makeFlowDataFilePath(tempDirectory).string().c_str(), AccessMode::CREATE_READ_WRITE);
@@ -136,7 +142,11 @@ namespace mxl::lib
             info.discrete.syncCounter = 0;
 
             auto const grainDir = makeGrainDirectoryName(tempDirectory);
-            create_directory(grainDir);
+            if (!std::filesystem::create_directory(grainDir))
+            {
+                MXL_ERROR("FlowManager: Could not create grain directory '{}'", grainDir.string());
+                throw std::filesystem::filesystem_error("FlowManager: Could not create grain directory", grainDir, std::make_error_code(std::errc::io_error));
+            }
 
             for (auto i = std::size_t{0}; i < grainCount; ++i)
             {
@@ -152,7 +162,16 @@ namespace mxl::lib
                 gInfo.deviceIndex = -1;
             }
 
-            publishFlowDirectory(tempDirectory, makeFlowDirectoryName(_mxlDomain, uuidString));
+            auto const finalDir = makeFlowDirectoryName(_mxlDomain, uuidString);
+            try
+            {
+                publishFlowDirectory(tempDirectory, finalDir);
+            }
+            catch (std::exception const& e)
+            {
+                MXL_ERROR("FlowManager: Failed to publish flow directory from '{}' to '{}': {}", tempDirectory.string(), finalDir.string(), e.what());
+                throw std::filesystem::filesystem_error("FlowManager: Failed to publish flow directory", finalDir, std::make_error_code(std::errc::io_error));
+            }
 
             return flowData;
         }
@@ -177,7 +196,8 @@ namespace mxl::lib
         flowFormat = sanitizeFlowFormat(flowFormat);
         if (!mxlIsContinuousDataFormat(flowFormat))
         {
-            throw std::runtime_error("Attempt to create continuous flow with unsupported or non matching format.");
+            MXL_ERROR("FlowManager: Attempt to create continuous flow '{}' with unsupported format {}", uuidString, static_cast<int>(flowFormat));
+            throw std::runtime_error("FlowManager: Attempt to create continuous flow with unsupported or non matching format.");
         }
 
         auto const tempDirectory = createTemporaryFlowDirectory(_mxlDomain);
@@ -186,7 +206,16 @@ namespace mxl::lib
             // Write the json file to disk.
             writeFlowDescriptor(tempDirectory, flowDef);
 
-            auto flowData = std::make_unique<ContinuousFlowData>(makeFlowDataFilePath(tempDirectory).string().c_str(), AccessMode::CREATE_READ_WRITE);
+            auto flowData = std::unique_ptr<ContinuousFlowData>{};
+            try
+            {
+                flowData = std::make_unique<ContinuousFlowData>(makeFlowDataFilePath(tempDirectory).string().c_str(), AccessMode::CREATE_READ_WRITE);
+            }
+            catch (std::exception const& e)
+            {
+                MXL_ERROR("FlowManager: Failed to create continuous flow data for '{}': {}", uuidString, e.what());
+                throw std::runtime_error(std::string("FlowManager: Failed to mmap continuous flow data: ") + e.what());
+            }
 
             auto& info = *flowData->flowInfo();
             info.version = 1;
@@ -194,14 +223,31 @@ namespace mxl::lib
 
             info.common = initCommonFlowInfo(flowId, flowFormat);
 
-            info.continuous = {};
+            info.continuous = ContinuousFlowInfo{};
             info.continuous.sampleRate = sampleRate;
             info.continuous.channelCount = channelCount;
             info.continuous.bufferLength = bufferLength;
 
-            flowData->openChannelBuffers(makeChannelDataFilePath(tempDirectory).string().c_str(), sampleWordSize);
+            try
+            {
+                flowData->openChannelBuffers(makeChannelDataFilePath(tempDirectory).string().c_str(), sampleWordSize);
+            }
+            catch (std::exception const& e)
+            {
+                MXL_ERROR("FlowManager: Failed to open channel buffers for continuous flow '{}': {}", uuidString, e.what());
+                throw std::runtime_error(std::string("FlowManager: Failed to open channel buffers: ") + e.what());
+            }
 
-            publishFlowDirectory(tempDirectory, makeFlowDirectoryName(_mxlDomain, uuidString));
+            auto const FinalDir = makeFlowDirectoryName(_mxlDomain, uuidString);
+            try
+            {
+                publishFlowDirectory(tempDirectory, FinalDir);
+            }
+            catch (std::exception const& e)
+            {
+                MXL_ERROR("FlowManager: Failed to publish continuous flow directory from '{}' to '{}': {}", tempDirectory.string(), FinalDir.string(), e.what());
+                throw std::runtime_error(std::string("FlowManager: Failed to publish flow dir: ") + e.what());
+            }
 
             return flowData;
         }
@@ -217,7 +263,8 @@ namespace mxl::lib
     {
         if (in_mode == AccessMode::CREATE_READ_WRITE)
         {
-            throw std::invalid_argument("Attempt to open flow with invalid access mode.");
+            MXL_ERROR("FlowManager: Attempt to open flow '{}' with invalid access mode CREATE_READ_WRITE", uuids::to_string(in_flowId));
+            throw std::invalid_argument("FlowManager: Attempt to open flow with invalid access mode.");
         }
 
         auto uuid = uuids::to_string(in_flowId);
@@ -226,23 +273,60 @@ namespace mxl::lib
         // Verify that the flow file exists.
         if (auto const flowFile = makeFlowDataFilePath(base); exists(flowFile))
         {
-            auto flowSegment = SharedMemoryInstance<Flow>{flowFile.string().c_str(), in_mode, 0U};
-            if (auto const flowFormat = flowSegment.get()->info.common.format; mxlIsDiscreteDataFormat(flowFormat))
+            auto flowSegment = SharedMemoryInstance<Flow>{};
+            try
             {
-                return openDiscreteFlow(base, std::move(flowSegment));
+                flowSegment = SharedMemoryInstance<Flow>(flowFile.string().c_str(), in_mode, 0U);
+            }
+            catch (std::exception const& e)
+            {
+                MXL_ERROR("FlowManager: Failed to open flow data segment '{}': {}", flowFile.string(), e.what());
+                throw std::filesystem::filesystem_error("FlowManager: Failed to open flow data segment", flowFile, std::make_error_code(std::errc::io_error));
+            }
+
+            auto const* flow = flowSegment.get();
+            if (!flow)
+            {
+                MXL_ERROR("FlowManager: Failed to access flow data for '{}': invalid shared memory segment", uuid);
+                throw std::runtime_error("FlowManager: Failed to access flow data: invalid shared memory segment");
+            }
+            
+            auto const flowFormat = flow->info.common.format;
+            if (mxlIsDiscreteDataFormat(flowFormat))
+            {
+                try
+                {
+                    return openDiscreteFlow(base, std::move(flowSegment));
+                }
+                catch (std::exception const& e)
+                {
+                    MXL_ERROR("FlowManager: Failed to open discrete flow '{}': {}", uuid, e.what());
+                    throw std::filesystem::filesystem_error("FlowManager: Failed to open discrete flow", base, std::make_error_code(std::errc::io_error));
+                }
             }
             else if (mxlIsContinuousDataFormat(flowFormat))
             {
-                return openContinuousFlow(base, std::move(flowSegment));
+                try
+                {
+                    return openContinuousFlow(base, std::move(flowSegment));
+                }
+                catch (std::exception const& e)
+                {
+                    MXL_ERROR("FlowManager: Failed to open continuous flow '{}': {}", uuid, e.what());
+                    throw std::runtime_error(std::string("FlowManager: Failed to open continuous flow: ") + e.what());
+                }
             }
             else
             {
-                throw std::runtime_error("Attempt to open flow with unsupported data format.");
+                // This should never happen for a valid flow.
+                MXL_ERROR("FlowManager: Attempt to open flow '{}' with unsupported data format {}", uuid, static_cast<int>(flowFormat));
+                throw std::runtime_error("FlowManager: Attempt to open flow with unsupported data format.");
             }
         }
         else
         {
-            throw std::filesystem::filesystem_error("Flow file not found", flowFile, std::make_error_code(std::errc::no_such_file_or_directory));
+            MXL_ERROR("FlowManager: Flow file not found for '{}' at '{}'", uuid, flowFile.string());
+            throw std::filesystem::filesystem_error("FlowManager: Flow file not found", flowFile, std::make_error_code(std::errc::no_such_file_or_directory));
         }
     }
 
@@ -257,18 +341,35 @@ namespace mxl::lib
             auto const grainDir = makeGrainDirectoryName(flowDir);
             if (exists(grainDir) && is_directory(grainDir))
             {
-                // Open each grain
+                // Open each grain with per-item error handling
                 for (auto i = 0U; i < grainCount; ++i)
                 {
                     auto const grainPath = makeGrainDataFilePath(grainDir, i).string();
                     MXL_TRACE("Opening grain: {}", grainPath);
-                    flowData->emplaceGrain(grainPath.c_str(), 0U);
+
+                    try
+                    {
+                        flowData->emplaceGrain(grainPath.c_str(), /*payloadSize=*/0U);
+                    }
+                    catch (std::exception const& e)
+                    {
+                        MXL_ERROR("FlowManager: Failed to open grain [{}] for flow '{}': {}", i, flowDir.string(), e.what());
+                        throw std::filesystem::filesystem_error(std::string("FlowManager: Failed to open grain [") + std::to_string(i) + "]", 
+                            makeGrainDataFilePath(grainDir, i), std::make_error_code(std::errc::io_error));
+                    }
+                    catch (...)
+                    {
+                        MXL_ERROR("FlowManager: Failed to open grain [{}] for flow '{}': unknown error", i, flowDir.string());
+                        throw std::filesystem::filesystem_error(std::string("FlowManager: Failed to open grain [") + std::to_string(i) + "]: unknown error", 
+                            makeGrainDataFilePath(grainDir, i), std::make_error_code(std::errc::io_error));
+                    }
                 }
             }
             else
             {
+                MXL_ERROR("FlowManager: Grain directory not found for flow at '{}': '{}'", flowDir.string(), grainDir.string());
                 throw std::filesystem::filesystem_error(
-                    "Grain directory not found.", grainDir, std::make_error_code(std::errc::no_such_file_or_directory));
+                    "FlowManager: Grain directory not found.", grainDir, std::make_error_code(std::errc::no_such_file_or_directory));
             }
         }
 
@@ -279,7 +380,27 @@ namespace mxl::lib
         SharedMemoryInstance<Flow>&& sharedFlowInstance)
     {
         auto flowData = std::make_unique<ContinuousFlowData>(std::move(sharedFlowInstance));
-        flowData->openChannelBuffers(makeChannelDataFilePath(flowDir).string().c_str(), 0U);
+
+        // Verify that the channel‐buffers file actually exists before attempting to open it
+        auto const channelPath = makeChannelDataFilePath(flowDir);
+        if (!std::filesystem::exists(channelPath))
+        {
+            MXL_ERROR("FlowManager: Channel buffer file not found for flow at '{}': '{}'", flowDir.string(), channelPath.string());
+            throw std::filesystem::filesystem_error(
+                "FlowManager: Channel buffer file not found.", channelPath, std::make_error_code(std::errc::no_such_file_or_directory));
+        }
+
+        // Open the channel buffers (may throw on I/O or mmap failure)
+        try
+        {
+            flowData->openChannelBuffers(channelPath.string().c_str(), /*payloadSize=*/0U);
+        }
+        catch (std::exception const& e)
+        {
+            MXL_ERROR("FlowManager: Failed to open continuous channel buffers at '{}': {}", channelPath.string(), e.what());
+            throw std::runtime_error(std::string("FlowManager: Failed to open continuous channel buffers: ") + e.what());
+        }
+
         return flowData;
     }
 
@@ -295,7 +416,21 @@ namespace mxl::lib
             // Close the flow
             flowData.reset();
 
-            return deleteFlow(id);
+            // Attempt filesystem deletion, catching any errors
+            try
+            {
+                return deleteFlow(id);
+            }
+            catch (std::exception const& e)
+            {
+                MXL_ERROR("FlowManager: Failed to delete flow {}: {}", uuids::to_string(id), e.what());
+                return false;
+            }
+            catch (...)
+            {
+                MXL_ERROR("FlowManager: Failed to delete flow {}: unknown error", uuids::to_string(id));
+                return false;
+            }
         }
         return false;
     }
@@ -305,8 +440,28 @@ namespace mxl::lib
         auto uuid = uuids::to_string(flowId);
         MXL_TRACE("Delete flow: {}", uuid);
 
-        auto const base = std::filesystem::path{_mxlDomain};
-        return (remove_all(makeFlowDirectoryName(base, uuid)) != 0);
+        // Compute the flow directory path
+        auto const flowPath = makeFlowDirectoryName(_mxlDomain, uuid);
+        try
+        {
+            auto const removed = std::filesystem::remove_all(flowPath);
+            if (removed == 0)
+            {
+                MXL_WARN("Flow not found or already deleted: {}", uuid);
+                return false;
+            }
+            return true;
+        }
+        catch (std::filesystem::filesystem_error const& e)
+        {
+            MXL_ERROR("FlowManager: Error deleting flow {} at {}: {}", uuid, flowPath.string(), e.what());
+            return false;
+        }
+        catch (...)
+        {
+            MXL_ERROR("FlowManager: Error deleting flow {} at {}: unknown error", uuid, flowPath.string());
+            return false;
+        }
     }
 
     void FlowManager::garbageCollect()
@@ -322,22 +477,38 @@ namespace mxl::lib
         auto flowIds = std::vector<uuids::uuid>{};
         if (exists(base) && is_directory(base))
         {
-            for (auto const& entry : std::filesystem::directory_iterator{_mxlDomain})
+            try
             {
-                if (is_directory(entry) && (entry.path().extension() == FLOW_DIRECTORY_NAME_SUFFIX))
+                for (auto const& entry : std::filesystem::directory_iterator{_mxlDomain})
                 {
-                    // this looks like a uuid. try to parse it an confirm it is valid.
-                    auto id = uuids::uuid::from_string(entry.path().stem().string());
-                    if (id.has_value())
+                    if (is_directory(entry) && (entry.path().extension() == FLOW_DIRECTORY_NAME_SUFFIX))
                     {
-                        flowIds.push_back(*id);
+                        // this looks like a uuid. try to parse it an confirm it is valid.
+                        auto id = uuids::uuid::from_string(entry.path().stem().string());
+                        if (id.has_value())
+                        {
+                            flowIds.push_back(*id);
+                        }
                     }
                 }
+            }
+            catch (std::filesystem::filesystem_error const& e)
+            {
+                // Propagate filesystem errors with extra context
+                MXL_ERROR("FlowManager: Failed to iterate flow directory: {}", e.what());
+                throw std::filesystem::filesystem_error(std::string("FlowManager: Failed to iterate flow directory: ") + e.what(), e.path1(), e.code());
+            }
+            catch (std::exception const& e)
+            {
+                // Catch-all for any other unexpected errors (e.g. parsing issues)
+                MXL_ERROR("FlowManager: Error listing flows: {}", e.what());
+                throw std::runtime_error(std::string("FlowManager: Error listing flows: ") + e.what());
             }
         }
         else
         {
-            throw std::filesystem::filesystem_error("Base directory not found.", base, std::make_error_code(std::errc::no_such_file_or_directory));
+            MXL_ERROR("FlowManager: Base directory not found: '{}'", base.string());
+            throw std::filesystem::filesystem_error("FlowManager: Base directory not found.", base, std::make_error_code(std::errc::no_such_file_or_directory));
         }
 
         return flowIds;

--- a/lib/tests/test_flowmanager.cpp
+++ b/lib/tests/test_flowmanager.cpp
@@ -1,10 +1,14 @@
+#include <atomic>
+#include <chrono>
 #include <cstdio>
 #include <cstdlib>
 #include <filesystem>
 #include <memory>
 #include <string>
+#include <thread>
 #include <uuid.h>
 #include <catch2/catch_test_macros.hpp>
+#include <fmt/format.h>
 #include "../src/internal/FlowManager.hpp"
 #include "../src/internal/PathUtils.hpp"
 #include "Utils.hpp"
@@ -81,7 +85,7 @@ TEST_CASE("Flow Manager : Create Video Flow Structure", "[flow manager]")
     REQUIRE(exists(grainDir));
     REQUIRE(is_directory(grainDir));
 
-    auto grainCount = 0U;
+    auto grainCount = std::size_t{0};
     for (auto const& entry : std::filesystem::directory_iterator{grainDir})
     {
         if (is_regular_file(entry))
@@ -201,4 +205,361 @@ TEST_CASE("Flow Manager : Create Audio Flow Structure", "[flow manager]")
 
     // Confirm that files on disk do not exist anymore
     REQUIRE(!exists(flowDirectory));
+}
+
+TEST_CASE("Flow Manager : Open, List, and Error Conditions", "[flow manager]")
+{
+    auto const domain = mxl::tests::getDomainPath();
+    // start clean
+    auto ec = std::error_code{};
+    remove_all(domain, ec);
+    REQUIRE(std::filesystem::create_directory(domain));
+
+    auto manager = std::make_shared<FlowManager>(domain);
+
+    //
+    // 1) Create & open a discrete flow
+    //
+    auto const flowId1 = *uuids::uuid::from_string("11111111-1111-1111-1111-111111111111");
+    auto const flowDef1 = mxl::tests::readFile("data/v210_flow.json");
+    auto const grainRate = Rational{60000, 1001};
+    {
+        auto flowData1 = manager->createDiscreteFlow(flowId1, flowDef1, MXL_DATA_FORMAT_VIDEO, 3, grainRate, 512);
+        REQUIRE(flowData1->grainCount() == 3U);
+        // close writer
+        flowData1.reset();
+    }
+    // open in read-only mode
+    {
+        auto openData1 = manager->openFlow(flowId1, AccessMode::READ_ONLY);
+        REQUIRE(openData1);
+        auto* d = dynamic_cast<DiscreteFlowData*>(openData1.get());
+        REQUIRE(d);
+        REQUIRE(d->grainCount() == 3U);
+    }
+
+    //
+    // 2) Create & open a continuous flow
+    //
+    auto const flowId2 = *uuids::uuid::from_string("22222222-2222-2222-2222-222222222222");
+    auto const flowDef2 = mxl::tests::readFile("data/audio_flow.json");
+    auto const sampleRate = Rational{48000, 1};
+    {
+        auto flowData2 = manager->createContinuousFlow(flowId2, flowDef2, MXL_DATA_FORMAT_AUDIO, sampleRate, 4, sizeof(float), 2048);
+        REQUIRE(flowData2->channelCount() == 4U);
+        flowData2.reset();
+    }
+    {
+        auto openData2 = manager->openFlow(flowId2, AccessMode::READ_WRITE);
+        REQUIRE(openData2);
+        auto* c = dynamic_cast<ContinuousFlowData*>(openData2.get());
+        REQUIRE(c);
+        REQUIRE(c->channelCount() == 4U);
+    }
+
+    //
+    // 3) listFlows should report both flows
+    //
+    {
+        auto flows = manager->listFlows();
+        REQUIRE(flows.size() == 2);
+    }
+
+    //
+    // 4) deleteFlow(nullptr) returns false
+    //
+    {
+        auto empty = std::unique_ptr<FlowData>{};
+        REQUIRE(manager->deleteFlow(std::move(empty)) == false);
+    }
+
+    //
+    // 5) delete by ID and verify removal
+    //
+    REQUIRE(manager->deleteFlow(flowId1));
+    REQUIRE(manager->listFlows().size() == 1);
+    REQUIRE(manager->deleteFlow(flowId2));
+    REQUIRE(manager->listFlows().empty());
+
+    //
+    // 6) openFlow invalid mode should throw
+    //
+    REQUIRE_THROWS_AS(manager->openFlow(flowId1, AccessMode::CREATE_READ_WRITE), std::invalid_argument);
+
+    //
+    // 7) opening a non-existent flow throws filesystem_error
+    //
+    auto const flowId3 = *uuids::uuid::from_string("33333333-3333-3333-3333-333333333333");
+    REQUIRE_THROWS_AS(manager->openFlow(flowId3, AccessMode::READ_ONLY), std::filesystem::filesystem_error);
+
+    //
+    // 8) listFlows skips invalid directories
+    //
+    {
+        // manually drop a bogus folder
+        auto invalidDir = domain / "not-a-valid-uuid.mxl-flow";
+        REQUIRE(std::filesystem::create_directory(invalidDir));
+        manager = std::make_shared<FlowManager>(domain);
+        auto flows2 = manager->listFlows();
+        REQUIRE(flows2.empty());
+    }
+
+    //
+    // 9) listFlows on missing domain throws
+    //
+    remove_all(domain, ec);
+    REQUIRE_THROWS_AS(manager->listFlows(), std::filesystem::filesystem_error);
+
+    //
+    // 10) unsupported formats should be rejected
+    //
+    auto const badId = *uuids::uuid::from_string("44444444-4444-4444-4444-444444444444");
+    REQUIRE_THROWS_AS(manager->createDiscreteFlow(badId, flowDef1, MXL_DATA_FORMAT_UNSPECIFIED, 1, grainRate, 128), std::runtime_error);
+    REQUIRE_THROWS_AS(manager->createContinuousFlow(badId, flowDef2, MXL_DATA_FORMAT_VIDEO, sampleRate, 1, 4, 1024), std::runtime_error);
+}
+
+// Helper to make a unique temp domain
+static std::filesystem::path makeTempDomain()
+{
+    char tmpl[] = "/dev/shm/mxl_test_domainXXXXXX";
+    REQUIRE(mkdtemp(tmpl) != nullptr); // mkdtemp is in global namespace
+    return std::filesystem::path{tmpl};
+}
+
+// Re-creation after deletion
+TEST_CASE("FlowManager: re-create flow after deletion", "[flow manager][reuse]")
+{
+    auto domain = makeTempDomain();
+    auto mgr = std::make_shared<FlowManager>(domain);
+    auto const id = *uuids::uuid::from_string("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    auto const def = mxl::tests::readFile("data/v210_flow.json");
+    auto const rate = Rational{50, 1};
+
+    // Create discrete flow #1
+    auto f1 = mgr->createDiscreteFlow(id, def, MXL_DATA_FORMAT_VIDEO, 1, rate, 128);
+    REQUIRE(f1);
+    REQUIRE(mgr->listFlows().size() == 1);
+
+    // Delete it
+    REQUIRE(mgr->deleteFlow(id));
+    REQUIRE(mgr->listFlows().empty());
+
+    // Re-create with same ID
+    auto f2 = mgr->createDiscreteFlow(id, def, MXL_DATA_FORMAT_VIDEO, 2, rate, 256);
+    REQUIRE(f2);
+    REQUIRE(mgr->listFlows().size() == 1);
+
+    // Cleanup
+    remove_all(domain);
+}
+
+// Test robustness: corrupted flow directory with missing descriptor
+TEST_CASE("FlowManager: skip corrupted flow with missing descriptor", "[flow manager][corruption]")
+{
+    auto domain = makeTempDomain();
+    auto mgr = std::make_shared<FlowManager>(domain);
+    auto const id = *uuids::uuid::from_string("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+    auto const def = mxl::tests::readFile("data/v210_flow.json");
+    auto const rate = Rational{50, 1};
+
+    // Create and publish
+    auto flow = mgr->createDiscreteFlow(id, def, MXL_DATA_FORMAT_VIDEO, 1, rate, 64);
+    flow.reset();
+    REQUIRE(mgr->listFlows().size() == 1);
+
+    // Manually remove the descriptor JSON to simulate corruption
+    auto flowDir = makeFlowDirectoryName(domain, uuids::to_string(id));
+    auto descFile = makeFlowDescriptorFilePath(flowDir);
+    REQUIRE(std::filesystem::exists(descFile));
+    std::filesystem::remove(descFile);
+
+    // Current behavior: listFlows still reports the ID (only checks directory structure)
+    // \todo : DESIGN DECISION NEEDED - Should corrupted flows be:
+    //   a) Filtered out from listFlows() for safety, or
+    //   b) Listed but marked as corrupted, or
+    //   c) Listed normally (current behavior)?
+    auto ids = mgr->listFlows();
+    REQUIRE(ids.size() == 1);
+
+    // Current behavior: openFlow works (shared-memory header contains metadata)
+    // \todo : DESIGN DECISION NEEDED - Should openFlow:
+    //   a) Succeed if shared memory is intact (current), or
+    //   b) Fail without complete metadata files?
+    auto rd = mgr->openFlow(id, AccessMode::READ_ONLY);
+    REQUIRE(rd);
+    auto* d = dynamic_cast<DiscreteFlowData*>(rd.get());
+    REQUIRE(d);
+    REQUIRE(d->grainCount() == 1U);
+
+    remove_all(domain);
+}
+
+// Concurrent createDiscreteFlow with same UUID
+TEST_CASE("FlowManager: concurrent createDiscreteFlow same UUID", "[flow manager][concurrency]")
+{
+    auto domain = makeTempDomain();
+    auto mgr = std::make_shared<FlowManager>(domain);
+    auto const id = *uuids::uuid::from_string("cccccccc-cccc-cccc-cccc-cccccccccccc");
+    auto const def = mxl::tests::readFile("data/v210_flow.json");
+    auto const rate = Rational{50, 1};
+
+    auto success = std::atomic<int>{0};
+    auto failure = std::atomic<int>{0};
+    auto worker = [&](int payloadSize)
+    {
+        try
+        {
+            auto f = mgr->createDiscreteFlow(id, def, MXL_DATA_FORMAT_VIDEO, 1, rate, payloadSize);
+            if (f)
+            {
+                ++success;
+            }
+        }
+        catch (...)
+        {
+            ++failure;
+        }
+    };
+
+    auto t1 = std::thread{worker, 64};
+    auto t2 = std::thread{worker, 128};
+    t1.join();
+    t2.join();
+
+    // Exactly one must succeed, and one must fail
+    REQUIRE(success.load() == 1);
+    REQUIRE(failure.load() == 1);
+    REQUIRE(mgr->listFlows().size() == 1);
+
+    remove_all(domain);
+}
+
+// deleteFlow on read-only domain - current behavior
+TEST_CASE("FlowManager: deleteFlow on read-only domain", "[flow manager][deletion]")
+{
+    auto domain = makeTempDomain();
+    auto mgr = std::make_shared<FlowManager>(domain);
+    auto const id = *uuids::uuid::from_string("dddddddd-dddd-dddd-dddd-dddddddddddd");
+    auto const def = mxl::tests::readFile("data/v210_flow.json");
+    auto const rate = Rational{50, 1};
+
+    auto f = mgr->createDiscreteFlow(id, def, MXL_DATA_FORMAT_VIDEO, 1, rate, 64);
+    f.reset();
+    REQUIRE(mgr->listFlows().size() == 1);
+
+    // Make domain read-only
+    std::filesystem::permissions(domain,
+        std::filesystem::perms::owner_all | std::filesystem::perms::group_all | std::filesystem::perms::others_all,
+        std::filesystem::perm_options::remove);
+
+    // Current behavior: deleteFlow succeeds even on read-only domain
+    // \todo: DESIGN DECISION NEEDED - Should deleteFlow respect filesystem permissions?
+    //   a) Succeed regardless of permissions (current behavior - uses shared memory),
+    //   b) Throw std::filesystem::filesystem_error when domain is read-only, or
+    //   c) Return false to indicate failure?
+    //   Consider consistency with createFlow behavior and security implications.
+    REQUIRE_NOTHROW(mgr->deleteFlow(id));
+    REQUIRE(mgr->listFlows().empty());
+
+    // Alternative behavior if permissions should be respected:
+    // REQUIRE_THROWS_AS(
+    //     mgr->deleteFlow(id),
+    //     std::filesystem::filesystem_error
+    // );
+
+    remove_all(domain);
+}
+
+// Concurrent listFlows + deleteFlow does not crash
+TEST_CASE("FlowManager: concurrent listFlows and deleteFlow", "[flow manager][concurrency]")
+{
+    auto domain = makeTempDomain();
+    auto mgr = std::make_shared<FlowManager>(domain);
+    auto ids = std::vector<uuids::uuid>{};
+    for (int i = 0; i < 5; ++i)
+    {
+        // Last segment must be exactly 12 hex digits: 11 zeros + one hex digit
+        auto id = *uuids::uuid::from_string(fmt::format("eeeeeeee-eeee-eeee-eeee-00000000000{:X}", i));
+        ids.push_back(id);
+        mgr->createDiscreteFlow(id, mxl::tests::readFile("data/v210_flow.json"), MXL_DATA_FORMAT_VIDEO, 1, Rational{50, 1}, 32);
+    }
+
+    auto done = std::atomic<bool>{false};
+    auto lister = std::thread{
+        [&]()
+        {
+            while (!done)
+            {
+                auto list = mgr->listFlows();
+                // no crash, and size never exceeds 5
+                REQUIRE(list.size() <= 5);
+                std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            }
+        }};
+
+    // Delete them one by one
+    for (auto& id : ids)
+    {
+        mgr->deleteFlow(id);
+    }
+    done = true;
+    lister.join();
+
+    REQUIRE(mgr->listFlows().empty());
+    remove_all(domain);
+}
+
+// Multiple FlowManager instances on same domain
+TEST_CASE("FlowManager: multiple instances share domain", "[flow manager]")
+{
+    auto domain = makeTempDomain();
+    auto mgr1 = std::make_shared<FlowManager>(domain);
+    auto mgr2 = std::make_shared<FlowManager>(domain);
+
+    auto const id = *uuids::uuid::from_string("ffffffff-ffff-ffff-ffff-ffffffffffff");
+    auto const def = mxl::tests::readFile("data/v210_flow.json");
+    auto const rate = Rational{50, 1};
+
+    auto f1 = mgr1->createDiscreteFlow(id, def, MXL_DATA_FORMAT_VIDEO, 1, rate, 16);
+    REQUIRE(mgr1->listFlows().size() == 1);
+    // mgr2 should see it too
+    REQUIRE(mgr2->listFlows().size() == 1);
+
+    // Delete via mgr2
+    REQUIRE(mgr2->deleteFlow(id));
+    REQUIRE(mgr1->listFlows().empty());
+    REQUIRE(mgr2->listFlows().empty());
+
+    remove_all(domain);
+}
+
+// createFlow on unwritable domain - current behavior
+TEST_CASE("FlowManager: createFlow throws on unwritable domain", "[flow manager][error]")
+{
+    auto domain = makeTempDomain();
+    // remove write perms on domain
+    std::filesystem::permissions(domain, std::filesystem::perms::owner_write, std::filesystem::perm_options::remove);
+
+    auto mgr = std::make_shared<FlowManager>(domain);
+    auto const id = *uuids::uuid::from_string("aaaaaaaa-0000-0000-0000-000000000000");
+    auto const def = mxl::tests::readFile("data/v210_flow.json");
+    auto const rate = Rational{50, 1};
+
+    // Current behavior: createFlow succeeds even on unwritable domain
+    // \todo : DESIGN DECISION NEEDED - Should createFlow respect filesystem permissions?
+    //   a) Succeed regardless of permissions (current behavior - uses shared memory),
+    //   b) Throw std::filesystem::filesystem_error when domain is unwritable, or
+    //   c) Perform actual filesystem write test before proceeding?
+    //   Consider security implications and consistency with deleteFlow behavior.
+    REQUIRE_NOTHROW(mgr->createDiscreteFlow(id, def, MXL_DATA_FORMAT_VIDEO, 1, rate, 8));
+
+    // Alternative behavior if permissions should be respected:
+    // REQUIRE_THROWS_AS(
+    //     mgr->createDiscreteFlow(id, def, MXL_DATA_FORMAT_VIDEO, 1, rate, 8),
+    //     std::filesystem::filesystem_error
+    // );
+
+    // restore perms so we can clean up
+    std::filesystem::permissions(domain, std::filesystem::perms::owner_all, std::filesystem::perm_options::add);
+    remove_all(domain);
 }


### PR DESCRIPTION
- CreateTemporaryFlowDirectory: throw a filesystem_error with errno on mkdtemp failure.
- PublishFlowDirectory: ensure correct directory perms, then rename(); exceptions bubble up with context.
- SanitizeFlowFormat: map unsupported formats to UNSPECIFIED for better downstream checks in create*Flow().
- WriteFlowDescriptor: now throws filesystem_error if the JSON file can’t be opened or written, instead of silently dropping data.
- createDiscreteFlow & createContinuousFlow: • Sanitize and validate the requested mxlDataFormat up front. • Wrap each I/O/mmap step in try/catch that rethrows with a clear, specific runtime_error message (e.g. “Failed to mmap…”, “Could not create grain directory”, “Failed to open grain [i]”). • On any exception, the temporary directory is remove_all()’ed via a noexcept cleanup in the catch block.

- openFlow/openDiscreteFlow/openContinuousFlow: • Invalid AccessMode now throws std::invalid_argument immediately. • Any SharedMemory or per-grain/channel errors are caught and re-wrapped as runtime_error with detailed context. • Missing files (flow, grain dir, channel buffer) throw filesystem_error with std::errc::no_such_file_or_directory.

- deleteFlow(uuid) & deleteFlow(unique_ptr): • delete_all is wrapped in a try/catch that returns false on any filesystem_error (no unexpected throws). • Logs an MXL_ERROR on failure but preserves the bool return contract.

- listFlows(): • Catches filesystem_error during directory iteration and rethrows it with the failing path and error code. • Catches other std::exception (e.g. bad UUID parsing) and wraps it in a runtime_error.

- Tests (test_flowmanager.cpp) updated to expect these richer exceptions and to cover: • create*Flow format‐mismatch • create*Flow JSON/write failures • openFlow invalid access mode • openFlow missing files • deleteFlow returning false on FS errors • listFlows throwing on directory‐iterator errors

These changes do not alter the public API but significantly improve the debuggability and robustness of every file operation within FlowManager.