### PR TITLE
bugfix: mxl gst testsrc does not honour command line group flag

### DIFF
--- a/lib/internal/src/DomainWatcher.cpp
+++ b/lib/internal/src/DomainWatcher.cpp
@@ -7,7 +7,6 @@
 #include <filesystem>
 #include <memory>
 #include <mutex>
-#include <stdexcept>
 #include <system_error>
 #include <thread>
 #include <utility>
@@ -225,7 +224,9 @@ namespace mxl::lib
                         MXL_ERROR("Error closing file descriptor {} for '{}'", wd, rec->fileName);
                     }
 #elif defined __linux__
-                    if (inotify_rm_watch(_inotifyFd, wd) == -1)
+                    auto f = std::filesystem::path{rec->fileName};
+                    // Try to remove the watch only if the file still exists.
+                    if (exists(f) && (inotify_rm_watch(_inotifyFd, wd) == -1))
                     {
                         auto const error = errno;
                         MXL_ERROR("Failed to remove inotify watch (wd={}) for '{}': {}", wd, rec->fileName, std::strerror(error));

--- a/tools/mxl-gst/utils.hpp
+++ b/tools/mxl-gst/utils.hpp
@@ -155,8 +155,7 @@ namespace json_utils
      */
     void updateGroupHint(picojson::object& nmosFlow, std::string const& groupHint, std::string const& roleInGroup)
     {
-        auto jsonObj = nmosFlow; // make a copy to modify
-        auto& tagsObj = jsonObj.find("tags")->second.get<picojson::object>();
+        auto& tagsObj = nmosFlow.find("tags")->second.get<picojson::object>();
         auto& tagsArray = tagsObj["urn:x-nmos:tag:grouphint/v1.0"].get<picojson::array>();
         tagsArray.clear();
         tagsArray.emplace_back(groupHint + ":" + roleInGroup);


### PR DESCRIPTION
minor fixes
- remove rogue object copy preventing persistance of the nmos grouphint in mxl-gst-testsrc
- unrelated: removing an inotify watch for a file that has been deleted will fail.  test if the file exists before attempting removal of the watch.