### PR TITLE
gst-mxl-rs: emit unquoted interlace-mode in mxlsrc caps

### DIFF
--- a/rust/gst-mxl-rs/src/mxlsrc/mxl_helper.rs
+++ b/rust/gst-mxl-rs/src/mxlsrc/mxl_helper.rs
@@ -57,12 +57,7 @@ pub(crate) fn set_json_caps(src: &MxlSrc, json: FlowDefDetails) -> Result<(), gs
                     "framerate",
                     gst::Fraction::new(video.grain_rate.numerator, video.grain_rate.denominator),
                 )
-                .field(
-                    "interlace-mode",
-                    serde_json::to_string(&video.interlace_mode).map_err(|err| {
-                        gst::loggable_error!(CAT, "Invalid interlace-mode: {}", err)
-                    })?,
-                )
+                .field("interlace-mode", video.interlace_mode.as_str())
                 .field("colorimetry", video.colorspace.to_lowercase())
                 .build();
 

--- a/rust/mxl/src/flow/flowdef.rs
+++ b/rust/mxl/src/flow/flowdef.rs
@@ -50,6 +50,18 @@ pub enum InterlaceMode {
     InterlacedBff,
 }
 
+impl InterlaceMode {
+    /// String form matching the `#[serde(rename = ...)]` wire names, suitable
+    /// for direct use in GStreamer caps (no surrounding JSON quote characters).
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Progressive => "progressive",
+            Self::InterlacedTff => "interlaced_tff",
+            Self::InterlacedBff => "interlaced_bff",
+        }
+    }
+}
+
 impl FromStr for InterlaceMode {
     type Err = ();
 


### PR DESCRIPTION
# Details

`mxlsrc::set_json_caps` was building the video caps' `interlace-mode` field via `serde_json::to_string(&video.interlace_mode)`. Because `InterlaceMode` is a serde enum with `#[serde(rename = "progressive")]` etc., this serialised a single variant to the *JSON encoding* `"progressive"` including the surrounding quote characters, so the caps ended up as `interlace-mode=(string)"\"progressive\""`.

Add `InterlaceMode::as_str()` returning the bare wire name that matches the `#[serde(rename = ...)]` attributes and use it from `set_json_caps`, so the caps contain the unquoted string, e.g. `progressive` that was intended.

This won't be the last PR on this, because those NMOS `interlaced_tff` and `interlaced_bff` values are not appropriate for GStreamer, which wants just `interleaved` for a single buffer containing interlaced fields or `alternate` for a buffer per field.

However, because the policy may end up being to remove all interlaced support from the MXL SDK, I'm not getting into this now.

# Backport requirements

None

<!-- SPDX-FileCopyrightText: 2026 Contributors to the Media eXchange Layer project. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->
