### PR TITLE
Second attempt to fix automated backports

### DIFF
--- a/.github/workflows/backports.yml
+++ b/.github/workflows/backports.yml
@@ -10,15 +10,6 @@ permissions:
 jobs:
   # These jobs are triggered when a PR is closed. The second job will only run when the first job
   # finds labels matching: backport/.*
-  token:
-    runs-on: ubuntu-latest
-    steps:
-      - name: "Get app token"
-        id: token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ vars.BACKPORT_APP_ID }}
-          private-key: ${{ secrets.BACKPORT_PRIVATE_KEY }}
   inspect:
     name: "Process PR labels"
     runs-on: ubuntu-latest
@@ -33,20 +24,26 @@ jobs:
   backport:
     name: "Create backport PR"
     runs-on: ubuntu-latest
-    needs: [inspect, token]
+    needs: inspect
     if: ${{ needs.inspect.outputs.target-branches != '[]' }} # Don't run if no backport/* labels were found by the prev. job
     strategy:
       matrix:
         target-branch: ${{ fromJSON(needs.inspect.outputs.target-branches) }}
     steps:
+      - name: "Get app token"
+        id: token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.BACKPORT_APP_ID }}
+          private-key: ${{ secrets.BACKPORT_PRIVATE_KEY }}
       - uses: actions/checkout@v4
         with:
           # This should set up the git cli to use the PAT created from the app in the 'token' job
-          token: ${{ needs.token.steps.token.outputs.token }}
+          token: ${{ steps.token.outputs.token }}
       - name: Create backport pull requests
         uses: korthout/backport-action@v4
         with:
-          github_token: ${{ needs.token.steps.token.outputs.token }}
+          github_token: ${{ steps.token.outputs.token }}
           label_pattern: a^ # We don't need the action to match the labels, we have done that in the prev. job, so we use the pattern 'a^' that never matches anything.
           target_branches: ${{ matrix.target-branch }} # We pass the branches here instead of relying on the label matching logic of the imported action.
           branch_name: backport/${pull_number}/-/${target_branch}


### PR DESCRIPTION
Move the app token step into the backport job. The token is revoked when the job terminates, so it can not be used in another job.

This time it should work. I have tested it with a GitHub app that I created on my account. It worked with these app permissions:
<img width="993" height="376" alt="2026-01-30-183835_hyprshot" src="https://github.com/user-attachments/assets/949c9556-f64c-44e2-9d3a-769a3dd52dd3" />

I have also verified that it still works when the actions permissions on the repository are more restrictive:
<img width="879" height="384" alt="2026-01-30-183410_hyprshot" src="https://github.com/user-attachments/assets/4b888b4f-6fcf-4f7f-adb9-dbd989521791" />
