### PR TITLE
Internal: Fix stack overflow in mxl-info

### DIFF
--- a/tools/mxl-info/main.cpp
+++ b/tools/mxl-info/main.cpp
@@ -19,6 +19,7 @@
 #include <mxl/flow.h>
 #include <mxl/mxl.h>
 #include <mxl/time.h>
+#include "mxl-internal/FlowInfo.hpp"
 #include "mxl-internal/PathUtils.hpp"
 
 namespace


### PR DESCRIPTION
After 63b33fc116e19ed0635694e60e4b5199563b9524, mxl-info will crash with a segmentation fault when trying to print the flow information. The reason is that without `FlowInfo.hpp` included, the output stream statement will first call the implicit constructor of `LatencyPrinter` and then call the output stream operator on that, leading to infinite recursion and stack overflow.