### PR TITLE
Fix instance releasing in Rust bindings

### DIFF
--- a/rust/mxl/src/instance.rs
+++ b/rust/mxl/src/instance.rs
@@ -27,9 +27,8 @@ impl InstanceContext {
         unsafe {
             let mut instance = std::ptr::null_mut();
             std::mem::swap(&mut self.instance, &mut instance);
-            self.api.destroy_instance(self.instance)
-        };
-        Ok(())
+            Error::from_status(self.api.destroy_instance(instance))
+        }
     }
 }
 


### PR DESCRIPTION
- We were not properly freeing the instance and we were also ignoring error code from that, which caused the background thread to not be properly terminated and then when DLL got unloaded caused SIGSEGV.