### PR TITLE
feat: Add a getGrainInfo function to allow grainInfo inspection without having to open a grain for mutation.

### DIFF
--- a/lib/include/mxl/flow.h
+++ b/lib/include/mxl/flow.h
@@ -289,6 +289,21 @@ extern "C"
     mxlStatus mxlFlowReaderGetGrainNonBlocking(mxlFlowReader reader, uint64_t index, mxlGrainInfo* grain, uint8_t** payload);
 
     /**
+     * Get grain info for a given index. This is used to inspect the grain info without opening the grain for mutation.
+     *
+     * \param[in] writer A valid flow writer
+     * \param[in] index The index of the grain to obtain.
+     * \param[out] mxlGrainInfo The requested mxlGrainInfo structure.
+     * \return The result code. \see mxlStatus
+     * \note Please note that this function can only be called on writers that
+     *      operate on discrete flows. Any attempt to call this function on a
+     *      writer that operates on another type of flow will result in an
+     *      error.
+     */
+    MXL_EXPORT
+    mxlStatus mxlFlowWriterGetGrainInfo(mxlFlowWriter writer, uint64_t index, mxlGrainInfo* mxlGrainInfo);
+
+    /**
      * Open a grain for mutation.  The flow writer will remember which index is currently opened. Before opening a new grain
      * for mutation, the user must either cancel the mutation using mxlFlowWriterCancelGrain or mxlFlowWriterCommitGrain.
      *

--- a/lib/internal/include/mxl-internal/DiscreteFlowWriter.hpp
+++ b/lib/internal/include/mxl-internal/DiscreteFlowWriter.hpp
@@ -10,6 +10,10 @@ namespace mxl::lib
     class DiscreteFlowWriter : public FlowWriter
     {
     public:
+        /** \brief Used to get the grain info for a specific grain index without opening the grain for mutation.
+         */
+        virtual mxlStatus getGrainInfo(std::uint64_t in_index, mxlGrainInfo* out_grainInfo) = 0;
+
         virtual mxlStatus openGrain(std::uint64_t in_index, mxlGrainInfo* out_grainInfo, std::uint8_t** out_payload) = 0;
 
         virtual mxlStatus commit(mxlGrainInfo const& mxlGrainInfo) = 0;

--- a/lib/internal/src/PosixDiscreteFlowWriter.cpp
+++ b/lib/internal/src/PosixDiscreteFlowWriter.cpp
@@ -41,6 +41,18 @@ namespace mxl::lib
         throw std::runtime_error("No open flow.");
     }
 
+    mxlStatus PosixDiscreteFlowWriter::getGrainInfo(std::uint64_t in_index, mxlGrainInfo* out_grainInfo)
+    {
+        if (_flowData)
+        {
+            auto offset = in_index % _flowData->flowInfo()->config.discrete.grainCount;
+            auto const grain = _flowData->grainAt(offset);
+            *out_grainInfo = grain->header.info;
+            return MXL_STATUS_OK;
+        }
+        return MXL_ERR_UNKNOWN;
+    }
+
     mxlStatus PosixDiscreteFlowWriter::openGrain(std::uint64_t in_index, mxlGrainInfo* out_grainInfo, std::uint8_t** out_payload)
     {
         if (_flowData)

--- a/lib/internal/src/PosixDiscreteFlowWriter.hpp
+++ b/lib/internal/src/PosixDiscreteFlowWriter.hpp
@@ -17,7 +17,7 @@ namespace mxl::lib
     ///
     /// Implementation of a FlowWriter based on POSIX shared memory mapping.
     ///
-    class PosixDiscreteFlowWriter : public DiscreteFlowWriter
+    class PosixDiscreteFlowWriter final : public DiscreteFlowWriter
     {
     public:
         ///
@@ -33,12 +33,16 @@ namespace mxl::lib
         /// The flow writer must first open the flow before invoking this method.
         ///
         [[nodiscard]]
-        FlowData const& getFlowData() const final;
+        virtual FlowData const& getFlowData() const override;
 
         ///
         /// \see FlowWriter::getFlowInfo
         ///
         virtual mxlFlowInfo getFlowInfo() override;
+
+        ///
+        /// \see DiscreteFlowWriter::getGrainInfo
+        virtual mxlStatus getGrainInfo(std::uint64_t in_index, mxlGrainInfo* out_grainInfo) override;
 
         ///
         /// \see DiscreteFlowWriter::openGrain

--- a/lib/src/flow.cpp
+++ b/lib/src/flow.cpp
@@ -404,6 +404,29 @@ mxlStatus mxlFlowReaderGetGrainNonBlocking(mxlFlowReader reader, uint64_t index,
 
 extern "C"
 MXL_EXPORT
+mxlStatus mxlFlowWriterGetGrainInfo(mxlFlowWriter writer, uint64_t index, mxlGrainInfo* grainInfo)
+{
+    try
+    {
+        if (grainInfo != nullptr)
+        {
+            if (auto const cppWriter = dynamic_cast<DiscreteFlowWriter*>(to_FlowWriter(writer)); cppWriter != nullptr)
+            {
+                return cppWriter->getGrainInfo(index, grainInfo);
+            }
+
+            return MXL_ERR_INVALID_FLOW_WRITER;
+        }
+        return MXL_ERR_INVALID_ARG;
+    }
+    catch (...)
+    {
+        return MXL_ERR_UNKNOWN;
+    }
+}
+
+extern "C"
+MXL_EXPORT
 mxlStatus mxlFlowWriterOpenGrain(mxlFlowWriter writer, uint64_t index, mxlGrainInfo* grainInfo, uint8_t** payload)
 {
     try


### PR DESCRIPTION
This relates to a specific need in the Fabrics API demo application. On the target side, we receive only the ring buffer index of the modified entry, not the complete grainIndex, because the immediate data is limited to 32 bits. We need to use the index field in mxlGrainInfo to recover the original grain index. Currently, the only available method to access the grain info is to open a grain for mutation (using the incomplete index). However, this approach has an unwanted side effect: it overwrites the index field with the provided index. To address this issue, I propose adding a new function, mxlFlowWriterGetGrainInfo, which would retrieve the grainInfo for a given index (supporting either grainIndex or ring buffer index) without modifying any fields.

This is needed by https://github.com/dmf-mxl/mxl/issues/181