### PR TITLE
Refactor MxlSink to use element clock directly in render functions

### DIFF
--- a/rust/gst-mxl-rs/src/mxlsink/imp.rs
+++ b/rust/gst-mxl-rs/src/mxlsink/imp.rs
@@ -258,21 +258,12 @@ impl BaseSinkImpl for MxlSink {
             )
         })?;
         let instance = init_mxl_instance(&settings)?;
-        let pipeline = self
-            .obj()
-            .parent()
-            .and_then(|p| p.downcast::<gst::Pipeline>().ok())
-            .ok_or(gst::error_msg!(
-                gst::CoreError::Failed,
-                ["Failed to get pipeline"]
-            ))?;
         context.state = Some(State {
             instance,
             flow: None,
             video: None,
             audio: None,
             data: None,
-            pipeline,
         });
 
         Ok(())
@@ -333,12 +324,18 @@ impl BaseSinkImpl for MxlSink {
 
         let mut context = self.context.lock().map_err(|_| gst::FlowError::Error)?;
         let state = context.state.as_mut().ok_or(gst::FlowError::Error)?;
+        // Borrow the element for the duration of this render call so
+        // the format-specific paths can read its propagated pipeline
+        // clock via `Element::clock()` without `State` having to
+        // cache a strong ref (which would form a refcount cycle).
+        let element = self.obj();
+        let element: &gst::Element = element.upcast_ref();
         if state.video.is_some() {
-            render_video::video(state, buffer)
+            render_video::video(state, element, buffer)
         } else if state.audio.is_some() {
-            render_audio::audio(state, buffer)
+            render_audio::audio(state, element, buffer)
         } else if state.data.is_some() {
-            render_data::data(state, buffer)
+            render_data::data(state, element, buffer)
         } else {
             Err(gst::FlowError::Error)
         }

--- a/rust/gst-mxl-rs/src/mxlsink/render_audio.rs
+++ b/rust/gst-mxl-rs/src/mxlsink/render_audio.rs
@@ -32,6 +32,7 @@ const LATENCY_CUSHION: u64 = 5_000_000;
 
 pub(crate) fn audio(
     state: &mut mxlsink::state::State,
+    element: &gst::Element,
     buffer: &gst::Buffer,
 ) -> Result<gst::FlowSuccess, gst::FlowError> {
     let map = buffer.map_readable().map_err(|_| gst::FlowError::Error)?;
@@ -44,7 +45,7 @@ pub(crate) fn audio(
         .map_err(|_| gst::FlowError::Error)?;
     let buffer_length = flow_info.bufferLength as u64;
     let max_chunk = (buffer_length / 2) as usize;
-    let clock = state.pipeline.clock().ok_or(gst::FlowError::Error)?;
+    let clock = element.clock().ok_or(gst::FlowError::Error)?;
     let gst_now = clock.time();
     let audio_state = state.audio.as_mut().ok_or(gst::FlowError::Error)?;
     let bytes_per_sample = (audio_state.flow_def.bit_depth / 8) as usize;

--- a/rust/gst-mxl-rs/src/mxlsink/render_data.rs
+++ b/rust/gst-mxl-rs/src/mxlsink/render_data.rs
@@ -21,6 +21,7 @@ const LATENCY_CUSHION: u64 = 5_000_000;
 
 pub(crate) fn data(
     state: &mut mxlsink::state::State,
+    element: &gst::Element,
     buffer: &gst::Buffer,
 ) -> Result<gst::FlowSuccess, gst::FlowError> {
     let data_state = state.data.as_mut().ok_or(gst::FlowError::Error)?;
@@ -30,7 +31,7 @@ pub(crate) fn data(
         .grain_rate()
         .map_err(|_| gst::FlowError::Error)?;
 
-    let clock = state.pipeline.clock().ok_or(gst::FlowError::Error)?;
+    let clock = element.clock().ok_or(gst::FlowError::Error)?;
     let gst_now = clock.time();
     let mxl_now = state.instance.get_time();
     let initial = data_state.initial_time.get_or_insert(InitialTime {

--- a/rust/gst-mxl-rs/src/mxlsink/render_video.rs
+++ b/rust/gst-mxl-rs/src/mxlsink/render_video.rs
@@ -20,6 +20,7 @@ const LATENCY_CUSHION: u64 = 5_000_000;
 
 pub(crate) fn video(
     state: &mut mxlsink::state::State,
+    element: &gst::Element,
     buffer: &gst::Buffer,
 ) -> Result<gst::FlowSuccess, gst::FlowError> {
     let video_state = state.video.as_mut().ok_or(gst::FlowError::Error)?;
@@ -29,7 +30,7 @@ pub(crate) fn video(
         .grain_rate()
         .map_err(|_| gst::FlowError::Error)?;
 
-    let clock = state.pipeline.clock().ok_or(gst::FlowError::Error)?;
+    let clock = element.clock().ok_or(gst::FlowError::Error)?;
     let gst_now = clock.time();
     let mxl_now = state.instance.get_time();
     let initial = video_state.initial_time.get_or_insert(InitialTime {

--- a/rust/gst-mxl-rs/src/mxlsink/state.rs
+++ b/rust/gst-mxl-rs/src/mxlsink/state.rs
@@ -56,7 +56,6 @@ pub(crate) struct State {
     pub video: Option<VideoState>,
     pub audio: Option<AudioState>,
     pub data: Option<DataState>,
-    pub pipeline: gst::Pipeline,
 }
 
 pub(crate) struct VideoState {


### PR DESCRIPTION

<!-- SPDX-FileCopyrightText: 2026 Contributors to the Media eXchange Layer project. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

# Problem

The `mxlsink` element assumed it was directly contained in a Pipeline, whereas it might be nested in a Bin.

# Details

- Removed the pipeline reference from the State struct.
- Updated render functions for audio, video, and data to accept an element reference and use its clock instead of the pipeline's clock.
- Simplified state management by eliminating unnecessary strong references that could lead to reference cycles.


# Backport requirements

None, `gst-mxl-rs` is only in main, not v1.0 branch.