### PR TITLE
Build shared library and tests from common object library

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -5,30 +5,26 @@ include(GNUInstallDirs)
 
 # Configure the version.h header file base on the current project version
 configure_file(
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/mxl/version.h.in
-    ${CMAKE_CURRENT_BINARY_DIR}/include/mxl/version.h
-    @ONLY
-)
+        ${CMAKE_CURRENT_SOURCE_DIR}/include/mxl/version.h.in
+        ${CMAKE_CURRENT_BINARY_DIR}/include/mxl/version.h
+        @ONLY
+    )
 
-# Files to be compiled into the library
-add_library(mxl SHARED)
-target_compile_features(mxl
-        PRIVATE
+add_library(mxl-objects OBJECT)
+target_compile_features(mxl-objects
+        PUBLIC
             cxx_std_20
     )
-set_target_properties(mxl
-        PROPERTIES
-            POSITION_INDEPENDENT_CODE    ON
-            VISIBILITY_INLINES_HIDDEN    ON
-            C_VISIBILITY_PRESET          hidden
-            CXX_VISIBILITY_PRESET        hidden
-            C_EXTENSIONS                 OFF
-            CXX_EXTENSIONS               OFF
-            VERSION                      "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}"
-            SOVERSION                    "${PROJECT_VERSION_MAJOR}"
+set_target_properties(mxl-objects
+        PROPERTIES 
+            POSITION_INDEPENDENT_CODE ON      # Needed to bulid shared library later
+            VISIBILITY_INLINES_HIDDEN ON
+            C_VISIBILITY_PRESET       hidden
+            CXX_VISIBILITY_PRESET     hidden
+            C_EXTENSIONS              OFF
+            CXX_EXTENSIONS            OFF
     )
-
-target_sources(mxl
+target_sources(mxl-objects
         PRIVATE
             src/flow.cpp
             src/mxl.cpp
@@ -54,8 +50,7 @@ target_sources(mxl
             src/internal/Thread.cpp
             src/internal/Time.cpp
             src/internal/Timing.cpp
-        )
-
+    )
 
 if (NOT TARGET stduuid)
     find_package(stduuid CONFIG REQUIRED)
@@ -73,20 +68,45 @@ if (NOT TARGET picojson::picojson)
     find_package(picojson REQUIRED)
 endif()
 
-target_include_directories(mxl PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-)
-target_link_libraries(mxl
+target_include_directories(mxl-objects
         PRIVATE
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
+    )
+target_link_libraries(mxl-objects
+        PUBLIC
             stduuid
             spdlog::spdlog
             fmt::fmt
             picojson::picojson
     )
 
-# Alias trace to libtrace::libtrace so that this library can be used
+add_library(mxl SHARED)
+target_compile_features(mxl
+        PRIVATE
+            cxx_std_20
+    )
+set_target_properties(mxl
+        PROPERTIES
+            VERSION                      "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}"
+            SOVERSION                    "${PROJECT_VERSION_MAJOR}"
+    )
+target_link_options(mxl
+        PRIVATE
+            "-Wl,--exclude-libs,ALL"
+    )
+
+target_include_directories(mxl 
+        PUBLIC
+            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+    )
+
+target_link_libraries(mxl
+        PRIVATE
+            mxl-objects
+    )
+
+# Alias mxl to mxl::mxl so that this library can be used
 # in lieu of a module from the local source tree
 add_library(${PROJECT_NAME}::mxl ALIAS mxl)
 add_subdirectory(tests)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -26,9 +26,6 @@ set_target_properties(mxl-objects
     )
 target_sources(mxl-objects
         PRIVATE
-            src/flow.cpp
-            src/mxl.cpp
-            src/time.cpp
             src/internal/DomainWatcher.cpp
             src/internal/Flow.cpp
             src/internal/FlowData.cpp
@@ -88,16 +85,31 @@ target_compile_features(mxl
     )
 set_target_properties(mxl
         PROPERTIES
-            VERSION                      "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}"
-            SOVERSION                    "${PROJECT_VERSION_MAJOR}"
+            POSITION_INDEPENDENT_CODE ON      # Needed to bulid shared library later
+            VISIBILITY_INLINES_HIDDEN ON
+            C_VISIBILITY_PRESET       hidden
+            CXX_VISIBILITY_PRESET     hidden
+            C_EXTENSIONS              OFF
+            CXX_EXTENSIONS            OFF
+            VERSION                   "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}"
+            SOVERSION                 "${PROJECT_VERSION_MAJOR}"
     )
 target_link_options(mxl
         PRIVATE
             "-Wl,--exclude-libs,ALL"
     )
 
+target_sources(mxl
+        PRIVATE
+            src/flow.cpp
+            src/mxl.cpp
+            src/time.cpp
+    )
+
 target_include_directories(mxl 
         PUBLIC
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
             $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
     )
 

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -28,27 +28,9 @@ target_sources(mxl-tests
         test_time.cpp
         test_sharedmem.cpp
         Utils.cpp
-        ../src/internal/DomainWatcher.cpp
-        ../src/internal/Flow.cpp
-        ../src/internal/FlowData.cpp
-        ../src/internal/FlowIoFactory.cpp
-        ../src/internal/FlowManager.cpp
-        ../src/internal/FlowParser.cpp
-        ../src/internal/FlowReader.cpp
-        ../src/internal/FlowWriter.cpp
-        ../src/internal/Instance.cpp
-        ../src/internal/PathUtils.cpp
-        ../src/internal/PosixContinuousFlowReader.cpp
-        ../src/internal/PosixContinuousFlowWriter.cpp
-        ../src/internal/PosixDiscreteFlowReader.cpp
-        ../src/internal/PosixDiscreteFlowWriter.cpp
-        ../src/internal/PosixFlowIoFactory.cpp
-        ../src/internal/SharedMemory.cpp
-        ../src/internal/Thread.cpp
-        ../src/internal/Time.cpp
-        ../src/internal/Timing.cpp
-        ../src/internal/Sync.cpp
     )
+
+target_link_libraries(mxl-tests PRIVATE mxl-objects)
 
 if (NOT TARGET Catch2::Catch2WithMain)
     find_package(Catch2 REQUIRED)

--- a/tools/mxl-gst/CMakeLists.txt
+++ b/tools/mxl-gst/CMakeLists.txt
@@ -40,12 +40,11 @@ if (gstreamer_FOUND)
     target_sources(mxl-gst-videotestsrc
             PRIVATE
                 videotestsrc.cpp
-                ../../lib/src/internal/FlowParser.cpp
-                ../../lib/src/internal/PathUtils.cpp
-            )
+        )
 
     target_link_libraries(mxl-gst-videotestsrc
             PRIVATE
+                mxl-objects
                 mxl
                 stduuid
                 CLI11::CLI11
@@ -63,22 +62,21 @@ if (gstreamer_FOUND)
         )
     set_target_properties(mxl-gst-videosink
             PROPERTIES
-                POSITION_INDEPENDENT_CODE    ON
-                VISIBILITY_INLINES_HIDDEN    ON
-                C_VISIBILITY_PRESET          hidden
-                CXX_VISIBILITY_PRESET        hidden
-                C_EXTENSIONS                 OFF
-                CXX_EXTENSIONS               OFF
+                POSITION_INDEPENDENT_CODE   ON
+                VISIBILITY_INLINES_HIDDEN   ON
+                C_VISIBILITY_PRESET         hidden
+                CXX_VISIBILITY_PRESET       hidden
+                C_EXTENSIONS                OFF
+                CXX_EXTENSIONS              OFF
         )
     target_sources(mxl-gst-videosink
             PRIVATE
                 videosink.cpp
-                ../../lib/src/internal/FlowParser.cpp
-                ../../lib/src/internal/PathUtils.cpp
-            )
+        )
 
     target_link_libraries(mxl-gst-videosink
             PRIVATE
+                mxl-objects
                 mxl
                 stduuid
                 CLI11::CLI11
@@ -91,35 +89,34 @@ if (gstreamer_FOUND)
 
     add_executable(mxl-gst-looping-filesrc)
     target_compile_features(mxl-gst-looping-filesrc
-        PRIVATE
-        cxx_std_20
-    )
+            PRIVATE
+                cxx_std_20
+        )
     set_target_properties(mxl-gst-looping-filesrc
-        PROPERTIES
-        POSITION_INDEPENDENT_CODE ON
-        VISIBILITY_INLINES_HIDDEN ON
-        C_VISIBILITY_PRESET hidden
-        CXX_VISIBILITY_PRESET hidden
-        C_EXTENSIONS OFF
-        CXX_EXTENSIONS OFF
-    )
+            PROPERTIES
+                POSITION_INDEPENDENT_CODE   ON
+                VISIBILITY_INLINES_HIDDEN   ON
+                C_VISIBILITY_PRESET         hidden
+                CXX_VISIBILITY_PRESET       hidden
+                C_EXTENSIONS                OFF
+                CXX_EXTENSIONS              OFF
+        )
     target_sources(mxl-gst-looping-filesrc
-        PRIVATE
-        looping_filesrc.cpp
-        ../../lib/src/internal/FlowParser.cpp
-        ../../lib/src/internal/PathUtils.cpp
-    )
+            PRIVATE
+                looping_filesrc.cpp
+        )
 
     target_link_libraries(mxl-gst-looping-filesrc
-        PRIVATE
-        mxl
-        stduuid
-        CLI11::CLI11
-        spdlog::spdlog
-        PkgConfig::gstreamer
-        PkgConfig::gstreamer-app
-        PkgConfig::gstreamer-video
-    )
+            PRIVATE
+                mxl-objects
+                mxl
+                stduuid
+                CLI11::CLI11
+                spdlog::spdlog
+                PkgConfig::gstreamer
+                PkgConfig::gstreamer-app
+                PkgConfig::gstreamer-video
+        )
 
 
     # Not really a fan of having this relative to the binary,

--- a/tools/mxl-gst/CMakeLists.txt
+++ b/tools/mxl-gst/CMakeLists.txt
@@ -46,9 +46,7 @@ if (gstreamer_FOUND)
             PRIVATE
                 mxl-objects
                 mxl
-                stduuid
                 CLI11::CLI11
-                spdlog::spdlog
                 PkgConfig::gstreamer
                 PkgConfig::gstreamer-app
                 PkgConfig::gstreamer-video
@@ -78,7 +76,6 @@ if (gstreamer_FOUND)
             PRIVATE
                 mxl-objects
                 mxl
-                stduuid
                 CLI11::CLI11
                 spdlog::spdlog
                 PkgConfig::gstreamer
@@ -110,9 +107,7 @@ if (gstreamer_FOUND)
             PRIVATE
                 mxl-objects
                 mxl
-                stduuid
                 CLI11::CLI11
-                spdlog::spdlog
                 PkgConfig::gstreamer
                 PkgConfig::gstreamer-app
                 PkgConfig::gstreamer-video

--- a/tools/mxl-info/CMakeLists.txt
+++ b/tools/mxl-info/CMakeLists.txt
@@ -22,13 +22,6 @@ target_sources(mxl-info
             main.cpp
     )
 
-if (NOT TARGET stduuid)
-    find_package(stduuid CONFIG REQUIRED)
-endif ()
-
-if (NOT TARGET fmt::fmt)
-    find_package(fmt CONFIG REQUIRED)
-endif ()
 
 if (NOT TARGET CLI11::CLI11)
     find_package(CLI11 CONFIG REQUIRED)
@@ -38,8 +31,6 @@ target_link_libraries(mxl-info
         PRIVATE
             mxl-objects
             mxl
-            stduuid
-            fmt::fmt
             CLI11::CLI11
     )
 

--- a/tools/mxl-info/CMakeLists.txt
+++ b/tools/mxl-info/CMakeLists.txt
@@ -19,7 +19,6 @@ set_target_properties(mxl-info
     )
 target_sources(mxl-info
         PRIVATE
-            ../../lib/src/internal/PathUtils.cpp
             main.cpp
     )
 
@@ -37,6 +36,7 @@ endif ()
 
 target_link_libraries(mxl-info
         PRIVATE
+            mxl-objects
             mxl
             stduuid
             fmt::fmt


### PR DESCRIPTION
Create a cmake object library that contains all library objects. The shared library and the tests are linked to this object lib. Avoids having to build the objects twice.

Also adds a linker flag to avoid exposing symbols from the static libraries that we link into our library to be exposed on the library surface. 

Before:
```
nm -gD build/Linux-Clang-Debug/lib/libmxl.so | count
7585
```

After:
```
nm -gD build/Linux-Clang-Debug/lib/libmxl.so | count
355
```