### PR TITLE
DMF-139: Enforce tmpfs domain in mxlCreateInstance

### DIFF
--- a/lib/src/mxl.cpp
+++ b/lib/src/mxl.cpp
@@ -46,6 +46,13 @@ mxlInstance mxlCreateInstance(char const* in_mxlDomain, char const* in_options)
 {
     try
     {
+        bool isTmpFs = false;
+        if (mxlIsTmpFs(in_mxlDomain, &isTmpFs) == MXL_STATUS_OK && !isTmpFs)
+        {
+            MXL_ERROR("Domain '{}' is not on a tmpfs filesystem", in_mxlDomain);
+            return nullptr;
+        }
+
         auto const opts = (in_options != nullptr) ? in_options : "";
         auto domainWatcher = std::make_shared<mxl::lib::DomainWatcher>(in_mxlDomain);
         auto flowIoFactory = std::make_unique<mxl::lib::PosixFlowIoFactory>(domainWatcher);

--- a/lib/tests/test_instance.cpp
+++ b/lib/tests/test_instance.cpp
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2025 Contributors to the Media eXchange Layer project.
 // SPDX-License-Identifier: Apache-2.0
 
+#include <array>
+#include <filesystem>
 #include <uuid.h>
 #include <catch2/catch_test_macros.hpp>
 #include <mxl/flow.h>
@@ -18,6 +20,19 @@ namespace
         struct statfs buf;
         REQUIRE(statfs(path, &buf) == 0);
         return (buf.f_type == TMPFS_MAGIC) || (buf.f_type == RAMFS_MAGIC);
+    }
+
+    std::filesystem::path findNonTmpFsPath()
+    {
+        for (auto const* candidate : std::array{"/var/tmp", "/var", "/home"})
+        {
+            struct statfs buf{};
+            if (::statfs(candidate, &buf) != 0)
+                continue;
+            if (buf.f_type != TMPFS_MAGIC && buf.f_type != RAMFS_MAGIC)
+                return std::filesystem::path{candidate};
+        }
+        return {};
     }
 }
 #endif
@@ -52,6 +67,20 @@ TEST_CASE("mxlIsTmpFs detects /dev/shm as tmpfs on Linux", "[mxlIsTmpFs]")
     bool isTmpFs = false;
     REQUIRE(mxlIsTmpFs("/dev/shm", &isTmpFs) == MXL_STATUS_OK);
     REQUIRE(isTmpFs);
+}
+
+TEST_CASE("mxlCreateInstance returns NULL for non-tmpfs domain", "[mxlCreateInstance]")
+{
+    auto const base = findNonTmpFsPath();
+    if (base.empty())
+        SKIP("No non-tmpfs filesystem found on this system");
+
+    auto const domain = base / "mxl_test_non_tmpfs";
+    std::filesystem::create_directories(domain);
+    auto cleanup = std::shared_ptr<void>(nullptr, [&](void*) { std::filesystem::remove_all(domain); });
+
+    auto instance = mxlCreateInstance(domain.string().c_str(), nullptr);
+    REQUIRE(instance == nullptr);
 }
 #endif
 


### PR DESCRIPTION
Introduces the mxlIsTmpFs() API function to determine whether a given path resides on a RAM-backed filesystem, such as tmpfs or ramfs. 

Additions to https://github.com/dmf-mxl/mxl/issues/459