### PR TITLE
Fix potential fabrics memory leak + fix blocking write API or writes where timeout < 100ms

### DIFF
--- a/lib/fabrics/ofi/src/internal/Initiator.cpp
+++ b/lib/fabrics/ofi/src/internal/Initiator.cpp
@@ -25,7 +25,7 @@ namespace mxl::lib::fabrics::ofi
     {
         if (_inner)
         {
-            _inner.release();
+            _inner.reset();
         }
 
         switch (config.provider)

--- a/lib/fabrics/ofi/src/internal/RCInitiator.cpp
+++ b/lib/fabrics/ofi/src/internal/RCInitiator.cpp
@@ -502,14 +502,11 @@ namespace mxl::lib::fabrics::ofi
 
         for (;;)
         {
-            // If there is nothing more to do, return control to the caller.
-            if (!hasPendingWork())
+            // Poll all queues, execute all maintainance actions
+            if (!makeProgress())
             {
                 return false;
             }
-
-            // Poll all queues, execute all maintainance actions
-            makeProgress();
 
             // Calculate the remaining time until the user wants the blocking function to return. If there is no time left
             // (millisecond precision) return right away.


### PR DESCRIPTION
Fix a memory leak that would happen if someone would re-configure a fabrics initiator object by calling the setup function again.

Fix the blocking write function for initiators. This function would end up not doing internal state maintenance when the timeout for the blocking function call would be less than the internal minimum event queue poll interval. 