### PR TITLE
Fix continuous flow latency reporting in mxl-info

### DIFF
--- a/examples/Dockerfile.reader.txt
+++ b/examples/Dockerfile.reader.txt
@@ -14,4 +14,4 @@ COPY build/Linux-Clang-Release/tools/mxl-info/mxl-info /app/
 
 RUN patchelf --set-rpath /app mxl-info
 
-CMD ["watch", "/app/mxl-gst-info", "-d", "/domain", "-l"]
+CMD["sh", "-c", "while true; do /app/mxl-info -d /domain -l || true; sleep 2; done"]

--- a/tools/mxl-info/main.cpp
+++ b/tools/mxl-info/main.cpp
@@ -5,17 +5,20 @@
 #include <cstdlib>
 #include <ctime>
 #include <filesystem>
+#include <fstream>
 #include <iostream>
 #include <sstream>
 #include <string>
 #include <unistd.h>
 #include <uuid.h>
 #include <CLI/CLI.hpp>
+#include <fmt/color.h>
 #include <fmt/format.h>
 #include <gsl/span>
 #include <mxl/flow.h>
 #include <mxl/mxl.h>
 #include <mxl/time.h>
+#include <picojson/picojson.h>
 #include <sys/file.h>
 #include "../../lib/src/internal/PathUtils.hpp"
 
@@ -47,11 +50,28 @@ std::ostream& operator<<(std::ostream& os, mxlFlowInfo const& info)
        << '\t' << fmt::format("{: >18}: {}", "Format", getFormatString(info.common.format)) << '\n'
        << '\t' << fmt::format("{: >18}: {:0>8x}", "Flags", info.common.flags) << '\n';
 
+    auto const now = mxlGetTime();
+
     if (mxlIsDiscreteDataFormat(info.common.format))
     {
         os << '\t' << fmt::format("{: >18}: {}/{}", "Grain rate", info.discrete.grainRate.numerator, info.discrete.grainRate.denominator) << '\n'
            << '\t' << fmt::format("{: >18}: {}", "Grain count", info.discrete.grainCount) << '\n'
            << '\t' << fmt::format("{: >18}: {}", "Head index", info.discrete.headIndex) << '\n';
+
+        auto const currentIndex = mxlTimestampToIndex(&info.discrete.grainRate, now);
+        auto const latency = currentIndex - info.discrete.headIndex;
+
+        fmt::color color{fmt::color::green};
+        if (latency > static_cast<std::uint64_t>(info.discrete.grainCount))
+        {
+            color = fmt::color::red;
+        }
+        else if (latency == static_cast<std::uint64_t>(info.discrete.grainCount))
+        {
+            color = fmt::color::yellow;
+        }
+
+        os << '\t' << fmt::format(fmt::fg(color), "{: >18}: {}", "Latency (grains)", latency) << std::endl;
     }
     else if (mxlIsContinuousDataFormat(info.common.format))
     {
@@ -62,19 +82,66 @@ std::ostream& operator<<(std::ostream& os, mxlFlowInfo const& info)
            << '\t' << fmt::format("{: >18}: {}", "Commit batch size", info.continuous.commitBatchSize) << '\n'
            << '\t' << fmt::format("{: >18}: {}", "Sync batch size", info.continuous.syncBatchSize) << '\n'
            << '\t' << fmt::format("{: >18}: {}", "Head index", info.continuous.headIndex) << '\n';
-    }
 
-    auto const now = mxlGetTime();
-    auto const currentIndex = mxlTimestampToIndex(&info.discrete.grainRate, now);
-    os << '\t' << fmt::format("{: >18}: {}", "Latency (grains)", currentIndex - info.discrete.headIndex) << '\n'
-       << '\t' << fmt::format("{: >18}: {}", "Latency (ns)", now - info.common.lastWriteTime) << std::endl;
+        auto const currentIndex = mxlTimestampToIndex(&info.continuous.sampleRate, now);
+        auto const latency = currentIndex - info.continuous.headIndex;
+
+        fmt::color color{fmt::color::green};
+        if (latency > static_cast<std::uint64_t>(info.continuous.bufferLength))
+        {
+            color = fmt::color::red;
+        }
+        else if (latency == static_cast<std::uint64_t>(info.continuous.bufferLength))
+        {
+            color = fmt::color::yellow;
+        }
+
+        os << '\t' << fmt::format(fmt::fg(color), "{: >18}: {}", "Latency (samples)", latency) << std::endl;
+    }
 
     return os;
 }
 
+std::string getFlowLabel(std::filesystem::path const& descPath)
+{
+    std::string label{"Unnamed flow"};
+    if (!exists(descPath))
+    {
+        return label;
+    }
+
+    std::ifstream descFile{descPath};
+    if (!descFile)
+    {
+        return label;
+    }
+
+    std::string content((std::istreambuf_iterator<char>(descFile)), std::istreambuf_iterator<char>());
+    descFile.close();
+
+    picojson::value v;
+    std::string err = picojson::parse(v, content);
+    if (!err.empty())
+    {
+        return label;
+    }
+
+    auto const& obj = v.get<picojson::object>();
+    auto flowTypeIt = obj.find("label");
+    if (flowTypeIt == obj.end() || !flowTypeIt->second.is<std::string>())
+    {
+        return label;
+    }
+    else
+    {
+        label = flowTypeIt->second.get<std::string>();
+    }
+
+    return label;
+}
+
 int listAllFlows(std::string const& in_domain)
 {
-    std::cout << "--- MXL Flows ---" << '\n';
     auto base = std::filesystem::path{in_domain};
 
     if (exists(base) && is_directory(base))
@@ -87,7 +154,8 @@ int listAllFlows(std::string const& in_domain)
                 auto id = uuids::uuid::from_string(entry.path().stem().string());
                 if (id.has_value())
                 {
-                    std::cout << "\t" << *id << '\n';
+                    auto descPath = mxl::lib::makeFlowDescriptorFilePath(base, entry.path().stem().string());
+                    std::cout << "\t" << *id << ", \"" << getFlowLabel(descPath) << "\"" << std::endl;
                 }
             }
         }


### PR DESCRIPTION
Fix #121 

- Latency reporting of continuous buffers was using discrete buffer index
- Remove the nanoseconds based latency reporting. it was using the flow mtime which is irrelevant. we may want to actually compute the value if someone cares about it.  reporting the latency as grains or samples.
- Help debug timing issues but displaying latency values in red (out of ringbuffer) yellow (on the edge) or green (in the ringbuffer)

Also fix #127 and #128 (example docker compose reader dockerfile syntax for recent distros)