### PR TITLE
Update backport workflow to use Node.js >20 actions

### DIFF
--- a/.github/workflows/backports.yml
+++ b/.github/workflows/backports.yml
@@ -32,11 +32,11 @@ jobs:
     steps:
       - name: "Get app token"
         id: token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.BACKPORT_APP_ID }}
           private-key: ${{ secrets.BACKPORT_PRIVATE_KEY }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # This should set up the git cli to use the PAT created from the app in the 'token' job
           token: ${{ steps.token.outputs.token }}


### PR DESCRIPTION
## Summary
- Bump `actions/create-github-app-token` from v2 to v3
- Bump `actions/checkout` from v4 to v6

Both actions were running on the deprecated Node.js 20 runtime, which will be force-migrated to Node.js 24 on June 2, 2026.

No breaking changes for the inputs/outputs used by this workflow (`app-id`, `private-key`, `token`). Both v3 and v6 are backward-compatible for our usage. The only caveat is a minimum self-hosted runner version of v2.329.0, which GitHub-hosted runners already satisfy.

Note: v3 of `create-github-app-token` deprecates `app-id` in favor of `client-id` but still accepts `app-id`. Migrating to `client-id` could be a follow-up.

Closes #450