### PR TITLE
Adding documentation on how to change the audio channel count using t…

### DIFF
--- a/docs/Tools.md
+++ b/docs/Tools.md
@@ -101,7 +101,8 @@ A binary that uses the gstreamer 'videotestsrc' and 'audiotestsrc' elements to p
   ]
 }
 ```
-And here is an example of the NMOS FLow json file for an audio flow. To modify the number of audio channels present in a flow, modify the *"channel_count"* parameter to the desired value.
+Below is an example of an **augmented NMOS Flow JSON** for audio.  
+&emsp; **Note:** The *channel_count* property is a mandatory MXL requirement (not found in standard NMOS definition). To adjust the number of audio channels, simply update the *channel_count* value.
 
 ```json
 {


### PR DESCRIPTION
Adding documentation on how to change the audio channel count using the mxl-gst-videotestsrc tool. Also updating the video_flow.json example in the documentation to reflect latest changes.

There is one issue with having up to date .json files example in the tools.md though. It make the license parser of the github action to trip on these 2 lines:

"$copyright": "SPDX-FileCopyrightText: 2025 Contributors to the Media eXchange Layer project.",
"$license": "SPDX-License-Identifier: Apache-2.0",

If I remove them, the github action work as intended. Do we want to modify the github actions to parse them correctly, or I just remove them from the markdown?