### PR TITLE
Enable blocking API for EFA provider on libfabric >2.5

### DIFF
--- a/lib/fabrics/ofi/src/internal/CompletionQueue.cpp
+++ b/lib/fabrics/ofi/src/internal/CompletionQueue.cpp
@@ -6,6 +6,7 @@
 #include <memory>
 #include <optional>
 #include <utility>
+#include <fcntl.h>
 #include <sys/types.h>
 #include <mxl-internal/Logging.hpp>
 #include <rdma/fi_eq.h>
@@ -36,6 +37,14 @@ namespace mxl::lib::fabrics::ofi
         raw.flags = 0;                   // if signaling vector is required, this should use the flag "FI_AFFINITY"
         raw.signaling_vector = 0;        // this should indicate the CPU core that interrupts associated with the cq should target.
         return raw;
+    }
+
+    bool CompletionQueue::isWaitObjectSupportedForEFA() noexcept
+    {
+        auto const fiVersion = ::fi_version();
+
+        // check that library version >= 2.5
+        return (FI_MAJOR(fiVersion) > 2) || ((FI_MAJOR(fiVersion) == 2) && (FI_MINOR(fiVersion) >= 5));
     }
 
     std::shared_ptr<CompletionQueue> CompletionQueue::open(std::shared_ptr<Domain> domain, CompletionQueue::Attributes const& attr)

--- a/lib/fabrics/ofi/src/internal/CompletionQueue.hpp
+++ b/lib/fabrics/ofi/src/internal/CompletionQueue.hpp
@@ -40,6 +40,10 @@ namespace mxl::lib::fabrics::ofi
             enum fi_wait_obj waitObject; /**< The underlying wait object that should be used. */
         };
 
+        /** \brief Check if wait any wait object type supported by the EFA provider for this libfabric version
+         */
+        static bool isWaitObjectSupportedForEFA() noexcept;
+
     public:
         /** \brief Create a new completion queue in the specified domain.
          */

--- a/lib/fabrics/ofi/src/internal/RDMInitiator.cpp
+++ b/lib/fabrics/ofi/src/internal/RDMInitiator.cpp
@@ -137,7 +137,11 @@ namespace mxl::lib::fabrics::ofi
         auto cqAttr = CompletionQueue::Attributes::defaults();
         if (provider == Provider::EFA)
         {
-            cqAttr.waitObject = FI_WAIT_NONE;
+            if (!CompletionQueue::isWaitObjectSupportedForEFA())
+            {
+                MXL_WARN("Wait objects not supported in EFA provider for this libfabric version. Only non-blocking API available.");
+                cqAttr.waitObject = FI_WAIT_NONE;
+            }
         }
         auto cq = CompletionQueue::open(endpoint.domain(), cqAttr);
         endpoint.bind(cq, FI_TRANSMIT | FI_RECV);

--- a/lib/fabrics/ofi/src/internal/RDMTarget.cpp
+++ b/lib/fabrics/ofi/src/internal/RDMTarget.cpp
@@ -47,7 +47,11 @@ namespace mxl::lib::fabrics::ofi
         auto cqAttr = CompletionQueue::Attributes::defaults();
         if (provider == Provider::EFA)
         {
-            cqAttr.waitObject = FI_WAIT_NONE;
+            if (!CompletionQueue::isWaitObjectSupportedForEFA())
+            {
+                MXL_WARN("Wait objects not supported in EFA provider for this libfabric version. Only non-blocking API available.");
+                cqAttr.waitObject = FI_WAIT_NONE;
+            }
         }
         auto cq = CompletionQueue::open(domain, cqAttr);
         endpoint.bind(cq, FI_RECV | FI_TRANSMIT);


### PR DESCRIPTION
Support for blocking completion queue access was added very recently to libfabric. This is what enables the very low CPU impact that we saw during the NAB interop on AWS.

This PR enables use of the blocking API in the EFA provider. It also adds a warning that is logged when using the EFA provider on a libfabric version that does not support the blocking API.