### PR TITLE
Fix race condition in DomainWatcher::stop()

### DIFF
--- a/lib/internal/include/mxl-internal/DomainWatcher.hpp
+++ b/lib/internal/include/mxl-internal/DomainWatcher.hpp
@@ -93,6 +93,10 @@ namespace mxl::lib
         void stop()
         {
             _running = false;
+            if (_watchThread.joinable())
+            {
+                _watchThread.join();
+            }
         }
 
         /** \brief Returns the number of writers registered for flow id 'id'

--- a/lib/internal/src/DomainWatcher.cpp
+++ b/lib/internal/src/DomainWatcher.cpp
@@ -111,11 +111,7 @@ namespace mxl::lib
 
     DomainWatcher::~DomainWatcher()
     {
-        _running = false;
-        if (_watchThread.joinable())
-        {
-            _watchThread.join();
-        }
+        stop();
 
 #ifdef __APPLE__
         ::close(_kq);


### PR DESCRIPTION
stop() only set the _running flag without joining the thread, leaving a window where the event loop could process one more inotify event before checking the flag. Join the thread in stop() to guarantee the event loop has fully exited before the caller proceeds.

Fixes #446