### PR TITLE
mxlsrc: attach MXL flow from negotiate, not start

### DIFF
--- a/rust/gst-mxl-rs/src/mxlsrc/imp.rs
+++ b/rust/gst-mxl-rs/src/mxlsrc/imp.rs
@@ -38,9 +38,9 @@ pub(crate) static CAT: LazyLock<gst::DebugCategory> = LazyLock::new(|| {
     gst::DebugCategory::new("mxlsrc", gst::DebugColorFlags::empty(), Some("MXL Source"))
 });
 
-struct ClockWait {
+pub(crate) struct ClockWait {
     clock_id: Option<gst::SingleShotClockId>,
-    flushing: bool,
+    pub(crate) flushing: bool,
 }
 
 impl Default for ClockWait {
@@ -56,7 +56,7 @@ impl Default for ClockWait {
 pub struct MxlSrc {
     pub settings: Mutex<Settings>,
     pub context: Mutex<Context>,
-    clock_wait: Mutex<ClockWait>,
+    pub(crate) clock_wait: Mutex<ClockWait>,
 }
 
 pub enum CreateState {
@@ -252,6 +252,43 @@ impl BaseSrcImpl for MxlSrc {
     fn negotiate(&self) -> Result<(), gst::LoggableError> {
         gst::info!(CAT, imp = self, "Negotiating caps…");
 
+        {
+            let settings = self
+                .settings
+                .lock()
+                .map_err(|e| gst::loggable_error!(CAT, "Failed to lock settings mutex {}", e))?;
+            if settings.audio_flow.is_some() && settings.video_flow.is_some() {
+                gst::warning!(CAT, imp = self, "You can't set both video and audio flows");
+                return self.parent_negotiate();
+            }
+            if settings.domain.is_empty()
+                || (settings.video_flow.is_none() && settings.audio_flow.is_none())
+            {
+                gst::warning!(CAT, imp = self, "domain or flow-id not set yet");
+                return self.parent_negotiate();
+            }
+        }
+
+        // `start()` does not attach the MXL reader (so PLAYING is reachable
+        // before the producer creates the flow). Attach here on the streaming
+        // thread. `init_mxl_reader` polls until the flow exists; `unlock()` sets
+        // `clock_wait.flushing` so teardown can interrupt that wait.
+        let need_init = {
+            let context = self
+                .context
+                .lock()
+                .map_err(|e| gst::loggable_error!(CAT, "Failed to lock context mutex {}", e))?;
+            context
+                .state
+                .as_ref()
+                .map(|s| s.video.is_none() && s.audio.is_none())
+                .unwrap_or(true)
+        };
+        if need_init {
+            mxl_helper::init(self)
+                .map_err(|e| gst::loggable_error!(CAT, "Failed to attach flow: {}", e))?;
+        }
+
         let settings = self
             .settings
             .lock()
@@ -265,16 +302,6 @@ impl BaseSrcImpl for MxlSrc {
             .as_ref()
             .ok_or(gst::loggable_error!(CAT, "Failed to get state"))?
             .instance;
-        if settings.audio_flow.is_some() && settings.video_flow.is_some() {
-            gst::warning!(CAT, imp = self, "You can't set both video and audio flows");
-            return self.parent_negotiate();
-        }
-        if settings.domain.is_empty()
-            || settings.video_flow.is_none() && settings.audio_flow.is_none()
-        {
-            gst::warning!(CAT, imp = self, "domain or flow-id not set yet");
-            return self.parent_negotiate();
-        }
         let flow_id = mxl_helper::get_flow_type_id(&settings)?;
         let json_flow_description = mxl_helper::get_mxl_flow_json(instance, flow_id)?;
         let flow_description = mxl_helper::get_flow_def(self, json_flow_description)?;
@@ -346,8 +373,10 @@ impl BaseSrcImpl for MxlSrc {
     }
 
     fn start(&self) -> Result<(), gst::ErrorMessage> {
+        // Do not attach here: `start()` runs on the state-change thread; blocking
+        // on `FlowNotFound` would freeze the transition. Flow attach runs from
+        // `negotiate()` instead.
         self.unlock_stop()?;
-        mxl_helper::init(self)?;
         gst::info!(CAT, imp = self, "Started");
 
         Ok(())

--- a/rust/gst-mxl-rs/src/mxlsrc/mxl_helper.rs
+++ b/rust/gst-mxl-rs/src/mxlsrc/mxl_helper.rs
@@ -138,16 +138,36 @@ pub(crate) fn generate_channel_mask_from_channels(channels: u32) -> gst::Bitmask
     gst::Bitmask::new(mask)
 }
 
-fn init_mxl_reader(settings: &MutexGuard<'_, Settings>) -> Result<FlowReader, gst::ErrorMessage> {
-    let mxl_instance = init_mxl_instance(settings)?;
-    let flow_id = if settings.video_flow.is_some() {
-        settings.video_flow.as_ref()
-    } else {
-        settings.audio_flow.as_ref()
-    }
-    .ok_or_else(|| gst::error_msg!(gst::CoreError::Failed, ["Missing flow id in settings"]))?;
+/// Video or audio.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum FlowKind {
+    Video,
+    Audio,
+}
+
+/// Blocks until `create_flow_reader` succeeds, sleeping briefly and retrying
+/// while MXL returns `FlowNotFound`.
+///
+/// Before each attempt, checks `is_flushing` and returns an error if so, to
+/// avoid blocking teardown via `unlock` if the flow has not yet been created.
+///
+/// `domain` and `flow_id` are passed in by the caller (typically cloned under a
+/// short `settings` lock in `init`) so this function never holds
+/// `MutexGuard<Settings>` across `thread::sleep` in the `FlowNotFound` loop.
+fn init_mxl_reader(
+    mxlsrc: &MxlSrc,
+    domain: &str,
+    flow_id: &str,
+) -> Result<FlowReader, gst::ErrorMessage> {
+    let mxl_instance = init_mxl_instance(domain)?;
     let mut warned = false;
     loop {
+        if is_flushing(mxlsrc) {
+            return Err(gst::error_msg!(
+                gst::CoreError::Failed,
+                ["Aborted waiting for flow"]
+            ));
+        }
         match mxl_instance.create_flow_reader(flow_id) {
             Ok(reader) => break Ok(reader),
             Err(mxl::Error::FlowNotFound) => {
@@ -168,11 +188,38 @@ fn init_mxl_reader(settings: &MutexGuard<'_, Settings>) -> Result<FlowReader, gs
     }
 }
 
-pub(crate) fn init(mxlsrc: &MxlSrc) -> Result<(), gst::ErrorMessage> {
-    let settings = mxlsrc
-        .settings
+fn is_flushing(mxlsrc: &MxlSrc) -> bool {
+    mxlsrc
+        .clock_wait
         .lock()
-        .map_err(|_| gst::error_msg!(gst::CoreError::Failed, ["Missing settings"]))?;
+        .map(|cw| cw.flushing)
+        .unwrap_or(true)
+}
+
+pub(crate) fn init(mxlsrc: &MxlSrc) -> Result<(), gst::ErrorMessage> {
+    let (domain, flow_kind, flow_id) = {
+        let settings = mxlsrc
+            .settings
+            .lock()
+            .map_err(|_| gst::error_msg!(gst::CoreError::Failed, ["Missing settings"]))?;
+        let domain = settings.domain.clone();
+        if let Some(flow_id) = settings.video_flow.clone() {
+            (domain, FlowKind::Video, flow_id)
+        } else if let Some(flow_id) = settings.audio_flow.clone() {
+            (domain, FlowKind::Audio, flow_id)
+        } else {
+            return Err(gst::error_msg!(
+                gst::CoreError::Failed,
+                ["Set exactly one of video-flow-id or audio-flow-id"]
+            ));
+        }
+    };
+
+    // Wait for the flow to be created without holding `settings` or `context` mutexes
+    // across the poll/sleep loop.
+    let reader = init_mxl_reader(mxlsrc, domain.as_str(), flow_id.as_str())?;
+    let binding = reader.get_info();
+    let reader_info = binding.as_ref();
 
     let mut context = mxlsrc.context.lock().map_err(|e| {
         gst::error_msg!(
@@ -181,10 +228,7 @@ pub(crate) fn init(mxlsrc: &MxlSrc) -> Result<(), gst::ErrorMessage> {
         )
     })?;
 
-    let reader = init_mxl_reader(&settings)?;
-    let binding = reader.get_info();
-    let reader_info = binding.as_ref();
-    let instance = init_mxl_instance(&settings).map_err(|e| {
+    let instance = init_mxl_instance(domain.as_str()).map_err(|e| {
         gst::error_msg!(
             gst::CoreError::Failed,
             ["Failed to initialize MXL instance: {}", e]
@@ -195,79 +239,79 @@ pub(crate) fn init(mxlsrc: &MxlSrc) -> Result<(), gst::ErrorMessage> {
         mxl_index: 0,
         gst_time: ClockTime::from_mseconds(0),
     };
-    if settings.video_flow.is_some() {
-        let grain_rate = reader_info
-            .map_err(|e| {
+    match flow_kind {
+        FlowKind::Video => {
+            let grain_rate = reader_info
+                .map_err(|e| {
+                    gst::error_msg!(
+                        gst::CoreError::Failed,
+                        ["Failed to initialize MXL reader info: {}", e]
+                    )
+                })?
+                .config
+                .common()
+                .grain_rate()
+                .map_err(|e| {
+                    gst::error_msg!(
+                        gst::CoreError::Failed,
+                        ["Failed to initialize MXL discrete flow info: {}", e]
+                    )
+                })?;
+            let grain_reader = reader.to_grain_reader().map_err(|e| {
                 gst::error_msg!(
                     gst::CoreError::Failed,
-                    ["Failed to initialize MXL reader info: {}", e]
-                )
-            })?
-            .config
-            .common()
-            .grain_rate()
-            .map_err(|e| {
-                gst::error_msg!(
-                    gst::CoreError::Failed,
-                    ["Failed to initialize MXL discrete flow info: {}", e]
+                    ["Failed to initialize MXL grain reader: {}", e]
                 )
             })?;
-        let grain_reader = reader.to_grain_reader().map_err(|e| {
-            gst::error_msg!(
-                gst::CoreError::Failed,
-                ["Failed to initialize MXL grain reader: {}", e]
-            )
-        })?;
 
-        context.state = Some(State {
-            instance,
-            initial_info,
-            video: Some(VideoState {
-                grain_rate,
-                frame_counter: 0,
-                is_initialized: false,
-                grain_reader,
-            }),
-            audio: None,
-        });
-    } else if settings.audio_flow.is_some() {
-        let reader_audio = init_mxl_reader(&settings)?;
-        let samples_reader = reader_audio.to_samples_reader().map_err(|e| {
-            gst::error_msg!(
-                gst::CoreError::Failed,
-                ["Failed to initialize MXL grain reader: {}", e]
-            )
-        })?;
-        context.state = Some(State {
-            instance,
-            initial_info,
-            video: None,
-            audio: Some(AudioState {
-                reader,
-                samples_reader,
-                batch_counter: 0,
-                is_initialized: false,
-                index: 0,
-                next_discont: false,
-            }),
-        });
+            context.state = Some(State {
+                instance,
+                initial_info,
+                video: Some(VideoState {
+                    grain_rate,
+                    frame_counter: 0,
+                    is_initialized: false,
+                    grain_reader,
+                }),
+                audio: None,
+            });
+        }
+        FlowKind::Audio => {
+            let reader_audio = init_mxl_reader(mxlsrc, domain.as_str(), flow_id.as_str())?;
+            let samples_reader = reader_audio.to_samples_reader().map_err(|e| {
+                gst::error_msg!(
+                    gst::CoreError::Failed,
+                    ["Failed to initialize MXL grain reader: {}", e]
+                )
+            })?;
+            context.state = Some(State {
+                instance,
+                initial_info,
+                video: None,
+                audio: Some(AudioState {
+                    reader,
+                    samples_reader,
+                    batch_counter: 0,
+                    is_initialized: false,
+                    index: 0,
+                    next_discont: false,
+                }),
+            });
+        }
     }
     Ok(())
 }
 
-fn init_mxl_instance(
-    settings: &MutexGuard<'_, Settings>,
-) -> Result<MxlInstance, gst::ErrorMessage> {
+fn init_mxl_instance(domain: &str) -> Result<MxlInstance, gst::ErrorMessage> {
     let mxl_api = mxl::load_api(get_mxl_so_path())
         .map_err(|e| gst::error_msg!(gst::CoreError::Failed, ["Failed to load MXL API: {}", e]))?;
 
-    let mxl_instance =
-        mxl::MxlInstance::new(mxl_api, settings.domain.as_str(), "").map_err(|e| {
-            gst::error_msg!(
-                gst::CoreError::Failed,
-                ["Failed to load MXL instance: {}", e]
-            )
-        })?;
+    let mxl_instance = mxl::MxlInstance::new(mxl_api, domain, "").map_err(|e| {
+        gst::error_msg!(
+            gst::CoreError::Failed,
+            ["Failed to load MXL instance: {}", e]
+        )
+    })?;
 
     Ok(mxl_instance)
 }

--- a/rust/gst-mxl-rs/src/mxlsrc/src_tests.rs
+++ b/rust/gst-mxl-rs/src/mxlsrc/src_tests.rs
@@ -94,12 +94,14 @@ mod tests {
         gst::Element::link_many([&src1, &sink])
             .map_err(|e| glib::Error::new(CoreError::Failed, &e.message))?;
 
-        pipeline_producer
-            .set_state(gst::State::Playing)
-            .map_err(|_| glib::Error::new(CoreError::Failed, "Producer state change failed"))?;
+        // Consumer first to demonstrate that mxlsrc does not block the state change
+        // if the MXL flow does not exist yet.
         pipeline_consumer
             .set_state(gst::State::Playing)
             .map_err(|_| glib::Error::new(CoreError::Failed, "Consumer state change failed"))?;
+        pipeline_producer
+            .set_state(gst::State::Playing)
+            .map_err(|_| glib::Error::new(CoreError::Failed, "Producer state change failed"))?;
 
         thread::sleep(Duration::from_millis(600));
 


### PR DESCRIPTION
Resolves #503.

**I am not a Rust programmer, so I relied heavily on Cursor help for idiomatic Rust! 😁**

`BaseSrc::start` runs on the state-change thread; blocking on `FlowNotFound` there prevented reaching PLAYING before the flow was created.

- `start()`: only `unlock_stop`; defer reader setup to `negotiate()`.
- `negotiate()`: after validating domain/flow ids, call `init()` when no reader state yet, then resolve caps from the MXL flow definition.
- `init_mxl_reader()`: poll loop checks `clock_wait.flushing` so `unlock()` can interrupt during teardown.