### PR TITLE
Take into account the vcpkg.json file when building the image hash

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
         id: docker-hash
         run: |
           # Create a hash based on Dockerfile content and matrix parameters
-          HASH_INPUT=$(cat .devcontainer/Dockerfile .devcontainer/register-clang-version.sh)
+          HASH_INPUT=$(cat .devcontainer/Dockerfile .devcontainer/register-clang-version.sh vcpkg.json)
           HASH_INPUT="${HASH_INPUT}${{ matrix.version }}${{ matrix.architecture }}${{ matrix.compiler }}"
           DOCKER_HASH=$(echo -n "$HASH_INPUT" | sha256sum | cut -d' ' -f1)
           echo "hash=$DOCKER_HASH" >> $GITHUB_OUTPUT

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -3,7 +3,7 @@
   "dependencies": [
     {
       "name": "catch2",
-      "version>=": "3.8.1#0"
+      "version>=": "3.10.0#0"
     },
     {
       "name": "stduuid",
@@ -19,7 +19,7 @@
     },
     {
       "name": "fmt",
-      "version>=": "11.0.2#1"
+      "version>=": "11.2.0#0"
     },
     {
       "name": "picojson",
@@ -35,5 +35,5 @@
       "platform": "linux"
     }
   ],
-  "builtin-baseline": "189fcdcb953b871d206ffada6db047496fc3f496"
+  "builtin-baseline": "4002e3abc6d3e468c73d2d9777a7dd96af5dc224"
 }


### PR DESCRIPTION
Also : keep up with dependency updates (fmt and catch2).