### PR TITLE
Remove stale docs on mxlGarbageCollectFlows

### DIFF
--- a/lib/include/mxl/mxl.h
+++ b/lib/include/mxl/mxl.h
@@ -84,8 +84,6 @@ extern "C"
     /// no longer active (in other words, no readers or writers are using them. This typically
     /// happens when an application creating flows writers crashes or exits without cleaning up.
     /// A flow is considered active if a shared advisory lock is held on the data file of the flow.
-    /// This function is automatically called when the instance is created but should be called periodically
-    /// on a long running application to clean up any flows that are no longer active.
     ///
     MXL_EXPORT
     mxlStatus mxlGarbageCollectFlows(mxlInstance in_instance);


### PR DESCRIPTION
# Details

I didn't with a cursory check find any other references to this behaviour, e.g. in `Architecture.md`.

Resolves #527. Alternative to #528.

# Backport requirements

Yes.