### PR TITLE
Garbage-collect orphan flow directories in Instance constructor

### DIFF
--- a/lib/internal/src/Instance.cpp
+++ b/lib/internal/src/Instance.cpp
@@ -90,6 +90,19 @@ namespace mxl::lib
         std::call_once(loggingFlag, [&]() { initializeLogging(); });
         parseOptions(options);
         MXL_DEBUG("Instance created. MXL Domain: {}", mxlDomain.string());
+
+        // Honour the contract documented for `mxlGarbageCollectFlows` in
+        // `lib/include/mxl/mxl.h` and `docs/Architecture.md`: "automatically
+        // called when the instance is created". A previous writer that died
+        // without releasing its flow (process crash, SIGKILL, host reboot)
+        // leaves its `<flowId>.mxl-flow/` directory on disk; without this
+        // pass, the next `createFlowWriter` would silently re-open those
+        // stale files, and downstream readers would see no fresh data.
+        // `garbageCollect()` is best-effort and swallows its own errors, so
+        // failures here cannot abort instance creation.
+        [[maybe_unused]]
+        auto const collected = garbageCollect();
+        MXL_DEBUG("Garbage-collected {} orphan flow(s) at instance startup.", collected);
     }
 
     Instance::~Instance()

--- a/lib/tests/test_instance.cpp
+++ b/lib/tests/test_instance.cpp
@@ -180,3 +180,30 @@ TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Flow deletion on ins
     mxlDestroyInstance(instanceB);
     REQUIRE_FALSE(flowDirectoryExists(id));
 }
+
+TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "mxlCreateInstance garbage-collects orphan flow directories", "[instance]")
+{
+    // Fabricate a leftover flow directory + `data` file with no flock held,
+    // mimicking the on-disk state a previous writer leaves behind when its
+    // process is killed before the C++ destructor chain can run (SIGKILL,
+    // segfault, host reboot). The public `mxlGarbageCollectFlows` API is
+    // documented to be invoked automatically by `mxlCreateInstance`; this
+    // test pins that contract.
+    auto const orphanId = uuids::to_string(uuids::uuid_system_generator{}());
+    auto const orphanDir = mxl::lib::makeFlowDirectoryName(domain, orphanId);
+    auto const orphanDataFile = mxl::lib::makeFlowDataFilePath(domain, orphanId);
+
+    std::filesystem::create_directories(orphanDir);
+    REQUIRE(flowDirectoryExists(orphanId));
+    // The garbage collector only checks whether the `data` file is flock'd,
+    // not its contents, so an empty file is enough.
+    std::ofstream{orphanDataFile};
+    REQUIRE(std::filesystem::exists(orphanDataFile));
+
+    auto instance = mxlCreateInstance(domain.string().c_str(), nullptr);
+    REQUIRE(instance != nullptr);
+
+    REQUIRE_FALSE(flowDirectoryExists(orphanId));
+
+    REQUIRE(mxlDestroyInstance(instance) == MXL_STATUS_OK);
+}


### PR DESCRIPTION
Resolves #527 

# Details

Invoke `Instance::garbageCollect()` once at the end of the constructor body to honour the documented contract. The call is best-effort: any exception is caught and logged inside `garbageCollect` itself, so a failure here cannot abort instance creation.

Add a Catch2 test that fabricates a leftover `<flowId>.mxl-flow/data` file with no flock held -- the on-disk fingerprint of a crashed writer -- then constructs a fresh instance and asserts the directory is gone.

<!-- SPDX-FileCopyrightText: 2026 Contributors to the Media eXchange Layer project. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- Before submitting a pull request, please check that:
- it has a suitably descriptive title
- it mentions any issue(s) that it addresses
- you have considered whether it should be backported (specify how far back below)
- all commits are signed
-->

# Backport requirements

Maybe?