### PR TITLE
Fix use-after-free in DomainWatcher

### DIFF
--- a/lib/internal/src/DomainWatcher.cpp
+++ b/lib/internal/src/DomainWatcher.cpp
@@ -244,7 +244,7 @@ namespace mxl::lib
                 if (::inotify_rm_watch(_inotifyFd, wd) == -1)
                 {
                     auto const error = errno;
-                    if ((error != EINVAL) || std::filesystem::exists(it->second.fileName))
+                    if ((error != EINVAL) || std::filesystem::exists(record.fileName))
                     {
                         MXL_WARN("Failed to remove inotify watch (wd={}) for '{}': {}", wd, record.fileName, std::strerror(error));
                     }


### PR DESCRIPTION
I have not encountered any crashes because of this, but it was reported by valgrind.