### PR TITLE
Add pkg-config C consumer test for `libmxl-fabrics`

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -139,7 +139,7 @@ configure_file(
         @ONLY
     )
 # Test-only .pc file in the build dir for pre-install test.
-if (BUILD_TESTING)
+if (BUILD_TESTS)
     set(MXL_PKGCONFIG_PREFIX     "${CMAKE_CURRENT_BINARY_DIR}")
     set(MXL_PKGCONFIG_LIBDIR     "${CMAKE_CURRENT_BINARY_DIR}")
     set(MXL_PKGCONFIG_INCLUDEDIR "${CMAKE_SOURCE_DIR}/lib/include")

--- a/lib/fabrics/include/mxl/fabrics.h
+++ b/lib/fabrics/include/mxl/fabrics.h
@@ -3,8 +3,14 @@
 
 #pragma once
 
-#include <cstddef>
-#include <cstdint>
+#ifdef __cplusplus
+#   include <cstddef>
+#   include <cstdint>
+#else
+#   include <stddef.h>
+#   include <stdint.h>
+#endif
+
 #include <mxl/flow.h>
 #include <mxl/mxl.h>
 #include <mxl/platform.h>
@@ -92,7 +98,7 @@ extern "C"
      */
     typedef struct mxlFabricsMemoryRegion_t
     {
-        std::uintptr_t addr;                /**< Start address of the contiguous memory region. */
+        uintptr_t addr;                     /**< Start address of the contiguous memory region. */
         size_t size;                        /**< Size of that memory region */
         mxlFabricsMemoryRegionLocation loc; /**< Location information for that memory region. */
     } mxlFabricsMemoryRegion;
@@ -159,7 +165,7 @@ extern "C"
      * Create a fabrics target. The target is the receiver of write operations from an initiator.
      * \param in_fabricsInstance A valid mxl fabrics instance
      * \param out_target A valid fabrics target
-     */ 
+     */
     MXL_EXPORT
     mxlStatus mxlFabricsCreateTarget(mxlFabricsInstance in_fabricsInstance, mxlFabricsTarget* out_target);
 
@@ -306,7 +312,7 @@ extern "C"
      * \param in_targetInfo A valid target info to serialize
      * \param out_string A user supplied buffer of the correct size. Initially you can pass a NULL pointer to obtain the size of the string.
      * \param in_stringSize The size of the output string.
-     */ 
+     */
     MXL_EXPORT
     mxlStatus mxlFabricsTargetInfoToString(mxlTargetInfo const in_targetInfo, char* out_string, size_t* in_stringSize);
 

--- a/lib/fabrics/ofi/CMakeLists.txt
+++ b/lib/fabrics/ofi/CMakeLists.txt
@@ -7,6 +7,14 @@ find_package(PkgConfig REQUIRED)
 
 pkg_check_modules(libfabric REQUIRED IMPORTED_TARGET libfabric)
 
+if (NOT TARGET spdlog::spdlog)
+    find_package(spdlog CONFIG REQUIRED)
+endif()
+
+if (NOT TARGET fmt::fmt)
+    find_package(fmt CONFIG REQUIRED)
+endif()
+
 add_library(mxl-fabrics-objects OBJECT)
 target_compile_features(mxl-fabrics-objects
         PRIVATE
@@ -35,13 +43,11 @@ target_sources(mxl-fabrics-objects
             src/internal/Endpoint.cpp
     )
 target_link_libraries(mxl-fabrics-objects
-        PUBLIC
-            mxl
-            mxl-fabrics-headers
-            PkgConfig::libfabric
         PRIVATE
             mxl-internal-headers
-    )
+            mxl-fabrics-headers
+            PkgConfig::libfabric
+)
 set_target_properties(mxl-fabrics-objects
         PROPERTIES
             POSITION_INDEPENDENT_CODE ${MXL_POSITION_INDEPENDENT_CODE}
@@ -53,11 +59,13 @@ set_target_properties(mxl-fabrics-objects
 mxl_enable_target_ipo(mxl-fabrics-objects)
 
 add_library(mxl-fabrics)
-target_link_libraries(mxl-fabrics
+
+target_sources(mxl-fabrics
         PRIVATE
-            mxl-fabrics-objects
-    )
-set_target_properties(mxl-fabrics-objects
+            $<TARGET_OBJECTS:mxl-fabrics-objects>
+)
+
+set_target_properties(mxl-fabrics
         PROPERTIES
             POSITION_INDEPENDENT_CODE ${MXL_POSITION_INDEPENDENT_CODE}
             VISIBILITY_INLINES_HIDDEN ON
@@ -74,7 +82,10 @@ target_link_libraries(mxl-fabrics
             mxl
             mxl-fabrics-headers
             PkgConfig::libfabric
-    )
+        PRIVATE
+            spdlog::spdlog
+            fmt::fmt
+      )
 
 # Add common linker options
 mxl_add_common_target_link_options(mxl-fabrics PRIVATE)
@@ -120,11 +131,31 @@ write_basic_package_version_file(
     )
 
 # Generate a pkg-config file
+set(MXL_PKGCONFIG_PREFIX       "${CMAKE_INSTALL_PREFIX}")
+set(MXL_PKGCONFIG_LIBDIR       "${CMAKE_INSTALL_FULL_LIBDIR}")
+set(MXL_PKGCONFIG_INCLUDEDIR   "${CMAKE_INSTALL_FULL_INCLUDEDIR}")
+set(MXL_PKGCONFIG_EXTRA_CFLAGS "")
 configure_file(
         ${CMAKE_CURRENT_LIST_DIR}/cmake/libmxl-fabrics.pc.in
         ${CMAKE_CURRENT_BINARY_DIR}/libmxl-fabrics.pc
         @ONLY
     )
+# Test-only .pc file in the build dir for pre-install test.
+if (BUILD_TESTS)
+    set(MXL_PKGCONFIG_PREFIX       "${CMAKE_CURRENT_BINARY_DIR}")
+    set(MXL_PKGCONFIG_LIBDIR       "${CMAKE_CURRENT_BINARY_DIR}")
+    set(MXL_PKGCONFIG_INCLUDEDIR   "${CMAKE_SOURCE_DIR}/lib/include")
+    set(MXL_PKGCONFIG_EXTRA_CFLAGS "-I${CMAKE_SOURCE_DIR}/lib/fabrics/include")
+    
+    set(MXL_PKGCONFIG_TEST_DIR  "${CMAKE_BINARY_DIR}/pkgconfig_test")
+    file(MAKE_DIRECTORY "${MXL_PKGCONFIG_TEST_DIR}")
+
+    configure_file(
+        ${CMAKE_CURRENT_LIST_DIR}/cmake/libmxl-fabrics.pc.in
+        ${MXL_PKGCONFIG_TEST_DIR}/libmxl-fabrics.pc
+        @ONLY
+    )
+endif()
 
 
 # Install the generated config and version files.

--- a/lib/fabrics/ofi/cmake/libmxl-fabrics.pc.in
+++ b/lib/fabrics/ofi/cmake/libmxl-fabrics.pc.in
@@ -1,13 +1,13 @@
-prefix=@CMAKE_INSTALL_PREFIX@
+prefix=@MXL_PKGCONFIG_PREFIX@
 exec_prefix=${prefix}
-libdir=@CMAKE_INSTALL_FULL_LIBDIR@
-includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+libdir=@MXL_PKGCONFIG_LIBDIR@
+includedir=@MXL_PKGCONFIG_INCLUDEDIR@
 
 Name: libmxl-fabrics
 Version: @PROJECT_VERSION@
 Requires: libmxl libfabric
 Description: Media eXchange Layer SDK Fabrics library
 Libs: -L${libdir} -lmxl-fabrics
-Libs.private: -pthread 
-Cflags: -I${includedir}
-
+Requires.private: spdlog
+Libs.private: -pthread
+Cflags: -I${includedir} @MXL_PKGCONFIG_EXTRA_CFLAGS@

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -90,8 +90,15 @@ add_test(
           ${VCPKG_INSTALLED_DIR}
           ${VCPKG_TARGET_TRIPLET}
           ${BUILD_SHARED_LIBS}
+	  ${MXL_ENABLE_FABRICS_OFI}
           MXL_LINKER_FLAG=${MXL_LINKER_FLAG}
           ${CMAKE_C_COMPILER}
+)
+set_tests_properties(
+  "pkg-config C consumer can link and run"
+  PROPERTIES
+    ENVIRONMENT
+    "PKG_CONFIG_PATH=$ENV{PKG_CONFIG_PATH}"
 )
 
 # Copy test files to the build directory

--- a/lib/tests/test_pkgconfig_c_link.sh
+++ b/lib/tests/test_pkgconfig_c_link.sh
@@ -6,16 +6,17 @@
 set -e
 
 usage() {
-    echo "usage: $0 <build_dir> <vcpkg_install_dir> <vcpkg_triplet> <BUILD_SHARED_LIBS: ON|OFF> <MXL_LINKER_FLAG=<linker-selection-flag>> <c_compiler>" >&2
+    echo "usage: $0 <build_dir> <vcpkg_install_dir> <vcpkg_triplet> <BUILD_SHARED_LIBS: ON|OFF> <MXL_ENABLE_FABRICS_OFI: ON|OFF> <MXL_LINKER_FLAG=<linker-selection-flag>> <c_compiler>" >&2
     echo "  build_dir         Path to the CMake build directory." >&2
     echo "  vcpkg_install_dir vcpkg install directory" >&2
     echo "  vcpkg_triplet     vcpkg target triplet used for the build." >&2
     echo "  BUILD_SHARED_LIBS Indicates whether the build uses shared libraries (ON or OFF)." >&2
+    echo "  MXL_ENABLE_FABRICS_OFI Enable libmxl-fabrics.pc test (ON or OFF)." >&2
     echo "  MXL_LINKER_FLAG   Optional compiler linker-selection flag (e.g. -fuse-ld=lld); empty means use default linker." >&2
     echo "  c_compiler        Path to the C compiler executable." >&2
 }
 
-if [ "$#" -ne 6 ]; then
+if [ "$#" -ne 7 ]; then
     usage
     exit 1
 fi
@@ -24,21 +25,21 @@ BUILD_DIR="$1"
 VCPKG_INSTALL_DIR="$2"
 VCPKG_TRIPLET="$3"
 BUILD_SHARED_LIBS="$4"
-MXL_LINKER_FLAG="${5#MXL_LINKER_FLAG=}"
-C_COMPILER="$6"
+MXL_ENABLE_FABRICS_OFI="$5"
+MXL_LINKER_FLAG="${6#MXL_LINKER_FLAG=}"
+C_COMPILER="$7"
 
-PKGCFG_STATIC=
-RPATH_FLAGS=
-if [ "$BUILD_SHARED_LIBS" = "OFF" ]; then
-    PKGCFG_STATIC="--static"
-elif [ "$BUILD_SHARED_LIBS" = "ON" ]; then
-    RPATH_FLAGS="-Wl,-rpath,$BUILD_DIR/lib"
-else
-    usage
-    exit 2
-fi
+case "$BUILD_SHARED_LIBS" in
+  ON|OFF) ;;
+  *) usage; exit 2 ;;
+esac
 
-export PKG_CONFIG_PATH="$BUILD_DIR/pkgconfig_test:$VCPKG_INSTALL_DIR/$VCPKG_TRIPLET/lib/pkgconfig"
+case "$MXL_ENABLE_FABRICS_OFI" in
+  ON|OFF) ;;
+  *) usage; exit 2 ;;
+esac
+
+export PKG_CONFIG_PATH="$BUILD_DIR/pkgconfig_test:$VCPKG_INSTALL_DIR/$VCPKG_TRIPLET/lib/pkgconfig:${PKG_CONFIG_PATH}"
 
 TEST_DIR="$(mktemp -d /tmp/mxl_pkgconfig_test.XXXXXX)"
 
@@ -62,23 +63,65 @@ EOF
     if [ "$BUILD_SHARED_LIBS" = "OFF" ]; then
         "$C_COMPILER" mxl_link_test.c \
            $MXL_LINKER_FLAG \
-           $(pkg-config --cflags --libs $PKGCFG_STATIC libmxl) \
+           $(pkg-config --cflags --libs --static libmxl) \
            -L"$BUILD_DIR/lib/internal" \
            -o mxl_link_test
     else
         "$C_COMPILER" mxl_link_test.c \
             $MXL_LINKER_FLAG \
-            $(pkg-config --cflags --libs $PKGCFG_STATIC libmxl) \
-            $RPATH_FLAGS \
+            $(pkg-config --cflags --libs libmxl) \
+            "-Wl,-rpath,$BUILD_DIR/lib" \
             -o mxl_link_test
     fi
 
-    mkdir mxl_link_test_domain
+    mkdir ./mxl_link_test_domain
     ./mxl_link_test
+
+    rm -rf ./mxl_link_test_domain
+    rm  ./mxl_link_test
+    rm  ./mxl_link_test.c
 )
 
-rm -rf $TEST_DIR/mxl_link_test_domain
-rm  $TEST_DIR/mxl_link_test
-rm  $TEST_DIR/mxl_link_test.c
-rmdir $TEST_DIR
+if [ "$MXL_ENABLE_FABRICS_OFI" = ON ]; then
+(
+    set -e
+    cd $TEST_DIR
 
+    cat > fabrics_link_test.c <<'EOF'
+#include <mxl/fabrics.h>
+int main(void)
+{
+    (void)&mxlFabricsCreateInstance;
+    (void)&mxlFabricsDestroyInstance;
+    return 0;
+}
+EOF
+
+    # libfabric may be supplied at a non-default path via PKG_CONFIG_PATH
+    FABRIC_LIBDIR=$(pkg-config --variable=libdir libfabric)
+
+    if [ "$BUILD_SHARED_LIBS" = "OFF" ]; then
+        "$C_COMPILER" fabrics_link_test.c \
+           $MXL_LINKER_FLAG \
+           $(pkg-config --cflags --libs --static libmxl-fabrics) \
+           -L"$BUILD_DIR/lib/internal" \
+           "-Wl,-rpath,$FABRIC_LIBDIR" \
+           -o fabrics_link_test
+    else
+         "$C_COMPILER" fabrics_link_test.c \
+            $MXL_LINKER_FLAG \
+            $(pkg-config --cflags --libs libmxl-fabrics libfabric) \
+            "-Wl,-rpath,$BUILD_DIR/lib" \
+            "-Wl,-rpath,$BUILD_DIR/lib/fabrics/ofi" \
+            "-Wl,-rpath,$FABRIC_LIBDIR" \
+            -o fabrics_link_test
+    fi
+
+    ./fabrics_link_test
+
+    rm ./fabrics_link_test
+    rm ./fabrics_link_test.c
+)
+fi
+
+rmdir $TEST_DIR


### PR DESCRIPTION
Add a minimal C consumer test that builds and links against `libmxl-fabrics` using `pkg-config`. This follows earlier work that added equivalent coverage for `libmxl.pc`, extending the same validation to `libmxl-fabrics.pc`.

The `libmxl-fabrics` CMake configuration was also modified to correct static build errors caused by linking against an `OBJECT` target that cannot be resolved or exported in the static build path.

`PKG_CONFIG_PATH` must point to the external libfabric installation if the system-provided library is missing or not the required version.