### PR TITLE
Include libfabric error code in fabrics Event::Error::toString

### DIFF
--- a/lib/fabrics/ofi/src/internal/Event.cpp
+++ b/lib/fabrics/ofi/src/internal/Event.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "Event.hpp"
+#include <fmt/format.h>
 #include <rdma/fabric.h>
 #include "EventQueue.hpp"
 #include "Exception.hpp"
@@ -69,7 +70,13 @@ namespace mxl::lib::fabrics::ofi
 
     std::string Event::Error::toString() const
     {
-        return ::fi_eq_strerror(_eq->raw(), _providerErr, _errData.data(), nullptr, 0);
+        // _err is the libfabric-level error (FI_E*); _providerErr is set by the
+        // underlying provider (e.g. the tcp provider's errno). Surface both so
+        // callers see the real reason even when the provider has nothing extra
+        // to say (in which case fi_eq_strerror would otherwise return "Success").
+        auto const* fiStr = ::fi_strerror(_err);
+        auto const* provStr = ::fi_eq_strerror(_eq->raw(), _providerErr, _errData.data(), nullptr, 0);
+        return fmt::format("fi_err={} ({}) prov_err={} ({})", _err, fiStr ? fiStr : "", _providerErr, provStr ? provStr : "");
     }
 
     Event::Event(Inner ev)


### PR DESCRIPTION
# Details

`Event::Error::toString()` only renders the provider-specific component via
`fi_eq_strerror()`. When the failure is at the libfabric layer (an `FI_E*`
error with `prov_errno == 0`), `fi_eq_strerror()` returns `"Success"`, so a
real connect failure shows up as a bare `Success` line on every retry and
reads as noise.

Render both `fi_strerror(_err)` and the provider's `fi_eq_strerror()` output,
e.g. `fi_err=111 (Connection refused) prov_err=0 (Success)` instead of just
`Success`.

Downstream tracking: qvest-digital/go-mxl#51.

# Backport requirements

None
