### PR TITLE
Enable optional LTO/IPO of the library targets.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,38 @@ project(mxl
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
 
+
+#-------------------------------------------------------------------------------
+# Determine optional IPO support and allow enabling IPO on a per target basis.
+#-------------------------------------------------------------------------------
+option(MXL_ENABLE_IPO "Enable LTO/IPO on the library targets." OFF)
+
+set(MXL_IPO_SUPPORTED OFF)
+if(MXL_ENABLE_IPO)
+    include(CheckIPOSupported)
+
+    check_ipo_supported(RESULT MXL_IPO_SUPPORTED OUTPUT output LANGUAGES C CXX)
+    if(MXL_IPO_SUPPORTED)
+        message(STATUS "Enabling LTO/IPO support.")
+    else()
+        message(WARNING "LTO/IPO is not supported: ${output}")
+    endif()
+endif()
+
+if (MXL_IPO_SUPPORTED)
+    function(mxl_enable_target_ipo target)
+        message(STATUS "Enabling LTO/IPO on target: ${target}")
+        set_target_properties(${target}
+                PROPERTIES
+                    INTERPROCEDURAL_OPTIMIZATION ON
+            )
+    endfunction()
+else ()
+    function(mxl_enable_target_ipo target)
+    endfunction()
+endif ()
+
+
 find_program(ccache_executable ccache)
 
 if(ccache_executable)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -82,9 +82,13 @@ target_link_libraries(mxl
             mxl-common  # Common objects for libmxl and libmxl-fabrics
     )
 
+# Enable LTO/IPO on target if enabled and supported
+mxl_enable_target_ipo(mxl)
+
 # Alias mxl to mxl::mxl so that this library can be used
 # in lieu of a module from the local source tree
 add_library(${PROJECT_NAME}::mxl ALIAS mxl)
+
 
 if (MXL_ENABLE_FABRICS_OFI)
     add_subdirectory(fabrics)

--- a/lib/fabrics/ofi/CMakeLists.txt
+++ b/lib/fabrics/ofi/CMakeLists.txt
@@ -49,6 +49,9 @@ set_target_properties(mxl-fabrics-objects
             CXX_EXTENSIONS            OFF
     )
 
+# Enable LTO/IPO on target if enabled and supported
+mxl_enable_target_ipo(mxl-fabrics-objects)
+
 add_library(mxl-fabrics SHARED)
 target_link_libraries(mxl-fabrics
         PRIVATE
@@ -76,6 +79,9 @@ target_link_libraries(mxl-fabrics
             mxl-fabrics-headers
             PkgConfig::libfabric
     )
+
+# Enable LTO/IPO on target if enabled and supported
+mxl_enable_target_ipo(mxl-fabrics)
 
 add_library(${PROJECT_NAME}::mxl-fabrics ALIAS mxl-fabrics)
 

--- a/lib/internal/CMakeLists.txt
+++ b/lib/internal/CMakeLists.txt
@@ -92,6 +92,9 @@ target_link_libraries(mxl-common
             mxl-internal-headers
     )
 
+# Enable LTO/IPO on target if enabled and supported
+mxl_enable_target_ipo(mxl-common)
+
 install(TARGETS mxl-common EXPORT ${PROJECT_NAME}-targets
         COMPONENT ${PROJECT_NAME}-lib
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/lib/tests/fabrics/ofi/CMakeLists.txt
+++ b/lib/tests/fabrics/ofi/CMakeLists.txt
@@ -46,6 +46,11 @@ target_include_directories(mxl-fabrics-ofi-tests
             "${CMAKE_CURRENT_SOURCE_DIR}/../../../fabrics/ofi/src/internal"
     )
 
+# Enable LTO/IPO on target if enabled and supported
+# This is necessary here, because the tests directly link the OBJECTS library
+# that has LTO/IPO enabled.
+mxl_enable_target_ipo(mxl-fabrics-ofi-tests)
+
 include(CTest)
 include(Catch)
 catch_discover_tests(mxl-fabrics-ofi-tests)


### PR DESCRIPTION
With this changeset LTO/IPO can be enabled on all library targets by specifying the cmake option `MXL_ENABLE_IPO`.
For toolchains that don't support LTO/IPO the request will be ignored with a message indicating that LTO/IPO support is missing.