### PR TITLE
fixed Dockerfile URLs in Building.md

### DIFF
--- a/docs/Building.md
+++ b/docs/Building.md
@@ -22,8 +22,8 @@ This is the preferred option for development on WSL2 or native linux desktop. Th
 
 _Note: the following instructions apply to Ubuntu 22.04._
 
-1. Install all apt packages specified in the [Dockerfile](.devcontainer/Dockerfile)
-2. Install vcpkg as done in the [Dockerfile](.devcontainer/Dockerfile)
+1. Install all apt packages specified in the [Dockerfile](/.devcontainer/Dockerfile)
+2. Install vcpkg as done in the [Dockerfile](/.devcontainer/Dockerfile)
 3. Create a build directory and invoke cmake with a build preset. the list of available presets is:
 
 ```bash


### PR DESCRIPTION
https://github.com/dmf-mxl/mxl/blob/main/docs/Building.md has relative links `[Dockerfile](.devcontainer/Dockerfile)` when they should be fully specified links `[Dockerfile](/.devcontainer/Dockerfile)`