### PR TITLE
Update backport workflow to use Node.js >20 actions

### DIFF
--- a/.github/workflows/backports.yml
+++ b/.github/workflows/backports.yml
@@ -32,11 +32,11 @@ jobs:
     steps:
       - name: "Get app token"
         id: token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.BACKPORT_APP_ID }}
           private-key: ${{ secrets.BACKPORT_PRIVATE_KEY }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # This should set up the git cli to use the PAT created from the app in the 'token' job
           token: ${{ steps.token.outputs.token }}


### PR DESCRIPTION
Bump actions/create-github-app-token from v2 to v3 and actions/checkout from v4 to v6 to move off the deprecated Node.js 20 runtime.

Closes #450