### PR TITLE
Backport workflow: Use `client-id` parameter instead of deprecated `app-id`.

### DIFF
--- a/.github/workflows/backports.yml
+++ b/.github/workflows/backports.yml
@@ -34,7 +34,7 @@ jobs:
         id: token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.BACKPORT_APP_ID }}
+          client-id: ${{ vars.BACKPORT_CLIENT_ID }}
           private-key: ${{ secrets.BACKPORT_PRIVATE_KEY }}
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
Deprecated in [v3](https://github.com/actions/create-github-app-token/releases/tag/v3.1.0)  of the create-github-app-token workflow.