### PR TITLE
Change media_type to video/v210a and add ASCII art docs of that media type

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -89,7 +89,7 @@ The following example demonstrates how a FlowWriter may write a grain as slices 
 
 ## Video
 
-Video grains can be of two different formats: video/v210 for video without transparency and video/v210+alpha for fill and key signals (video with alpha transparency).
+Video grains can be of two different formats: video/v210 for video without transparency and video/v210a for fill and key signals (video with alpha transparency).
 
 ### video/v210
 

--- a/lib/include/mxl/flowinfo.h
+++ b/lib/include/mxl/flowinfo.h
@@ -18,7 +18,7 @@
 //
 // The current video formats supported by MXL use 1 or 2 planes:
 // - video/v210 flow will have only 1 plane out of MXL_MAX_PLANES_PER_GRAIN
-// - video/v210+alpha flow will have 2 planes out of MXL_MAX_PLANES_PER_GRAIN
+// - video/v210a flow will have 2 planes out of MXL_MAX_PLANES_PER_GRAIN
 //
 #define MXL_MAX_PLANES_PER_GRAIN 4
 

--- a/lib/internal/src/FlowParser.cpp
+++ b/lib/internal/src/FlowParser.cpp
@@ -351,7 +351,7 @@ namespace mxl::lib
                     throw std::invalid_argument{std::move(msg)};
                 }
             }
-            else if (mediaType == "video/v210+alpha")
+            else if (mediaType == "video/v210a")
             {
                 if (!_interlaced || ((height % 2) == 0))
                 {
@@ -442,7 +442,7 @@ namespace mxl::lib
                 {
                     sliceLengths[0] = v210fillSize;
                 }
-                else if (mediaType == "video/v210+alpha")
+                else if (mediaType == "video/v210a")
                 {
                     sliceLengths[0] = v210fillSize;
                     sliceLengths[1] = get10BitAlphaLineLength(width);
@@ -476,7 +476,7 @@ namespace mxl::lib
 
             case MXL_DATA_FORMAT_VIDEO:
             {
-                if (auto const mediaType = fetchAs<std::string>(_root, "media_type"); mediaType != "video/v210" && mediaType != "video/v210+alpha")
+                if (auto const mediaType = fetchAs<std::string>(_root, "media_type"); mediaType != "video/v210" && mediaType != "video/v210a")
                 {
                     auto msg = std::string{"Unsupported video media_type: "} + mediaType;
                     throw std::invalid_argument{std::move(msg)};

--- a/lib/tests/data/v210+alpha_flow.json
+++ b/lib/tests/data/v210+alpha_flow.json
@@ -11,7 +11,7 @@
   "format": "urn:x-nmos:format:video",
   "label": "MXL Test Flow, 1080p29 with alpha",
   "parents": [],
-  "media_type": "video/v210+alpha",
+  "media_type": "video/v210a",
   "grain_rate": {
     "numerator": 30000,
     "denominator": 1001


### PR DESCRIPTION
Change media_type to video/v210alpha, removing plus sign (+) to avoid confusion with Structured Syntax Suffixes (https://www.iana.org/assignments/media-type-structured-suffix/media-type-structured-suffix.xhtml#structured-syntax-suffix).

Added ASCII art of video/v210alpha format.