### PR TITLE
Add support for planar video

### DIFF
--- a/lib/internal/include/mxl-internal/FlowParser.hpp
+++ b/lib/internal/include/mxl-internal/FlowParser.hpp
@@ -104,6 +104,14 @@ namespace mxl::lib
         bool _interlaced;
         /** The flow grain rate, if defined, 0/1 if undefined. */
         mxlRational _grainRate;
+
+        struct Component {
+            size_t height;
+            size_t pitch;
+        };
+
+        /** Data planes. */
+        std::array<Component, MXL_MAX_PLANES_PER_GRAIN> _components;
         /** The parsed flow object. */
         picojson::object _root;
     };

--- a/lib/internal/src/FlowParser.cpp
+++ b/lib/internal/src/FlowParser.cpp
@@ -306,6 +306,23 @@ namespace mxl::lib
                 _grainRate.numerator *= 2;
                 _interlaced = true;
             }
+
+            auto const components = fetchAs<picojson::array>(_root, "components");
+            if (components.size() > MXL_MAX_PLANES_PER_GRAIN)
+            {
+                throw std::invalid_argument{"Unsupported number of planes!"};
+            }
+            _components = {};
+            for (size_t i = 0; i < components.size(); i++)
+            {
+                auto const& component = components[i].get<picojson::object>();
+                auto const planeWidth = static_cast<std::size_t>(fetchAs<double>(component, "width"));
+                auto const planeHeight = static_cast<std::size_t>(fetchAs<double>(component, "height"));
+                auto const bitDepth = static_cast<std::uint8_t>(fetchAs<double>(component, "bit_depth"));
+                uint8_t const bytesPerPixel = (bitDepth + 7) / 8;
+                size_t const pitch = planeWidth * bytesPerPixel;
+                _components[i] = {planeHeight, pitch};
+            }
         }
     }
 
@@ -370,6 +387,18 @@ namespace mxl::lib
                     auto msg = std::string{"Invalid video height for interlaced v210a. Must be even."};
                     throw std::invalid_argument{std::move(msg)};
                 }
+            }
+            else if (mediaType == "video/raw")
+            {
+                if (_interlaced)
+                {
+                    auto msg = std::string{"Interlaced planar video is not supported!"};
+                    throw std::invalid_argument{std::move(msg)};
+                }
+                payloadSize = std::accumulate(_components.begin(),
+                    _components.end(),
+                    0,
+                    [](size_t sum, auto const& component) { return sum + component.pitch * component.height; });
             }
             else
             {
@@ -444,6 +473,13 @@ namespace mxl::lib
                     sliceLengths[0] = v210fillSize;
                     sliceLengths[1] = get10BitAlphaLineLength(width);
                 }
+                else if (mediaType == "video/raw")
+                {
+                    for (size_t i = 0; i < _components.size(); i++)
+                    {
+                        sliceLengths[i] = _components[i].pitch;
+                    }
+                }
                 else
                 {
                     auto msg = std::string{"Unsupported video media_type: "} + mediaType;
@@ -473,20 +509,35 @@ namespace mxl::lib
 
             case MXL_DATA_FORMAT_VIDEO:
             {
-                if (auto const mediaType = fetchAs<std::string>(_root, "media_type"); mediaType != "video/v210" && mediaType != "video/v210a")
+                auto const mediaType = fetchAs<std::string>(_root, "media_type");
+
+                if (mediaType == "video/v210" || mediaType == "video/v210a")
                 {
-                    auto msg = std::string{"Unsupported video media_type: "} + mediaType;
-                    throw std::invalid_argument{std::move(msg)};
+                    auto h = static_cast<std::size_t>(fetchAs<double>(_root, "frame_height"));
+                    if (_interlaced)
+                    {
+                        return h / 2;
+                    }
+                    else
+                    {
+                        return h;
+                    }
                 }
 
-                // For v210, the number of slices is always the number of video lines
-                auto h = static_cast<std::size_t>(fetchAs<double>(_root, "frame_height"));
-                if (_interlaced)
+                if (mediaType == "video/raw")
                 {
-                    return h / 2;
+                    if (_interlaced)
+                    {
+                        auto msg = std::string{"Interlaced planar video is not supported!"};
+                        throw std::invalid_argument{std::move(msg)};
+                    }
+                    size_t slices = std::accumulate(
+                        _components.begin(), _components.end(), 0, [](size_t sum, auto const& component) { return sum + component.height; });
+                    return slices;
                 }
 
-                return h;
+                auto msg = std::string{"Unsupported video media_type: "} + mediaType;
+                throw std::invalid_argument{std::move(msg)};
             }
             default:
             {

--- a/lib/tests/data/420_8bits_flow.json
+++ b/lib/tests/data/420_8bits_flow.json
@@ -1,0 +1,43 @@
+{
+  "$copyright": "SPDX-FileCopyrightText: 2025 Contributors to the Media eXchange Layer project.",
+  "$license": "SPDX-License-Identifier: Apache-2.0",
+  "description": "___CHANGE ME___ Long description of the video flow",
+  "id": "5fbec3b1-1b0f-417d-9059-8b94a47197ed",
+  "tags": {
+    "urn:x-nmos:tag:grouphint/v1.0": [
+      "___CHANGE ME FOR A NAME UNIQUE TO YOUR MEDIA FUNCTION INSTANCE___:Video"
+    ]
+  },
+  "format": "urn:x-nmos:format:video",
+  "label": "___CHANGE ME___ Short description of the video flow",
+  "parents": [],
+  "media_type": "video/raw",
+  "grain_rate": {
+    "numerator": 25,
+    "denominator": 1
+  },
+  "frame_width": 1920,
+  "frame_height": 1080,
+  "interlace_mode": "progressive",
+  "colorspace": "BT709",
+  "components": [
+    {
+      "name": "Y",
+      "width": 1920,
+      "height": 1080,
+      "bit_depth": 8
+    },
+    {
+      "name": "Cb",
+      "width": 960,
+      "height": 540,
+      "bit_depth": 8
+    },
+    {
+      "name": "Cr",
+      "width": 960,
+      "height": 540,
+      "bit_depth": 8
+    }
+  ]
+}

--- a/lib/tests/data/420_8bits_flow.json.license
+++ b/lib/tests/data/420_8bits_flow.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2026 Contributors to the Media eXchange Layer project.
+
+SPDX-License-Identifier: Apache-2.0

--- a/lib/tests/data/422_10bits_flow.json
+++ b/lib/tests/data/422_10bits_flow.json
@@ -1,0 +1,43 @@
+{
+  "$copyright": "SPDX-FileCopyrightText: 2025 Contributors to the Media eXchange Layer project.",
+  "$license": "SPDX-License-Identifier: Apache-2.0",
+  "description": "___CHANGE ME___ Long description of the video flow",
+  "id": "5fbec3b1-1b0f-417d-9059-8b94a47197ed",
+  "tags": {
+    "urn:x-nmos:tag:grouphint/v1.0": [
+      "___CHANGE ME FOR A NAME UNIQUE TO YOUR MEDIA FUNCTION INSTANCE___:Video"
+    ]
+  },
+  "format": "urn:x-nmos:format:video",
+  "label": "___CHANGE ME___ Short description of the video flow",
+  "parents": [],
+  "media_type": "video/raw",
+  "grain_rate": {
+    "numerator": 25,
+    "denominator": 1
+  },
+  "frame_width": 1920,
+  "frame_height": 1080,
+  "interlace_mode": "progressive",
+  "colorspace": "BT709",
+  "components": [
+    {
+      "name": "Y",
+      "width": 1920,
+      "height": 1080,
+      "bit_depth": 10
+    },
+    {
+      "name": "Cb",
+      "width": 960,
+      "height": 1080,
+      "bit_depth": 10
+    },
+    {
+      "name": "Cr",
+      "width": 960,
+      "height": 1080,
+      "bit_depth": 10
+    }
+  ]
+}

--- a/lib/tests/data/422_10bits_flow.json.license
+++ b/lib/tests/data/422_10bits_flow.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2026 Contributors to the Media eXchange Layer project.
+
+SPDX-License-Identifier: Apache-2.0

--- a/lib/tests/test_flows.cpp
+++ b/lib/tests/test_flows.cpp
@@ -247,6 +247,62 @@ TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Video Flow (With Alp
     mxlDestroyInstance(instanceWriter);
 }
 
+TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Video Flow : 4:2:2 10 bits", "[mxl flows]")
+{
+    auto const opts = "{}";
+    auto flowDef = mxl::tests::readFile("data/422_10bits_flow.json");
+
+    auto instance = mxlCreateInstance(domain.string().c_str(), opts);
+    REQUIRE(instance != nullptr);
+
+    mxlFlowWriter writer;
+    mxlFlowConfigInfo configInfo;
+    bool flowWasCreated = false;
+    REQUIRE(mxlCreateFlowWriter(instance, flowDef.c_str(), "", &writer, &configInfo, &flowWasCreated) == MXL_STATUS_OK);
+    REQUIRE(flowWasCreated);
+
+    REQUIRE(configInfo.discrete.sliceSizes[0] == 3840);
+    REQUIRE(configInfo.discrete.sliceSizes[1] == 1920);
+    REQUIRE(configInfo.discrete.sliceSizes[2] == 1920);
+    REQUIRE(configInfo.discrete.sliceSizes[3] == 0);
+
+    /// Open the grain.
+    mxlGrainInfo gInfo;
+
+    REQUIRE(mxlFlowWriterGetGrainInfo(writer, 0, &gInfo) == MXL_STATUS_OK);
+
+    REQUIRE(gInfo.grainSize == 8294400);
+    REQUIRE(gInfo.totalSlices == 3240);
+}
+
+TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Video Flow : 4:2:0 8 bits", "[mxl flows]")
+{
+    auto const opts = "{}";
+    auto flowDef = mxl::tests::readFile("data/420_8bits_flow.json");
+
+    auto instance = mxlCreateInstance(domain.string().c_str(), opts);
+    REQUIRE(instance != nullptr);
+
+    mxlFlowWriter writer;
+    mxlFlowConfigInfo configInfo;
+    bool flowWasCreated = false;
+    REQUIRE(mxlCreateFlowWriter(instance, flowDef.c_str(), "", &writer, &configInfo, &flowWasCreated) == MXL_STATUS_OK);
+    REQUIRE(flowWasCreated);
+
+    REQUIRE(configInfo.discrete.sliceSizes[0] == 1920);
+    REQUIRE(configInfo.discrete.sliceSizes[1] == 960);
+    REQUIRE(configInfo.discrete.sliceSizes[2] == 960);
+    REQUIRE(configInfo.discrete.sliceSizes[3] == 0);
+
+    /// Open the grain.
+    mxlGrainInfo gInfo;
+
+    REQUIRE(mxlFlowWriterGetGrainInfo(writer, 0, &gInfo) == MXL_STATUS_OK);
+
+    REQUIRE(gInfo.grainSize == 3110400);
+    REQUIRE(gInfo.totalSlices == 2160);
+}
+
 TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Video Flow : Invalid flow (discrete)", "[mxl flows]")
 {
     auto const opts = "{}";


### PR DESCRIPTION
This pull request adds support for planar video formats. Plane characteristics are parsed from the NMOS string.
Two unit tests featuring a 4:2:2 10 bits and a 4:2:0 8 bits flow have been added.
Interlaced formats are not supported.