### PR TITLE
Use lychee directly for docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -79,11 +79,12 @@ jobs:
         run: ./.github/scripts/prepare-docs.sh
 
       - run: zensical build --clean
-
+      
+      - name: Install lychee
+        run: sudo snap install lychee
+          
       - name: Check for broken links with lychee
-        uses: lycheeverse/lychee-action@v2.0.2
-        with:
-          args: "./site/**/*.html --root-dir ./site"
+        run: lychee --root-dir ./site --verbose --no-progress --accept '100..=103,200..=299,403' './site/**/*.html'
 
       # Configure git for mike to push to gh-pages
       - name: Configure git for mike

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Check for broken links with lychee
         uses: lycheeverse/lychee-action@v2.0.2
         with:
-          args: ./site/**/*.html -- --root-dir ./site
+          args: "./site/**/*.html --root-dir ./site"
 
       # Configure git for mike to push to gh-pages
       - name: Configure git for mike


### PR DESCRIPTION
# Details

#546 caused some lychee argument passing problems with lychee-action v2, which made the workflow fail, so instead installing lychee directly.

Using snap install (not ideal I know) because cargo install takes too long. If there's a running with cargo binstall installed we can use that.

# Backport requirements

No