### PR TITLE
feat(rust): expose garbage_collect_flows

### DIFF
--- a/rust/gst-mxl-rs/src/mxlsink/imp.rs
+++ b/rust/gst-mxl-rs/src/mxlsink/imp.rs
@@ -450,5 +450,12 @@ fn init_mxl_instance(
             )
         })?;
 
+    // Best-effort: reclaim any flow directories left behind by a writer that
+    // exited or crashed before its destructors ran. Long-running processes
+    // get a fresh GC pass every time an element opens an instance.
+    if let Err(e) = mxl_instance.garbage_collect_flows() {
+        gst::warning!(CAT, "MXL garbage collection on init failed: {}", e);
+    }
+
     Ok(mxl_instance)
 }

--- a/rust/gst-mxl-rs/src/mxlsrc/mxl_helper.rs
+++ b/rust/gst-mxl-rs/src/mxlsrc/mxl_helper.rs
@@ -362,5 +362,12 @@ fn init_mxl_instance(domain: &str) -> Result<MxlInstance, gst::ErrorMessage> {
         )
     })?;
 
+    // Best-effort: reclaim any flow directories left behind by a writer that
+    // exited or crashed before its destructors ran. Long-running processes
+    // get a fresh GC pass every time an element opens an instance.
+    if let Err(e) = mxl_instance.garbage_collect_flows() {
+        gst::warning!(CAT, "MXL garbage collection on init failed: {}", e);
+    }
+
     Ok(mxl_instance)
 }

--- a/rust/mxl/src/instance.rs
+++ b/rust/mxl/src/instance.rs
@@ -161,6 +161,23 @@ impl MxlInstance {
             .map_err(|_| Error::Other("Invalid UTF-8 in flow definition".to_string()))
     }
 
+    /// Garbage-collect orphan flow directories in the MXL domain.
+    ///
+    /// Iterates over the domain's `<flowId>.mxl-flow/` directories and removes
+    /// any whose `data` file is no longer flock'd, i.e. that have no live
+    /// writer or reader holding the shared advisory lock. This typically
+    /// happens when a writer process exits or crashes without unwinding its
+    /// destructors (SIGKILL, segfault, host reboot).
+    pub fn garbage_collect_flows(&self) -> Result<()> {
+        unsafe {
+            Error::from_status(
+                self.context
+                    .api
+                    .garbage_collect_flows(self.context.instance),
+            )
+        }
+    }
+
     pub fn get_current_index(&self, rational: &mxl_sys::Rational) -> u64 {
         unsafe { self.context.api.get_current_index(rational) }
     }

--- a/rust/mxl/tests/basic_tests.rs
+++ b/rust/mxl/tests/basic_tests.rs
@@ -158,3 +158,14 @@ fn get_flow_def() {
     drop(flow_writer);
     mxl_instance.destroy().unwrap();
 }
+
+#[test]
+fn garbage_collect_flows_succeeds() {
+    // Smoke test that the `mxlGarbageCollectFlows` FFI binding is wired
+    // correctly. The C++ test suite already exercises the underlying
+    // behaviour; this just confirms the safe wrapper hands the call off
+    // without crashing and propagates a successful status.
+    let (mxl_instance, _domain_guard) = setup_test("garbage_collect_flows");
+    mxl_instance.garbage_collect_flows().unwrap();
+    mxl_instance.destroy().unwrap();
+}


### PR DESCRIPTION
# Details

Wrap the C `mxlGarbageCollectFlows` entry point in a safe Rust method on `MxlInstance`. Long-running applications can use this to reclaim shared memory left behind by writer processes that exited or crashed before their destructors ran (SIGKILL, segfault, host reboot), without having to recreate the instance.

Add a smoke test in `basic_tests.rs` that runs the call on an empty domain to verify the FFI binding is wired correctly; the behavioural contract is covered by the C++ test suite.

Use this feature in the gst-mxl-rs `mxlsrc` and `mxlsink` elements which makes force killing a writer pipeline and relaunching it work correctly.

# Backport requirements

None