### PR TITLE
Silence warning in picojson header for GCC release build

### DIFF
--- a/cmake/modules/Findpicojson.cmake
+++ b/cmake/modules/Findpicojson.cmake
@@ -11,11 +11,22 @@ find_package_handle_standard_args(picojson
 )
 
 if(picojson_FOUND)
+    write_file("${CMAKE_CURRENT_BINARY_DIR}/picojson_wrapper/picojson/wrapper.h"
+        "\
+#pragma once
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored \"-Wmaybe-uninitialized\"
+#include <picojson/picojson.h>
+#pragma GCC diagnostic pop")
+
     set(picojson_INCLUDE_DIRS ${picojson_INCLUDE_DIR})
     if(NOT TARGET picojson::picojson)
         add_library(picojson::picojson INTERFACE IMPORTED)
         set_target_properties(picojson::picojson PROPERTIES
             INTERFACE_INCLUDE_DIRECTORIES "${picojson_INCLUDE_DIRS}"
+        )
+        set_target_properties(picojson::picojson PROPERTIES
+            INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_BINARY_DIR}/picojson_wrapper"
         )
     endif()
 endif()

--- a/lib/internal/include/mxl-internal/FlowOptionsParser.hpp
+++ b/lib/internal/include/mxl-internal/FlowOptionsParser.hpp
@@ -6,7 +6,7 @@
 #include <cstdint>
 #include <optional>
 #include <string>
-#include <picojson/picojson.h>
+#include <picojson/wrapper.h>
 #include <mxl/platform.h>
 
 namespace mxl::lib

--- a/lib/internal/include/mxl-internal/FlowParser.hpp
+++ b/lib/internal/include/mxl-internal/FlowParser.hpp
@@ -7,7 +7,7 @@
 #include <array>
 #include <string>
 #include <uuid.h>
-#include <picojson/picojson.h>
+#include <picojson/wrapper.h>
 #include <mxl/dataformat.h>
 #include <mxl/flowinfo.h>
 #include <mxl/platform.h>

--- a/lib/internal/src/Instance.cpp
+++ b/lib/internal/src/Instance.cpp
@@ -17,7 +17,7 @@
 #include <sys/file.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <picojson/picojson.h>
+#include <picojson/wrapper.h>
 #include <spdlog/cfg/env.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <spdlog/spdlog.h>

--- a/lib/tests/test_flows.cpp
+++ b/lib/tests/test_flows.cpp
@@ -21,7 +21,7 @@
 #include <thread>
 #include <uuid.h>
 #include <catch2/catch_test_macros.hpp>
-#include <picojson/picojson.h>
+#include <picojson/wrapper.h>
 #include <mxl/flow.h>
 #include <mxl/mxl.h>
 #include <mxl/time.h>

--- a/tools/mxl-gst/CMakeLists.txt
+++ b/tools/mxl-gst/CMakeLists.txt
@@ -22,6 +22,9 @@ if (gstreamer_FOUND)
         find_package(spdlog CONFIG REQUIRED)
     endif ()
 
+    if (NOT TARGET picojson::picojson)
+        find_package(picojson REQUIRED)
+    endif ()
 
     add_executable(mxl-gst-testsrc)
     target_compile_features(mxl-gst-testsrc
@@ -47,6 +50,7 @@ if (gstreamer_FOUND)
                 mxl
                 stduuid
                 fmt::fmt
+                picojson::picojson
                 CLI11::CLI11
                 PkgConfig::gstreamer
                 PkgConfig::gstreamer-app
@@ -78,6 +82,7 @@ if (gstreamer_FOUND)
                 mxl
                 stduuid
                 fmt::fmt
+                picojson::picojson
                 CLI11::CLI11
                 spdlog::spdlog
                 PkgConfig::gstreamer
@@ -110,6 +115,7 @@ if (gstreamer_FOUND)
                 mxl
                 stduuid
                 fmt::fmt
+                picojson::picojson
                 CLI11::CLI11
                 PkgConfig::gstreamer
                 PkgConfig::gstreamer-app

--- a/tools/mxl-gst/looping_filesrc.cpp
+++ b/tools/mxl-gst/looping_filesrc.cpp
@@ -18,7 +18,7 @@
 #include <gst/gstcaps.h>
 #include <gst/gstobject.h>
 #include <gst/gstvalue.h>
-#include <picojson/picojson.h>
+#include <picojson/wrapper.h>
 #include <spdlog/cfg/env.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <mxl/flow.h>

--- a/tools/mxl-gst/sink.cpp
+++ b/tools/mxl-gst/sink.cpp
@@ -18,7 +18,7 @@
 #include <gst/gstclock.h>
 #include <gst/gstpipeline.h>
 #include <gst/gstsystemclock.h>
-#include <picojson/picojson.h>
+#include <picojson/wrapper.h>
 #include <mxl/flow.h>
 #include <mxl/mxl.h>
 #include <mxl/time.h>

--- a/tools/mxl-gst/testsrc.cpp
+++ b/tools/mxl-gst/testsrc.cpp
@@ -14,7 +14,7 @@
 #include <gst/app/gstappsink.h>
 #include <gst/gst.h>
 #include <gst/gstsystemclock.h>
-#include <picojson/picojson.h>
+#include <picojson/wrapper.h>
 #include <mxl/flow.h>
 #include <mxl/mxl.h>
 #include <mxl/time.h>

--- a/tools/mxl-info/CMakeLists.txt
+++ b/tools/mxl-info/CMakeLists.txt
@@ -51,11 +51,16 @@ if (NOT TARGET fmt::fmt)
     find_package(fmt CONFIG REQUIRED)
 endif()
 
+if (NOT TARGET picojson::picojson)
+    find_package(picojson REQUIRED)
+endif()
+
 target_link_libraries(mxl-info
         PRIVATE
             simple_uri_parser
             stduuid
             fmt::fmt
+            picojson::picojson
             mxl
             CLI11::CLI11
     )

--- a/tools/mxl-info/main.cpp
+++ b/tools/mxl-info/main.cpp
@@ -14,7 +14,7 @@
 #include <fmt/color.h>
 #include <fmt/format.h>
 #include <gsl/span>
-#include <picojson/picojson.h>
+#include <picojson/wrapper.h>
 #include <mxl/flow.h>
 #include <mxl/flowinfo.h>
 #include <mxl/mxl.h>


### PR DESCRIPTION
Not the prettiest fix, but it silences the warning only for that header.