### PR TITLE
Enable static builds with pkg-config integration.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,20 @@ if(APPLE)
     set(ENV{PKG_CONFIG_PATH} "/Library/Frameworks/GStreamer.framework/Versions/1.0/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}")
 endif()
 
+# Default build is shared libraries.
+# Use '-DBUILD_SHARED_LIBS=OFF' for static build.
+option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
+
+# Default PIC ON for static builds.
+# Use -DMXL_ENABLE_PIC=OFF to disable PIC
+option(MXL_ENABLE_PIC "Enable PIC for static libraries" ON)
+
+# Policy: shared always PIC, static set to MXL_ENABLE_PIC.
+set(MXL_POSITION_INDEPENDENT_CODE ON)
+if(NOT BUILD_SHARED_LIBS)
+  set(MXL_POSITION_INDEPENDENT_CODE ${MXL_ENABLE_PIC})
+endif()
+
 add_subdirectory(lib)
 add_subdirectory(utils)
 if (BUILD_TOOLS)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -102,7 +102,8 @@
                 "CMAKE_EXE_LINKER_FLAGS": "-Wl,--exclude-libs=ALL -Wl,-z,defs -Wl,--as-needed",
                 "CMAKE_MODULE_LINKER_FLAGS": "-Wl,--exclude-libs=ALL -Wl,-z,defs -Wl,--as-needed",
                 "CMAKE_SHARED_LINKER_FLAGS": "-Wl,--exclude-libs=ALL -Wl,-z,defs -Wl,--as-needed",
-                "CMAKE_CXX_SCAN_FOR_MODULES": "OFF"
+                "CMAKE_CXX_SCAN_FOR_MODULES": "OFF",
+                "CMAKE_LINKER_TYPE": "LLD"
             }
         },
         {

--- a/docs/Building.md
+++ b/docs/Building.md
@@ -55,6 +55,24 @@ cmake .. --preset Linux-Clang-Debug
 cmake --build build/Linux-Clang-Debug --target all
 ```
 
+## Static build notes
+
+By default, the CMake presets build MXL as shared libraries. To build
+MXL as static libraries instead, use the CMake option
+`-DBUILD_SHARED_LIBS=OFF`.
+
+For example:
+
+```
+mkdir build
+cd build
+cmake .. --preset Linux-GCC-Debug -DBUILD_SHARED_LIBS=OFF
+cmake --build build/Linux-GCC-Debug --target all
+```
+
+PIC is enabled by default and can be disabled with
+`-DMXL_ENABLE_PIC=OFF`.
+
 ## macOS notes
 
 1. Install the [Homebrew](https://brew.sh) package manager

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -43,14 +43,14 @@ install(DIRECTORY
 
 
 
-add_library(mxl SHARED)
+add_library(mxl)
 target_compile_features(mxl
         PRIVATE
             cxx_std_20
     )
 set_target_properties(mxl
         PROPERTIES
-            POSITION_INDEPENDENT_CODE ON      # Needed to bulid shared library later
+            POSITION_INDEPENDENT_CODE ${MXL_POSITION_INDEPENDENT_CODE}
             VISIBILITY_INLINES_HIDDEN ON
             C_VISIBILITY_PRESET       hidden
             CXX_VISIBILITY_PRESET     hidden
@@ -135,11 +135,29 @@ install(FILES
     )
 
 # Generate a pkg-config file
+set(MXL_PKGCONFIG_PREFIX     "${CMAKE_INSTALL_PREFIX}")
+set(MXL_PKGCONFIG_LIBDIR     "${CMAKE_INSTALL_FULL_LIBDIR}")
+set(MXL_PKGCONFIG_INCLUDEDIR "${CMAKE_INSTALL_FULL_INCLUDEDIR}")
 configure_file(
         ${CMAKE_CURRENT_LIST_DIR}/cmake/libmxl.pc.in
         ${CMAKE_CURRENT_BINARY_DIR}/libmxl.pc
         @ONLY
     )
+# Test-only .pc file in the build dir for pre-install test.
+if (BUILD_TESTING)
+    set(MXL_PKGCONFIG_PREFIX     "${CMAKE_CURRENT_BINARY_DIR}")
+    set(MXL_PKGCONFIG_LIBDIR     "${CMAKE_CURRENT_BINARY_DIR}")
+    set(MXL_PKGCONFIG_INCLUDEDIR "${CMAKE_SOURCE_DIR}/lib/include")
+
+    set(MXL_PKGCONFIG_TEST_DIR  "${CMAKE_BINARY_DIR}/pkgconfig_test")
+    file(MAKE_DIRECTORY "${MXL_PKGCONFIG_TEST_DIR}")
+
+    configure_file(
+        ${CMAKE_CURRENT_LIST_DIR}/cmake/libmxl.pc.in
+        ${MXL_PKGCONFIG_TEST_DIR}/libmxl.pc
+        @ONLY
+    )
+endif()
 
 # Install the generated pkg-config file
 install(FILES

--- a/lib/cmake/libmxl.pc.in
+++ b/lib/cmake/libmxl.pc.in
@@ -1,12 +1,13 @@
-prefix=@CMAKE_INSTALL_PREFIX@
+prefix=@MXL_PKGCONFIG_PREFIX@
 exec_prefix=${prefix}
-libdir=@CMAKE_INSTALL_FULL_LIBDIR@
-includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+libdir=@MXL_PKGCONFIG_LIBDIR@
+includedir=@MXL_PKGCONFIG_INCLUDEDIR@
 
 Name: libmxl
 Version: @PROJECT_VERSION@
 Description: Media eXchange Layer SDK
 Libs: -L${libdir} -lmxl
-Libs.private: -pthread -lmxl-common
+Requires.private: spdlog
+Libs.private: -pthread -lmxl-common -lstdc++ -lm
 Cflags: -I${includedir}
 

--- a/lib/fabrics/ofi/CMakeLists.txt
+++ b/lib/fabrics/ofi/CMakeLists.txt
@@ -44,7 +44,7 @@ target_link_libraries(mxl-fabrics-objects
     )
 set_target_properties(mxl-fabrics-objects
         PROPERTIES
-            POSITION_INDEPENDENT_CODE ON
+            POSITION_INDEPENDENT_CODE ${MXL_POSITION_INDEPENDENT_CODE}
             C_EXTENSIONS              OFF
             CXX_EXTENSIONS            OFF
     )
@@ -52,14 +52,14 @@ set_target_properties(mxl-fabrics-objects
 # Enable LTO/IPO on target if enabled and supported
 mxl_enable_target_ipo(mxl-fabrics-objects)
 
-add_library(mxl-fabrics SHARED)
+add_library(mxl-fabrics)
 target_link_libraries(mxl-fabrics
         PRIVATE
             mxl-fabrics-objects
     )
 set_target_properties(mxl-fabrics-objects
         PROPERTIES
-            POSITION_INDEPENDENT_CODE ON
+            POSITION_INDEPENDENT_CODE ${MXL_POSITION_INDEPENDENT_CODE}
             VISIBILITY_INLINES_HIDDEN ON
             C_VISIBILITY_PRESET       hidden
             CXX_VISIBILITY_PRESET     hidden

--- a/lib/internal/CMakeLists.txt
+++ b/lib/internal/CMakeLists.txt
@@ -25,13 +25,14 @@ target_link_libraries(mxl-internal-headers
 
 # Common code, used by both the libmxl and libmxl-fabrics library
 # linking this does not give access to the internal headers.
-add_library(mxl-common SHARED)
+add_library(mxl-common)
 target_compile_features(mxl-common
         PUBLIC
             cxx_std_20
     )
 set_target_properties(mxl-common
         PROPERTIES 
+            POSITION_INDEPENDENT_CODE ${MXL_POSITION_INDEPENDENT_CODE}
             VISIBILITY_INLINES_HIDDEN ON
             C_VISIBILITY_PRESET       hidden
             CXX_VISIBILITY_PRESET     hidden
@@ -100,6 +101,13 @@ install(TARGETS mxl-common EXPORT ${PROJECT_NAME}-targets
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    )
+
+# Exported because mxl-common depends on this INTERFACE
+# target. INTERFACE targets install no files.
+install(TARGETS mxl-internal-headers
+        EXPORT ${PROJECT_NAME}-targets
+        COMPONENT ${PROJECT_NAME}-dev
     )
 
 add_subdirectory(tests)

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -79,6 +79,20 @@ include(CTest)
 include(Catch)
 catch_discover_tests(mxl-tests)
 
+set(MXL_LINKER_FLAG "")
+if(CMAKE_LINKER_TYPE STREQUAL "LLD")
+  set(MXL_LINKER_FLAG "${CMAKE_C_USING_LINKER_LLD}")
+endif()
+add_test(
+  NAME "pkg-config C consumer can link and run"
+  COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test_pkgconfig_c_link.sh
+          ${CMAKE_BINARY_DIR}
+          ${VCPKG_TARGET_TRIPLET}
+          ${BUILD_SHARED_LIBS}
+          MXL_LINKER_FLAG=${MXL_LINKER_FLAG}
+          ${CMAKE_C_COMPILER}
+)
+
 # Copy test files to the build directory
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/data DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 

--- a/lib/tests/test_pkgconfig_c_link.sh
+++ b/lib/tests/test_pkgconfig_c_link.sh
@@ -1,0 +1,81 @@
+#!/bin/sh
+
+# SPDX-FileCopyrightText: 2025 Contributors to the Media eXchange Layer project.
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+usage() {
+    echo "usage: $0 <build_dir> <triplet> <BUILD_SHARED_LIBS: ON|OFF> <MXL_LINKER_FLAG=<linker-selection-flag>> <c_compiler>" >&2
+    echo "  build_dir         Path to the CMake build directory." >&2
+    echo "  triplet           vcpkg target triplet used for the build." >&2
+    echo "  BUILD_SHARED_LIBS Indicates whether the build uses shared libraries (ON or OFF)." >&2
+    echo "  MXL_LINKER_FLAG   Optional compiler linker-selection flag (e.g. -fuse-ld=lld); empty means use default linker." >&2
+    echo "  c_compiler        Path to the C compiler executable." >&2
+}
+
+if [ "$#" -ne 5 ]; then
+    usage
+    exit 1
+fi
+
+BUILD_DIR="$1"
+VCPKG_TRIPLET="$2"
+BUILD_SHARED_LIBS="$3"
+MXL_LINKER_FLAG="${4#MXL_LINKER_FLAG=}"
+C_COMPILER="$5"
+
+PKGCFG_STATIC=
+RPATH_FLAGS=
+if [ "$BUILD_SHARED_LIBS" = "OFF" ]; then
+    PKGCFG_STATIC="--static"
+elif [ "$BUILD_SHARED_LIBS" = "ON" ]; then
+    RPATH_FLAGS="-Wl,-rpath,$BUILD_DIR/lib"
+else
+    usage
+    exit 2
+fi
+
+export PKG_CONFIG_PATH="$BUILD_DIR/pkgconfig_test:$BUILD_DIR/vcpkg_installed/$VCPKG_TRIPLET/lib/pkgconfig"
+
+TEST_DIR="$(mktemp -d /tmp/mxl_pkgconfig_test.XXXXXX)"
+
+(
+    set -e
+    cd $TEST_DIR
+
+    cat > mxl_link_test.c <<'EOF'
+#include <mxl/mxl.h>
+#include <stddef.h>
+#include <stdlib.h>
+int main(void)
+{
+    mxlInstance instance = mxlCreateInstance("./mxl_link_test_domain", NULL);
+    int rc = !!instance ? EXIT_SUCCESS : EXIT_FAILURE;
+    mxlDestroyInstance(instance);
+    return rc;
+}
+EOF
+
+    if [ "$BUILD_SHARED_LIBS" = "OFF" ]; then
+        "$C_COMPILER" mxl_link_test.c \
+           $MXL_LINKER_FLAG \
+           $(pkg-config --cflags --libs $PKGCFG_STATIC libmxl) \
+           -L"$BUILD_DIR/lib/internal" \
+           -o mxl_link_test
+    else
+        "$C_COMPILER" mxl_link_test.c \
+            $MXL_LINKER_FLAG \
+            $(pkg-config --cflags --libs $PKGCFG_STATIC libmxl) \
+            $RPATH_FLAGS \
+            -o mxl_link_test
+    fi
+
+    mkdir mxl_link_test_domain
+    ./mxl_link_test
+)
+
+rm -rf $TEST_DIR/mxl_link_test_domain
+rm  $TEST_DIR/mxl_link_test
+rm  $TEST_DIR/mxl_link_test.c
+rmdir $TEST_DIR


### PR DESCRIPTION
This PR fixes static build correctness across CMake and `pkg-config`.

Static build issues surfaced while implementing static linking using `pkg-config` for an ffmpeg/MXL integration. MXL supported shared-library builds only, ignored `BUILD_SHARED_LIBS`, and provided incomplete `pkg-config` metadata for static linkage.

Key build-related changes:
- Correct handling of `BUILD_SHARED_LIBS=ON|OFF` across mxl targets
- Added `MXL_ENABLE_PIC` (default ON) to support static builds used in shared contexts
- Fixed pkg-config metadata for static linking
- Corrected CMake export-set dependency relationships

This change adds a C consumer link test to prevent regressions.

Tested with:
- Linux (GCC, Clang)
- macOS (Clang/x86_64)
- Shared and static builds (`BUILD_SHARED_LIBS=ON|OFF`)
- Debug and release builds
- Static ffmpeg build as downstream consumer on Linux

The ffmpeg integration lives in a downstream fork and is still being
finalized, but is included here for reference:
https://github.com/cbcrc/FFmpeg/tree/dmf-mxl/master
