### PR TITLE
Use system linker for Darwin presets instead of LLD

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -57,7 +57,8 @@
                 "rhs": "Darwin"
             },
             "cacheVariables": {
-                "VCPKG_TARGET_TRIPLET": "arm64-osx"
+                "VCPKG_TARGET_TRIPLET": "arm64-osx",
+                "CMAKE_LINKER_TYPE": "SYSTEM"
             },
             "vendor": {
                 "microsoft.com/VisualStudioRemoteSettings/CMake/1.0": {


### PR DESCRIPTION
LLD does not support Mach-O, so the Darwin-Clang-* presets fail with "invalid linker name in argument '-fuse-ld=lld'". Override CMAKE_LINKER_TYPE to SYSTEM in the darwin preset.

Fixes #463 