### PR TITLE
Added call to be able to be notified of partial grain updates from discrete flows.

### DIFF
--- a/lib/include/mxl/flow.h
+++ b/lib/include/mxl/flow.h
@@ -205,7 +205,9 @@ extern "C"
     mxlStatus mxlFlowReaderGetInfo(mxlFlowReader reader, mxlFlowInfo* info);
 
     /**
-     * Accessors for a flow grain at a specific index
+     * Accessors for a flow grain at a specific index.
+     * This method is expected to wait until the full grain is available (or the timeout expires). For partial grain access use
+     * mxlFlowReaderGetGrainSlice()
      *
      * \param[in] reader A valid discrete flow reader.
      * \param[in] index The index of the grain to obtain
@@ -220,6 +222,25 @@ extern "C"
      */
     MXL_EXPORT
     mxlStatus mxlFlowReaderGetGrain(mxlFlowReader reader, uint64_t index, uint64_t timeoutNs, mxlGrainInfo* grain, uint8_t** payload);
+
+    /**
+     * Accessors for a flow grain at a specific index, with a minimum number of valid slices.
+     *
+     * \param[in] reader A valid discrete flow reader.
+     * \param[in] index The index of the grain to obtain
+     * \param[in] minValidSlices The minimum number of valid slices required in the returned grain.
+     * \param[in] timeoutNs How long should we wait for the slice (in nanoseconds)
+     * \param[out] grain The requested mxlGrainInfo structure.
+     * \param[out] payload The requested grain payload.
+     * \return The result code. \see mxlStatus
+     * \note Please note that this function can only be called on readers that
+     *      operate on discrete flows. Any attempt to call this function on a
+     *      reader that operates on another type of flow will result in an
+     *      error.
+     */
+    MXL_EXPORT
+    mxlStatus mxlFlowReaderGetGrainSlice(mxlFlowReader reader, uint64_t index, uint16_t minValidSlices, uint64_t timeoutNs, mxlGrainInfo* grain,
+        uint8_t** payload);
 
     /**
      * Non-blocking accessors for a flow grain at a specific index

--- a/lib/internal/CMakeLists.txt
+++ b/lib/internal/CMakeLists.txt
@@ -47,6 +47,7 @@ target_sources(mxl-common
             src/FlowData.cpp
             src/FlowIoFactory.cpp
             src/FlowManager.cpp
+            src/FlowOptionsParser.cpp
             src/FlowParser.cpp
             src/FlowReader.cpp
             src/FlowWriter.cpp

--- a/lib/internal/include/mxl-internal/DiscreteFlowReader.hpp
+++ b/lib/internal/include/mxl-internal/DiscreteFlowReader.hpp
@@ -16,6 +16,7 @@ namespace mxl::lib
         /// The index must be >= mxlFlowInfo.tailIndex.
         ///
         /// \param in_index The grain index.
+        /// \param in_minValidSlices The expected number of valid slices in the returned mxlGrainInfo.
         /// \param in_timeoutNs How long to wait in nanoseconds for the grain if in_index is > mxlFlowInfo.headIndex
         /// \param out_grainInfo A valid pointer to mxlGrainInfo that will be copied to
         /// \param out_payload A valid void pointer to pointer that will be set to the first byte of the grain payload.
@@ -23,7 +24,8 @@ namespace mxl::lib
         ///
         /// \return A status code describing the outcome of the call.
         ///
-        virtual mxlStatus getGrain(std::uint64_t in_index, std::uint64_t in_timeoutNs, mxlGrainInfo* out_grainInfo, std::uint8_t** out_payload) = 0;
+        virtual mxlStatus getGrain(std::uint64_t in_index, std::uint16_t in_minValidSlices, std::uint64_t in_timeoutNs, mxlGrainInfo* out_grainInfo,
+            std::uint8_t** out_payload) = 0;
 
         ///
         /// Non-blocking accessor for a specific grain at a specific index.

--- a/lib/internal/include/mxl-internal/FlowManager.hpp
+++ b/lib/internal/include/mxl-internal/FlowManager.hpp
@@ -60,10 +60,14 @@ namespace mxl::lib
         /// \param[in] grainPayloadSize Size of the grain in host memory.  0 if the grain payload lives in device memory.
         /// \param[in] grainNumOfSlices Number of slices per grain.
         /// \param[in] grainSliceLengths Length of each slice in bytes.
+        /// \param[in] maxSyncBatchSizeHintOpt Optional max sync batch size hint.
+        /// \param[in] maxCommitBatchSizeHintOpt Optional max commit batch size hint
         ///
         std::unique_ptr<DiscreteFlowData> createDiscreteFlow(uuids::uuid const& flowId, std::string const& flowDef, mxlDataFormat flowFormat,
             std::size_t grainCount, mxlRational const& grainRate, std::size_t grainPayloadSize, std::size_t grainNumOfSlices,
-            std::array<std::uint32_t, MXL_MAX_PLANES_PER_GRAIN> grainSliceLengths);
+            std::array<std::uint32_t, MXL_MAX_PLANES_PER_GRAIN> grainSliceLengths,
+            std::optional<std::uint32_t> maxSyncBatchSizeHintOpt = std::nullopt,
+            std::optional<std::uint32_t> maxCommitBatchSizeHintOpt = std::nullopt);
 
         ///
         /// Create a new continuous flow together with its associated channel store and open it in read-write mode.
@@ -75,9 +79,13 @@ namespace mxl::lib
         /// \param[in] channelCount The number of channels in the flow.
         /// \param[in] sampleWordSize The size of one sample in bytes.
         /// \param[in] bufferLength The length of each channel buffer in samples.
+        /// \param[in] maxSyncBatchSizeHintOpt Optional max sync batch size hint.
+        /// \param[in] maxCommitBatchSizeHintOpt Optional max commit batch size hint
         ///
         std::unique_ptr<ContinuousFlowData> createContinuousFlow(uuids::uuid const& flowId, std::string const& flowDef, mxlDataFormat flowFormat,
-            mxlRational const& sampleRate, std::size_t channelCount, std::size_t sampleWordSize, std::size_t bufferLength);
+            mxlRational const& sampleRate, std::size_t channelCount, std::size_t sampleWordSize, std::size_t bufferLength,
+            std::optional<std::uint32_t> maxSyncBatchSizeHintOpt = std::nullopt,
+            std::optional<std::uint32_t> maxCommitBatchSizeHintOpt = std::nullopt);
 
         /// Open an existing flow by id.
         ///

--- a/lib/internal/include/mxl-internal/FlowOptionsParser.hpp
+++ b/lib/internal/include/mxl-internal/FlowOptionsParser.hpp
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <picojson/picojson.h>
+
+namespace mxl::lib
+{
+    /**
+     * Parses flow options and extracts valid attributes.
+     */
+    class FlowOptionsParser
+    {
+    public:
+        /**
+         * Parses a json of flow options
+         *
+         * \param in_flowOptions The flow options
+         * \throws std::runtime_error on any parse error
+         */
+        FlowOptionsParser(std::string const& in_flowOptions);
+
+        /**
+         * Accessor for the 'maxCommitBatchSizeHint' field, which expresses the largest expected batch size in samples (for continuous flows) or
+         * slices (for discrete flows), in which new data is written to this this flow by its producer. For continuous flows, this value must be less
+         * than half of the buffer length. For discrete flows, this must be greater or equal to 1.
+         */
+        [[nodiscard]]
+        std::optional<std::uint32_t> getMaxCommitBatchSizeHint() const;
+
+        /**
+         * Accessor for the 'maxSyncBatchSizeHint' field, which expresses the largest expected batch size in samples (for continuous flows) or slices
+         * (for discrete flows), at which availability of new data is signaled to waiting consumers. This must be a multiple of the commit batch size
+         * greater or equal to 1.
+         */
+        [[nodiscard]]
+        std::optional<std::uint32_t> getMaxSyncBatchSizeHint() const;
+
+        /**
+         * Generic accessor for json fields.
+         *
+         * \param in_field The field name.
+         * \return The field value if found.
+         * \throw If the field is not found or T is incompatible
+         */
+        template<typename T>
+        [[nodiscard]]
+        T get(std::string const& field) const;
+
+    private:
+        /// \see mxlCommonFlowInfo::maxSyncBatchSizeHint
+        std::optional<std::uint32_t> _maxSyncBatchSizeHint;
+        /// \see mxlCommonFlowInfo::maxCommitBatchSizeHint
+        std::optional<std::uint32_t> _maxCommitBatchSizeHint;
+        /** The parsed flow object. */
+        picojson::object _root;
+    };
+
+}

--- a/lib/internal/include/mxl-internal/FlowParser.hpp
+++ b/lib/internal/include/mxl-internal/FlowParser.hpp
@@ -40,7 +40,7 @@ namespace mxl::lib
         /**
          * Accessor for the 'grain_rate' field, which either contains the
          * 'grain rate' for discrete flows, or the 'sample rate' for continuous
-         * floww.s
+         * flows.
          *
          * \return The grain rate or sample rate respectively if found and valid.
          */

--- a/lib/internal/include/mxl-internal/Instance.hpp
+++ b/lib/internal/include/mxl-internal/Instance.hpp
@@ -46,10 +46,11 @@ namespace mxl::lib
         /// Create a flow
         ///
         /// \param[in] flowDef The json flow definition according to the NMOS Flow Resource json schema
+        /// \param[in] options Additional options for flow creation
         /// \return The created flow resources in shared memory
         /// \throw std::runtime_error On any error (parse exception, shared memory conflicts, etc)
         ///
-        std::unique_ptr<FlowData> createFlow(std::string const& flowDef);
+        std::unique_ptr<FlowData> createFlow(std::string const& flowDef, std::string const& options = {});
 
         /// Delete a flow by id
         ///

--- a/lib/internal/src/FlowOptionsParser.cpp
+++ b/lib/internal/src/FlowOptionsParser.cpp
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "mxl-internal/FlowOptionsParser.hpp"
+#include <picojson/picojson.h>
+#include <mxl/mxl.h>
+#include "mxl-internal/Logging.hpp"
+
+namespace mxl::lib
+{
+    FlowOptionsParser::FlowOptionsParser(std::string const& in_options)
+    {
+        if (in_options.empty())
+        {
+            return;
+        }
+
+        //
+        // Parse the json options
+        //
+        auto jsonValue = picojson::value{};
+        auto const err = picojson::parse(jsonValue, in_options);
+        if (!err.empty())
+        {
+            throw std::invalid_argument{"Invalid JSON options. " + err};
+        }
+
+        // Confirm that the root is a json object
+        if (!jsonValue.is<picojson::object>())
+        {
+            throw std::invalid_argument{"Expected a JSON object"};
+        }
+        _root = jsonValue.get<picojson::object>();
+
+        auto maxCommitBatchSizeHintIt = _root.find("maxCommitBatchSizeHint");
+        if (maxCommitBatchSizeHintIt != _root.end())
+        {
+            if (!maxCommitBatchSizeHintIt->second.is<double>())
+            {
+                throw std::invalid_argument{"maxCommitBatchSizeHint must be a number."};
+            }
+
+            auto const v = maxCommitBatchSizeHintIt->second.get<double>();
+            if (v < 1)
+            {
+                throw std::invalid_argument{"maxCommitBatchSizeHint must be greater or equal to 1."};
+            }
+            _maxCommitBatchSizeHint = static_cast<std::uint32_t>(v);
+        }
+
+        auto maxSyncBatchSizeHintIt = _root.find("maxSyncBatchSizeHint");
+        if (maxSyncBatchSizeHintIt != _root.end())
+        {
+            if (!maxSyncBatchSizeHintIt->second.is<double>())
+            {
+                throw std::invalid_argument{"maxSyncBatchSizeHint must be a number."};
+            }
+
+            auto const v = maxSyncBatchSizeHintIt->second.get<double>();
+            if (v < 1)
+            {
+                throw std::invalid_argument{"maxSyncBatchSizeHint must be greater or equal to 1."};
+            }
+            _maxSyncBatchSizeHint = static_cast<std::uint32_t>(v);
+            if ((_maxSyncBatchSizeHint.value() % _maxCommitBatchSizeHint.value_or(1) != 0))
+            {
+                throw std::invalid_argument{"maxSyncBatchSizeHint must be a multiple of maxCommitBatchSizeHint."};
+            }
+        }
+    }
+
+    std::optional<std::uint32_t> FlowOptionsParser::getMaxCommitBatchSizeHint() const
+    {
+        return _maxCommitBatchSizeHint;
+    }
+
+    std::optional<std::uint32_t> FlowOptionsParser::getMaxSyncBatchSizeHint() const
+    {
+        return _maxSyncBatchSizeHint;
+    }
+} // namespace mxl::lib

--- a/lib/internal/src/PosixDiscreteFlowReader.hpp
+++ b/lib/internal/src/PosixDiscreteFlowReader.hpp
@@ -48,6 +48,7 @@ namespace mxl::lib
         /// A reading application should reopen the flow if this method returns MXL_ERR_FLOW_INVALID.
         ///
         /// \param in_index The grain index.
+        /// \param in_minValidSlices The expected number of valid slices in the returned mxlGrainInfo.
         /// \param in_timeoutNs How long to wait in nanoseconds for the grain if in_index is > mxlFlowInfo.headIndex
         /// \param out_grainInfo A valid pointer to mxlGrainInfo that will be copied to
         /// \param out_payload A valid void pointer to pointer that will be set to the first byte of the grain payload.
@@ -55,7 +56,7 @@ namespace mxl::lib
         ///
         /// \return A status code describing the outcome of the call.
         ///
-        virtual mxlStatus getGrain(std::uint64_t in_index, std::uint64_t in_timeoutNs, mxlGrainInfo* out_grainInfo,
+        virtual mxlStatus getGrain(std::uint64_t in_index, std::uint16_t in_minValidSlices, std::uint64_t in_timeoutNs, mxlGrainInfo* out_grainInfo,
             std::uint8_t** out_payload) override;
 
         ///

--- a/lib/src/flow.cpp
+++ b/lib/src/flow.cpp
@@ -17,7 +17,7 @@ using namespace mxl::lib;
 
 extern "C"
 MXL_EXPORT
-mxlStatus mxlCreateFlow(mxlInstance instance, char const* flowDef, char const* /*options*/, mxlFlowInfo* flowInfo)
+mxlStatus mxlCreateFlow(mxlInstance instance, char const* flowDef, char const* options, mxlFlowInfo* flowInfo)
 {
     try
     {
@@ -25,7 +25,7 @@ mxlStatus mxlCreateFlow(mxlInstance instance, char const* flowDef, char const* /
         {
             if (auto const cppInstance = to_Instance(instance); cppInstance != nullptr)
             {
-                auto const flowData = cppInstance->createFlow(flowDef);
+                auto const flowData = cppInstance->createFlow(flowDef, options ? options : "");
                 *flowInfo = *flowData->flowInfo();
                 return MXL_STATUS_OK;
             }
@@ -308,13 +308,21 @@ extern "C"
 MXL_EXPORT
 mxlStatus mxlFlowReaderGetGrain(mxlFlowReader reader, uint64_t index, uint64_t timeoutNs, mxlGrainInfo* grainInfo, uint8_t** payload)
 {
+    return mxlFlowReaderGetGrainSlice(reader, index, UINT16_MAX, timeoutNs, grainInfo, payload);
+}
+
+extern "C"
+MXL_EXPORT
+mxlStatus mxlFlowReaderGetGrainSlice(mxlFlowReader reader, uint64_t index, uint16_t minValidSlices, uint64_t timeoutNs, mxlGrainInfo* grainInfo,
+    uint8_t** payload)
+{
     try
     {
         if ((grainInfo != nullptr) && (payload != nullptr))
         {
             if (auto const cppReader = dynamic_cast<DiscreteFlowReader*>(to_FlowReader(reader)); cppReader != nullptr)
             {
-                return cppReader->getGrain(index, timeoutNs, grainInfo, payload);
+                return cppReader->getGrain(index, minValidSlices, timeoutNs, grainInfo, payload);
             }
             return MXL_ERR_INVALID_FLOW_READER;
         }


### PR DESCRIPTION
With the current API, mxlFlowReaderGetGrainSlice would always return immediately as soon as there was a commit done on a given grain index. This adds an API call for users wishing to wait on specific slices being available.

I'm thinking maybe the mxlFlowReaderGetGrain may need to morph into the full grain being available, maybe up for a quick discussion.

@mlefebvre1 can you verify this fixes your issue ?