### PR TITLE
Add mxlIsTmpFs() utility to detect RAM-backed filesystems

### DIFF
--- a/lib/include/mxl/mxl.h
+++ b/lib/include/mxl/mxl.h
@@ -6,6 +6,7 @@
 #ifdef __cplusplus
 #   include <cstdint>
 #else
+#   include <stdbool.h>
 #   include <stdint.h>
 #endif
 
@@ -87,6 +88,23 @@ extern "C"
     ///
     MXL_EXPORT
     mxlStatus mxlGarbageCollectFlows(mxlInstance in_instance);
+
+    ///
+    /// Checks whether the given path resides on a RAM-backed filesystem.
+    ///
+    /// On Linux, this detects tmpfs and ramfs using statfs().
+    /// On macOS, this checks the filesystem type name reported by statfs().
+    /// On other platforms, this always sets out_isTmpFs to false.
+    ///
+    /// \param in_path The filesystem path to check.
+    /// \param out_isTmpFs Pointer to a bool that will be set to true if the path
+    ///        is on a RAM-backed filesystem, false otherwise.
+    /// \return MXL_STATUS_OK on success, MXL_ERR_INVALID_ARG if in_path or
+    ///         out_isTmpFs is NULL, MXL_ERR_UNKNOWN if the filesystem type
+    ///         could not be determined.
+    ///
+    MXL_EXPORT
+    mxlStatus mxlIsTmpFs(char const* in_path, bool* out_isTmpFs);
 
     ///
     /// Destroy the MXL instance.  This will also release all flows readers/writers associated with the instance.

--- a/lib/src/mxl.cpp
+++ b/lib/src/mxl.cpp
@@ -11,6 +11,15 @@
 #include "mxl-internal/Logging.hpp"
 #include "mxl-internal/PosixFlowIoFactory.hpp"
 
+#ifdef __linux__
+#   include <sys/vfs.h>
+#   include <linux/magic.h>
+#elif defined(__APPLE__)
+#   include <cstring>
+#   include <sys/mount.h>
+#   include <sys/param.h>
+#endif
+
 static char const g_mxl_version_string[] = MXL_VERSION_FULL;
 
 extern "C"
@@ -52,6 +61,38 @@ mxlInstance mxlCreateInstance(char const* in_mxlDomain, char const* in_options)
         MXL_ERROR("Failed to create instance");
         return nullptr;
     }
+}
+
+extern "C" MXL_EXPORT
+mxlStatus mxlIsTmpFs(char const* in_path, bool* out_isTmpFs)
+{
+    if ((in_path == nullptr) || (out_isTmpFs == nullptr))
+    {
+        return MXL_ERR_INVALID_ARG;
+    }
+
+#ifdef __linux__
+    using statfs_t = struct statfs;
+    auto buf = statfs_t{};
+    if (::statfs(in_path, &buf) != 0)
+    {
+        return MXL_ERR_UNKNOWN;
+    }
+    *out_isTmpFs = (buf.f_type == TMPFS_MAGIC) || (buf.f_type == RAMFS_MAGIC);
+    return MXL_STATUS_OK;
+#elif defined(__APPLE__)
+    using statfs_t = struct statfs;
+    auto buf = statfs_t{};
+    if (::statfs(in_path, &buf) != 0)
+    {
+        return MXL_ERR_UNKNOWN;
+    }
+    *out_isTmpFs = std::strcmp(buf.f_fstypename, "tmpfs") == 0;
+    return MXL_STATUS_OK;
+#else
+    *out_isTmpFs = false;
+    return MXL_STATUS_OK;
+#endif
 }
 
 extern "C"

--- a/lib/tests/test_instance.cpp
+++ b/lib/tests/test_instance.cpp
@@ -7,6 +7,54 @@
 #include <mxl/mxl.h>
 #include "Utils.hpp"
 
+#ifdef __linux__
+#   include <sys/vfs.h>
+#   include <linux/magic.h>
+
+namespace
+{
+    bool pathIsTmpFs(char const* path)
+    {
+        struct statfs buf;
+        REQUIRE(statfs(path, &buf) == 0);
+        return (buf.f_type == TMPFS_MAGIC) || (buf.f_type == RAMFS_MAGIC);
+    }
+}
+#endif
+
+TEST_CASE("mxlIsTmpFs returns MXL_ERR_INVALID_ARG for NULL path", "[mxlIsTmpFs]")
+{
+    bool isTmpFs = true;
+    REQUIRE(mxlIsTmpFs(nullptr, &isTmpFs) == MXL_ERR_INVALID_ARG);
+}
+
+TEST_CASE("mxlIsTmpFs returns MXL_ERR_INVALID_ARG for NULL out pointer", "[mxlIsTmpFs]")
+{
+    REQUIRE(mxlIsTmpFs("/tmp", nullptr) == MXL_ERR_INVALID_ARG);
+}
+
+TEST_CASE("mxlIsTmpFs returns error for non-existent path", "[mxlIsTmpFs]")
+{
+    bool isTmpFs = true;
+    REQUIRE(mxlIsTmpFs("/this/path/does/not/exist", &isTmpFs) != MXL_STATUS_OK);
+}
+
+#ifdef __linux__
+TEST_CASE("mxlIsTmpFs matches statfs filesystem type on Linux", "[mxlIsTmpFs]")
+{
+    bool isTmpFs = false;
+    REQUIRE(mxlIsTmpFs("/", &isTmpFs) == MXL_STATUS_OK);
+    REQUIRE(isTmpFs == pathIsTmpFs("/"));
+}
+
+TEST_CASE("mxlIsTmpFs detects /dev/shm as tmpfs on Linux", "[mxlIsTmpFs]")
+{
+    bool isTmpFs = false;
+    REQUIRE(mxlIsTmpFs("/dev/shm", &isTmpFs) == MXL_STATUS_OK);
+    REQUIRE(isTmpFs);
+}
+#endif
+
 TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Flow readers / writers caching", "[instance]")
 {
     auto const opts = "{}";


### PR DESCRIPTION
Adds a public C API function that checks whether a given path resides on a RAM-backed filesystem.

Closes #459 