### PR TITLE
Add functions to query the maximum number of samples that can be read or written to a continuous flow in a single transaction.

### DIFF
--- a/lib/include/mxl/flow.h
+++ b/lib/include/mxl/flow.h
@@ -393,14 +393,29 @@ extern "C"
     mxlStatus mxlFlowWriterCancelGrain(mxlFlowWriter writer);
 
     /**
-     * Inform mxl that a user is done writing the grain that was previously opened.  This will in turn signal all readers waiting on the ringbuffer
-     * that a new grain is available. The mxlGrainInfo flags field in shared memory will be updated based on grain->flags This will increase the head
-     * and potentially the tail IF this grain is the new head.
+     * Inform mxl that a user is done writing the grain that was previously opened.
+     * This will in turn signal all readers waiting on the ringbuffer that a new grain is available. The mxlGrainInfo
+     * flags field in shared memory will be updated based on grain->flags This will increase the head and potentially
+     * the tail IF this grain is the new head.
      *
      * \return The result code. \see mxlStatus
      */
     MXL_EXPORT
     mxlStatus mxlFlowWriterCommitGrain(mxlFlowWriter writer, mxlGrainInfo const* grain);
+
+    /**
+     * Return the absolute maximum number of samples a read operation may retrieve from a flow.
+     *
+     * \param[in] reader A valid flow reader
+     * \param[out] maxReadLength A valid pointer referring to the location, in which to store
+     *      the maximum number of samples a read operation may retrieve from the flow \p reader operates on.
+     * \return The result code. \see mxlStatus
+     * \note Please note that a read of the specified length is only guaranteed to be possible, if
+     *      1. enough history is available, and
+     *      2. the read is performed at the current head index.
+     */
+    MXL_EXPORT
+    mxlStatus mxlFlowReaderGetMaxReadLengthSamples(mxlFlowReader reader, size_t* maxReadLength);
 
     /**
      * Accessor for a specific set of samples across all channels ending at a
@@ -444,6 +459,17 @@ extern "C"
     MXL_EXPORT
     mxlStatus mxlFlowReaderGetSamplesNonBlocking(mxlFlowReader reader, uint64_t index, size_t count,
         mxlWrappedMultiBufferSlice* payloadBuffersSlices);
+
+    /**
+     * Return the absolute maximum number of samples a write operation may write to a flow.
+     *
+     * \param[in] writer A valid flow writer
+     * \param[out] maxWriteLength A valid pointer referring to the location, at which to store
+     *      the maximum number of samples a write operation may write to the flow \p writer operates on.
+     * \return The result code. \see mxlStatus
+     */
+    MXL_EXPORT
+    mxlStatus mxlFlowWriterGetMaxWriteLengthSamples(mxlFlowWriter writer, size_t* maxWriteLength);
 
     /**
      * Open a specific set of mutable samples across all channels starting at a

--- a/lib/include/mxl/flowinfo.h
+++ b/lib/include/mxl/flowinfo.h
@@ -129,6 +129,8 @@ extern "C"
 
         /**
          * The number of samples in each of the ring buffers.
+         * Please be aware that it is only ever possible to read or write a fraction of this buffer, whose upper bound
+         * can be obtained by calling mxlFlowReaderGetMaxReadLengthSamples() or mxlFlowWriterGetMaxWriteLengthSamples().
          */
         uint32_t bufferLength;
 

--- a/lib/internal/include/mxl-internal/ContinuousFlowReader.hpp
+++ b/lib/internal/include/mxl-internal/ContinuousFlowReader.hpp
@@ -12,6 +12,15 @@ namespace mxl::lib
     {
     public:
         /**
+         * Return the maximum number of samples that can be retrieved by a read
+         * operation in one go.
+         * \return The maximum number of samples a read operation can return in
+         *      one go.
+         */
+        [[nodiscard]]
+        virtual std::size_t getMaxReadLength() const = 0;
+
+        /**
          * Blocking wait function for the sample at the specified index to
          * become available.
          *

--- a/lib/internal/include/mxl-internal/ContinuousFlowWriter.hpp
+++ b/lib/internal/include/mxl-internal/ContinuousFlowWriter.hpp
@@ -11,6 +11,15 @@ namespace mxl::lib
     {
     public:
         /**
+         * Return the maximum number of samples a write operation can write in
+         * one go.
+         * \return The maximum number of samples a write operation can write in
+         *      one go.
+         */
+        [[nodiscard]]
+        virtual std::size_t getMaxWriteLength() const = 0;
+
+        /**
          * Accessor for a specific set of mutable samples across all
          * channels ending at a specific index (`count` samples up to
          * `index`).

--- a/lib/internal/src/PosixContinuousFlowReader.cpp
+++ b/lib/internal/src/PosixContinuousFlowReader.cpp
@@ -46,6 +46,11 @@ namespace mxl::lib
         return getFlowData().flowInfo()->runtime;
     }
 
+    std::size_t PosixContinuousFlowReader::getMaxReadLength() const
+    {
+        return _bufferLength / 2U;
+    }
+
     mxlStatus PosixContinuousFlowReader::waitForSamples(std::uint64_t index, Timepoint deadline) const
     {
         if (_flowData)

--- a/lib/internal/src/PosixContinuousFlowReader.hpp
+++ b/lib/internal/src/PosixContinuousFlowReader.hpp
@@ -45,6 +45,10 @@ namespace mxl::lib
         [[nodiscard]]
         virtual mxlFlowRuntimeInfo getFlowRuntimeInfo() const override;
 
+        /** \see ContinuousFlowReader::getMaxReadLength */
+        [[nodiscard]]
+        virtual std::size_t getMaxReadLength() const override;
+
         /** \see ContinuousFlowReader::waitForSamples */
         virtual mxlStatus waitForSamples(std::uint64_t index, Timepoint deadline) const override;
 

--- a/lib/internal/src/PosixContinuousFlowWriter.cpp
+++ b/lib/internal/src/PosixContinuousFlowWriter.cpp
@@ -57,6 +57,11 @@ namespace mxl::lib
         return getFlowData().flowInfo()->runtime;
     }
 
+    std::size_t PosixContinuousFlowWriter::getMaxWriteLength() const
+    {
+        return _bufferLength / 2U;
+    }
+
     mxlStatus PosixContinuousFlowWriter::openSamples(std::uint64_t index, std::size_t count, mxlMutableWrappedMultiBufferSlice& payloadBufferSlices)
     {
         if (_flowData)

--- a/lib/internal/src/PosixContinuousFlowWriter.hpp
+++ b/lib/internal/src/PosixContinuousFlowWriter.hpp
@@ -48,6 +48,10 @@ namespace mxl::lib
         [[nodiscard]]
         virtual mxlFlowRuntimeInfo getFlowRuntimeInfo() const override;
 
+        /** \see ContinuousFlowWriter::getMaxWriteLength */
+        [[nodiscard]]
+        virtual std::size_t getMaxWriteLength() const override;
+
         /** \see ContinuousFlowWriter::openSamples */
         virtual mxlStatus openSamples(std::uint64_t index, std::size_t count, mxlMutableWrappedMultiBufferSlice& payloadBufferSlices) override;
 

--- a/lib/src/flow.cpp
+++ b/lib/src/flow.cpp
@@ -502,6 +502,30 @@ mxlStatus mxlFlowWriterCommitGrain(mxlFlowWriter writer, mxlGrainInfo const* gra
 
 extern "C"
 MXL_EXPORT
+mxlStatus mxlFlowReaderGetMaxReadLengthSamples(mxlFlowReader reader, size_t* maxReadLength)
+{
+    try
+    {
+        if (maxReadLength != nullptr)
+        {
+            if (auto const cppReader = dynamic_cast<ContinuousFlowReader*>(to_FlowReader(reader)); cppReader != nullptr)
+            {
+                *maxReadLength = cppReader->getMaxReadLength();
+                return MXL_STATUS_OK;
+            }
+
+            return MXL_ERR_INVALID_FLOW_READER;
+        }
+        return MXL_ERR_INVALID_ARG;
+    }
+    catch (...)
+    {
+        return MXL_ERR_UNKNOWN;
+    }
+}
+
+extern "C"
+MXL_EXPORT
 mxlStatus mxlFlowReaderGetSamples(mxlFlowReader reader, uint64_t index, size_t count, uint64_t timeoutNs,
     mxlWrappedMultiBufferSlice* payloadBuffersSlices)
 {
@@ -538,6 +562,30 @@ mxlStatus mxlFlowReaderGetSamplesNonBlocking(mxlFlowReader reader, uint64_t inde
             }
 
             return MXL_ERR_INVALID_FLOW_READER;
+        }
+        return MXL_ERR_INVALID_ARG;
+    }
+    catch (...)
+    {
+        return MXL_ERR_UNKNOWN;
+    }
+}
+
+extern "C"
+MXL_EXPORT
+mxlStatus mxlFlowWriterGetMaxWriteLengthSamples(mxlFlowWriter writer, size_t* maxWriteLength)
+{
+    try
+    {
+        if (maxWriteLength != nullptr)
+        {
+            if (auto const cppWriter = dynamic_cast<ContinuousFlowWriter*>(to_FlowWriter(writer)); cppWriter != nullptr)
+            {
+                *maxWriteLength = cppWriter->getMaxWriteLength();
+                return MXL_STATUS_OK;
+            }
+
+            return MXL_ERR_INVALID_FLOW_WRITER;
         }
         return MXL_ERR_INVALID_ARG;
     }


### PR DESCRIPTION
As discussed before these should help avoid confusion how many samples may be consumed or provided in one go.