### PR TITLE
Set batchSize defaults to a full grain and 10ms worth of audio samples.

### DIFF
--- a/lib/internal/include/mxl-internal/FlowManager.hpp
+++ b/lib/internal/include/mxl-internal/FlowManager.hpp
@@ -65,9 +65,8 @@ namespace mxl::lib
         ///
         std::unique_ptr<DiscreteFlowData> createDiscreteFlow(uuids::uuid const& flowId, std::string const& flowDef, mxlDataFormat flowFormat,
             std::size_t grainCount, mxlRational const& grainRate, std::size_t grainPayloadSize, std::size_t grainNumOfSlices,
-            std::array<std::uint32_t, MXL_MAX_PLANES_PER_GRAIN> grainSliceLengths,
-            std::optional<std::uint32_t> maxSyncBatchSizeHintOpt = std::nullopt,
-            std::optional<std::uint32_t> maxCommitBatchSizeHintOpt = std::nullopt);
+            std::array<std::uint32_t, MXL_MAX_PLANES_PER_GRAIN> grainSliceLengths, std::uint32_t maxSyncBatchSizeHintOpt = 1,
+            std::uint32_t maxCommitBatchSizeHintOpt = 1);
 
         ///
         /// Create a new continuous flow together with its associated channel store and open it in read-write mode.
@@ -84,8 +83,7 @@ namespace mxl::lib
         ///
         std::unique_ptr<ContinuousFlowData> createContinuousFlow(uuids::uuid const& flowId, std::string const& flowDef, mxlDataFormat flowFormat,
             mxlRational const& sampleRate, std::size_t channelCount, std::size_t sampleWordSize, std::size_t bufferLength,
-            std::optional<std::uint32_t> maxSyncBatchSizeHintOpt = std::nullopt,
-            std::optional<std::uint32_t> maxCommitBatchSizeHintOpt = std::nullopt);
+            std::uint32_t maxSyncBatchSizeHintOpt = 1, std::uint32_t maxCommitBatchSizeHintOpt = 1);
 
         /// Open an existing flow by id.
         ///

--- a/lib/internal/src/FlowManager.cpp
+++ b/lib/internal/src/FlowManager.cpp
@@ -79,8 +79,7 @@ namespace mxl::lib
         }
 
         mxlCommonFlowConfigInfo initCommonFlowConfigInfo(uuids::uuid const& flowId, mxlDataFormat format, mxlRational grainRate,
-            std::optional<std::uint32_t> const& maxSyncBatchSizeHintOpt = std::nullopt,
-            std::optional<std::uint32_t> const& maxCommitBatchSizeHintOpt = std::nullopt)
+            std::uint32_t maxSyncBatchSizeHintOpt, std::uint32_t maxCommitBatchSizeHintOpt)
         {
             auto result = mxlCommonFlowConfigInfo{};
 
@@ -89,8 +88,8 @@ namespace mxl::lib
             result.format = format;
             result.grainRate = grainRate;
 
-            result.maxCommitBatchSizeHint = maxCommitBatchSizeHintOpt.value_or(1);
-            result.maxSyncBatchSizeHint = maxSyncBatchSizeHintOpt.value_or(1);
+            result.maxCommitBatchSizeHint = maxCommitBatchSizeHintOpt;
+            result.maxSyncBatchSizeHint = maxSyncBatchSizeHintOpt;
 
             // FIXME: This should come from the configuration when device memory is supported
             result.payloadLocation = MXL_PAYLOAD_LOCATION_HOST_MEMORY;
@@ -143,8 +142,8 @@ namespace mxl::lib
 
     std::unique_ptr<DiscreteFlowData> FlowManager::createDiscreteFlow(uuids::uuid const& flowId, std::string const& flowDef, mxlDataFormat flowFormat,
         std::size_t grainCount, mxlRational const& grainRate, std::size_t grainPayloadSize, std::size_t grainNumOfSlices,
-        std::array<uint32_t, MXL_MAX_PLANES_PER_GRAIN> grainSliceLengths, std::optional<std::uint32_t> maxSyncBatchSizeHintOpt,
-        std::optional<std::uint32_t> maxCommitBatchSizeHintOpt)
+        std::array<uint32_t, MXL_MAX_PLANES_PER_GRAIN> grainSliceLengths, std::uint32_t maxSyncBatchSizeHintOpt,
+        std::uint32_t maxCommitBatchSizeHintOpt)
     {
         auto const uuidString = uuids::to_string(flowId);
         MXL_DEBUG("Create discrete flow. id: {}, grainCount: {}, grain payload size: {}", uuidString, grainCount, grainPayloadSize);
@@ -221,7 +220,7 @@ namespace mxl::lib
 
     std::unique_ptr<ContinuousFlowData> FlowManager::createContinuousFlow(uuids::uuid const& flowId, std::string const& flowDef,
         mxlDataFormat flowFormat, mxlRational const& sampleRate, std::size_t channelCount, std::size_t sampleWordSize, std::size_t bufferLength,
-        std::optional<std::uint32_t> maxSyncBatchSizeHintOpt, std::optional<std::uint32_t> maxCommitBatchSizeHintOpt)
+        std::uint32_t maxSyncBatchSizeHintOpt, std::uint32_t maxCommitBatchSizeHintOpt)
     {
         auto const uuidString = uuids::to_string(flowId);
         MXL_DEBUG("Create continuous flow. id: {}, channel count: {}, word size: {}, buffer length: {}",

--- a/lib/tests/test_flows.cpp
+++ b/lib/tests/test_flows.cpp
@@ -569,8 +569,8 @@ TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Video Flow : Options
     REQUIRE(mxlDestroyFlow(instanceWriter, uuids::to_string(configInfo.common.id).c_str()) == MXL_STATUS_OK);
 
     REQUIRE(mxlCreateFlow(instanceWriter, flowDef.c_str(), NULL, &configInfo) == MXL_STATUS_OK);
-    REQUIRE(configInfo.common.maxCommitBatchSizeHint == 1U);
-    REQUIRE(configInfo.common.maxSyncBatchSizeHint == 1U);
+    REQUIRE(configInfo.common.maxCommitBatchSizeHint == 1080U);
+    REQUIRE(configInfo.common.maxSyncBatchSizeHint == 1080U);
     REQUIRE(mxlDestroyFlow(instanceWriter, uuids::to_string(configInfo.common.id).c_str()) == MXL_STATUS_OK);
     REQUIRE(mxlDestroyInstance(instanceWriter) == MXL_STATUS_OK);
 }
@@ -970,8 +970,8 @@ TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Audio Flow : Options
     REQUIRE(mxlDestroyFlow(instanceWriter, uuids::to_string(configInfo.common.id).c_str()) == MXL_STATUS_OK);
 
     REQUIRE(mxlCreateFlow(instanceWriter, flowDef.c_str(), NULL, &configInfo) == MXL_STATUS_OK);
-    REQUIRE(configInfo.common.maxCommitBatchSizeHint == 1U);
-    REQUIRE(configInfo.common.maxSyncBatchSizeHint == 1U);
+    REQUIRE(configInfo.common.maxCommitBatchSizeHint == 480U);
+    REQUIRE(configInfo.common.maxSyncBatchSizeHint == 480U);
     REQUIRE(mxlDestroyFlow(instanceWriter, uuids::to_string(configInfo.common.id).c_str()) == MXL_STATUS_OK);
     REQUIRE(mxlDestroyInstance(instanceWriter) == MXL_STATUS_OK);
 }


### PR DESCRIPTION
Fixes https://github.com/dmf-mxl/mxl/issues/244

- For video: default to a full grain
- For Audio: default to 10ms worth of samples