### PR TITLE
Add optional target info file output/input to fabrics demo app

### DIFF
--- a/tools/mxl-fabrics-demo/demo.cpp
+++ b/tools/mxl-fabrics-demo/demo.cpp
@@ -796,8 +796,8 @@ int main(int argc, char** argv)
         std::string flowDescriptor{std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>()};
         mxl::lib::FlowParser descriptorParser{flowDescriptor};
 
-        std::string resolvedTargetInfo;
-        if (!targetInfo.empty() && targetInfo[0] == '@')
+        auto resolvedTargetInfo = std::string{};
+        if (!targetInfo.empty() && targetInfo.starts_with('@'))
         {
             // Read raw target info from file
             auto filePath = std::string{targetInfo.begin() + 1, targetInfo.end()};

--- a/tools/mxl-fabrics-demo/demo.cpp
+++ b/tools/mxl-fabrics-demo/demo.cpp
@@ -552,6 +552,7 @@ public:
             MXL_ERROR("Failed to convert target info to string with status '{}'", static_cast<int>(status));
             return status;
         }
+        targetInfoStr.pop_back();
 
         MXL_INFO("Target info:  {}", base64::to_base64(targetInfoStr));
 

--- a/tools/mxl-fabrics-demo/demo.cpp
+++ b/tools/mxl-fabrics-demo/demo.cpp
@@ -557,7 +557,7 @@ public:
 
         if (!targetInfoFile.empty())
         {
-            std::ofstream of{targetInfoFile};
+            auto of = std::ofstream{targetInfoFile};
             of << targetInfoStr;
             if (of.fail())
             {
@@ -799,8 +799,8 @@ int main(int argc, char** argv)
         if (!targetInfo.empty() && targetInfo[0] == '@')
         {
             // Read raw target info from file
-            std::string filePath{targetInfo.begin() + 1, targetInfo.end()};
-            std::ifstream of{filePath};
+            auto filePath = std::string{targetInfo.begin() + 1, targetInfo.end()};
+            auto of = std::ifstream{filePath};
             if (of.fail())
             {
                 MXL_ERROR("Failed to open target info file '{}'", filePath);

--- a/tools/mxl-fabrics-demo/demo.cpp
+++ b/tools/mxl-fabrics-demo/demo.cpp
@@ -6,6 +6,7 @@
 #include <csignal>
 #include <cstdint>
 #include <cstdlib>
+#include <fstream>
 #include <optional>
 #include <string>
 #include <uuid.h>
@@ -17,7 +18,6 @@
 #include <mxl/flow.h>
 #include <mxl/mxl.h>
 #include <mxl/time.h>
-#include "CLI/CLI.hpp"
 #include "mxl/dataformat.h"
 #include "mxl/flowinfo.h"
 #include "../../lib/fabrics/ofi/src/internal/Base64.hpp"
@@ -533,7 +533,7 @@ public:
         return MXL_STATUS_OK;
     }
 
-    mxlStatus printInfo()
+    mxlStatus printInfo(std::string const& targetInfoFile = {})
     {
         auto targetInfoStr = std::string{};
         size_t targetInfoStrSize;
@@ -554,6 +554,17 @@ public:
         }
 
         MXL_INFO("Target info:  {}", base64::to_base64(targetInfoStr));
+
+        if (!targetInfoFile.empty())
+        {
+            std::ofstream of{targetInfoFile};
+            of << targetInfoStr;
+            if (of.fail())
+            {
+                MXL_ERROR("Failed to write target info to '{}'", targetInfoFile);
+                return MXL_ERR_INTERNAL;
+            }
+        }
 
         return MXL_STATUS_OK;
     }
@@ -758,8 +769,8 @@ int main(int argc, char** argv)
     std::string targetInfo;
     app.add_option("--target-info",
         targetInfo,
-        "The target information. This is used when configured as an initiator . This is the target information to send to."
-        "You first start the target and it will print the targetInfo that you paste to this argument");
+        "As target: output file path for raw target info (optional, always logged as base64). "
+        "As initiator: base64-encoded target info, or a path prefixed with '@' to read raw target info from a file.");
 
     CLI11_PARSE(app, argc, argv);
 
@@ -784,6 +795,24 @@ int main(int argc, char** argv)
         std::string flowDescriptor{std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>()};
         mxl::lib::FlowParser descriptorParser{flowDescriptor};
 
+        std::string resolvedTargetInfo;
+        if (!targetInfo.empty() && targetInfo[0] == '@')
+        {
+            // Read raw target info from file
+            std::string filePath{targetInfo.begin() + 1, targetInfo.end()};
+            std::ifstream of{filePath};
+            if (of.fail())
+            {
+                MXL_ERROR("Failed to open target info file '{}'", filePath);
+                return MXL_ERR_INTERNAL;
+            }
+            resolvedTargetInfo = std::string{std::istreambuf_iterator<char>{of}, std::istreambuf_iterator<char>{}};
+        }
+        else
+        {
+            resolvedTargetInfo = base64::from_base64(targetInfo);
+        }
+
         auto app = AppInitator{
             Config{
                    .domain = domain,
@@ -794,7 +823,7 @@ int main(int argc, char** argv)
                    },
         };
 
-        if (status = app.setup(base64::from_base64(targetInfo)); status != MXL_STATUS_OK)
+        if (status = app.setup(resolvedTargetInfo); status != MXL_STATUS_OK)
         {
             MXL_ERROR("Failed to setup initiator with status '{}'", static_cast<int>(status));
             return status;
@@ -849,7 +878,7 @@ int main(int argc, char** argv)
             return status;
         }
 
-        if (status = app.printInfo(); status != MXL_STATUS_OK)
+        if (status = app.printInfo(targetInfo); status != MXL_STATUS_OK)
         {
             MXL_ERROR("Failed to print target info with status '{}'", static_cast<int>(status));
             return status;

--- a/tools/mxl-fabrics-demo/demo.cpp
+++ b/tools/mxl-fabrics-demo/demo.cpp
@@ -878,7 +878,8 @@ int main(int argc, char** argv)
             return status;
         }
 
-        if (status = app.printInfo(targetInfo); status != MXL_STATUS_OK)
+        auto targetInfoPath = targetInfo.empty() || targetInfo[0] != '@' ? targetInfo : std::string{targetInfo.begin() + 1, targetInfo.end()};
+        if (status = app.printInfo(targetInfoPath); status != MXL_STATUS_OK)
         {
             MXL_ERROR("Failed to print target info with status '{}'", static_cast<int>(status));
             return status;


### PR DESCRIPTION
# Details
Extend the `--target-info` command line option of the fabrics demo app. Existing apps should not break through this change.

Before, on the target side this option was ignored. Now it can specify a file to which the target info should be written. It is still always logged as base64. A leading '@' is stripped from the path if put there accidentally.

On the initiator, it will still parse the command line option as a base64-encoded target info blob. But when prefixed with an '@', it will instead read a raw target info string from a file at the path following the '@'.

Example:
```bash
# Target
mxl-fabrics-demo -d /dev/shm (...) --target-info [@]target.json  # Written to target.json
mxl-fabrics-demo -d /dev/shm (...)                               # Still visible in the log

# Initiator
mxl-fabrics-demo -d /dev/shm (...) --target-info @target.json                  # Read from target.json
mxl-fabrics-demo -d /dev/shm (...) --target-info "$(base64 -w0 < target.json)" # Command line arg interpreted as base64 target info
```


# Backport requirements
Nope.