### PR TITLE
Revert "Fix documentation error: mxlCreateInstance options are used!"

### DIFF
--- a/lib/include/mxl/mxl.h
+++ b/lib/include/mxl/mxl.h
@@ -71,7 +71,7 @@ extern "C"
     /// Create a new MXL instance for a specific domain.
     ///
     /// \param in_mxlDomain The domain is the directory where the MXL ringbuffers files are stored.  It should live on a tmpfs filesystem.
-    /// \param in_options Optional JSON string containing additional SDK options.
+    /// \param in_options Optional JSON string containing additional SDK options. Currently not used.
     /// \return A pointer to the MXL instance or NULL if the instance could not be created.
     ///
     MXL_EXPORT


### PR DESCRIPTION
This reverts commit 31866e7df35b8bff9032ac2fb9bfe9487819e026.

Sorry! Turns out this is still unused...