### PR TITLE
Fix use-after-free of writer's id

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ cmake_policy(SET CMP0076 NEW)
 # Set the timestamps of all extracted contents to the time of the extraction
 cmake_policy(SET CMP0135 NEW)
 
-set(mxl_VERSION 0.7.0)
+set(mxl_VERSION 0.7.1)
 
 if(DEFINED MXL_BUILD_NUMBER)
     string(APPEND mxl_VERSION ".${MXL_BUILD_NUMBER}")

--- a/lib/src/internal/Instance.cpp
+++ b/lib/src/internal/Instance.cpp
@@ -206,7 +206,7 @@ namespace mxl::lib
     {
         if (writer)
         {
-            auto const& id = writer->getId();
+            auto const id = writer->getId();
             auto removeFlowWatch = false;
             {
                 auto const lock = std::lock_guard{_mutex};


### PR DESCRIPTION
Since b252351c297148dd0dea4a69eca7a09dc3c891e9, there's a use-after-free when calling `Instance::releaseWriter`. `id` is a reference to now deleted writer's `_flowId` when we subsequently call `_watcher->removeFlow`. Copying the id fixes the issue.

There's no problem with releasing a reader as b252351c297148dd0dea4a69eca7a09dc3c891e9 didn't change it.