### PR TITLE
Add Feature issue template with Requirement Issue link

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,3 @@
-<!-- SPDX-FileCopyrightText: 2025 Contributors to the Media eXchange Layer project. -->
-<!-- SPDX-License-Identifier: Apache-2.0 -->
-
 ---
 name: Bug report
 about: Create a report to help us improve
@@ -39,3 +36,6 @@ If applicable, add screenshots to help explain your problem.
 
 **Additional context**
 Add any other context about the problem here.
+
+<!-- SPDX-FileCopyrightText: 2025 Contributors to the Media eXchange Layer project. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
+blank_issues_enabled: false
+
 # SPDX-FileCopyrightText: 2025 Contributors to the Media eXchange Layer project.
 # SPDX-License-Identifier: Apache-2.0
-
-blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: 2025 Contributors to the Media eXchange Layer project.
-# !-- SPDX-License-Identifier: Apache-2.0
-
 name: Feature
 description: Feature from MXL Requirement
 labels: []
@@ -19,7 +16,7 @@ body:
 
   - type: textarea
     id: description
-    attribute:
+    attributes:
       label: Description
       description: A clear and concise description of the feature
       placeholder: "Describe the feature"
@@ -34,3 +31,7 @@ body:
       placeholder: "Include any relevant background, links, or images."
     validations:
       required: false
+
+# SPDX-FileCopyrightText: 2025 Contributors to the Media eXchange Layer project.
+# SPDX-License-Identifier: Apache-2.0
+

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,3 @@
-<!-- SPDX-FileCopyrightText: 2025 Contributors to the Media eXchange Layer project. -->
-<!-- SPDX-License-Identifier: Apache-2.0 -->
-
 ---
 name: Feature request
 about: Suggest an idea for this project
@@ -21,3 +18,6 @@ A clear and concise description of any alternative solutions or features you've 
 
 **Additional context**
 Add any other context or screenshots about the feature request here.
+
+<!-- SPDX-FileCopyrightText: 2025 Contributors to the Media eXchange Layer project. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->

--- a/.github/ISSUE_TEMPLATE/tsc-meeting-topic.md
+++ b/.github/ISSUE_TEMPLATE/tsc-meeting-topic.md
@@ -1,6 +1,3 @@
-<!-- SPDX-FileCopyrightText: 2025 Contributors to the Media eXchange Layer project. -->
-<!-- SPDX-License-Identifier: Apache-2.0 -->
-
 ---
 name: TSC Meeting Topic
 about: Covers a topic discussed in the TSC weekly meeting
@@ -10,4 +7,5 @@ assignees: ''
 
 ---
 
-
+<!-- SPDX-FileCopyrightText: 2025 Contributors to the Media eXchange Layer project. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->


### PR DESCRIPTION
See #186 -- this adds a new issue template for Feature with a mandatory field to link to the related requirement.

It also moves the SPDX headers to the bottom of the templates as having them at the top means that the templates aren't recoginsed by GitHub.