### PR TITLE
Capabilities API preparation

### DIFF
--- a/lib/fabrics/include/mxl/fabrics.h
+++ b/lib/fabrics/include/mxl/fabrics.h
@@ -84,7 +84,7 @@ extern "C"
     {
         int version;                       /**< Struct version, must be set to MXL_FABRICS_API_VERSION by the caller. */
         mxlFabricsProvider provider;       /**< The provider that the interface can be used with */
-        mxlFabricsCaps_t caps;             /**< Interface capabilities */
+        mxlFabricsCaps caps;               /**< Interface capabilities */
         mxlFabricsEndpointAddress address; /**< Address (node/service) of this interface */
 
         /**

--- a/lib/fabrics/include/mxl/fabrics.h
+++ b/lib/fabrics/include/mxl/fabrics.h
@@ -71,7 +71,7 @@ extern "C"
         MXL_FABRICS_IFACE_CAP_SEND_RECEIVE = MXL_FABRICS_FLAG(2),        /**< The interface supports send/receive type operations */
     } mxlFabricsInterfaceCapFlags;
 
-    /** */
+    /** Capabilities of an interface */
     typedef struct mxlFabricsCaps_t
     {
         int version;             /**< Struct version, must be set to MXL_FABRICS_API_VERSION by the caller. */
@@ -79,6 +79,7 @@ extern "C"
         uint64_t maxMessageSize; /**< Maximum message size supported on this interface. */
     } mxlFabricsCaps;
 
+    /** Fabric interface configuration */
     typedef struct mxlFabricsInterfaceConfig_t
     {
         int version;                       /**< Struct version, must be set to MXL_FABRICS_API_VERSION by the caller. */

--- a/lib/fabrics/include/mxl/fabrics.h
+++ b/lib/fabrics/include/mxl/fabrics.h
@@ -45,7 +45,8 @@ extern "C"
 
     typedef enum mxlFabricsProvider_t
     {
-        MXL_FABRICS_PROVIDER_ANY = 0,   /**< Auto select the best provider. ** This might not be supported by all implementations. */
+        MXL_FABRICS_PROVIDER_ANY = 0,   /**< Auto select the best provider. ** This might not be supported by all implementations. Currently this
+                                           allways falls back to the TCP provider. */
         MXL_FABRICS_PROVIDER_TCP = 1,   /**< Provider that uses linux tcp sockets. */
         MXL_FABRICS_PROVIDER_VERBS = 2, /**< Provider for userspace verbs (libibverbs) and librdmcm for connection management. */
         MXL_FABRICS_PROVIDER_EFA = 3,   /**< Provider for AWS Elastic Fabric Adapter. */

--- a/lib/fabrics/include/mxl/fabrics.h
+++ b/lib/fabrics/include/mxl/fabrics.h
@@ -17,6 +17,7 @@
 #include <mxl/platform.h>
 
 #define MXL_FABRICS_API_VERSION 0 /**< Version of the API defined by this header. */
+#define MXL_FABRICS_FLAG(n)     (1 << n)
 
 #ifdef __cplusplus
 extern "C"
@@ -44,7 +45,7 @@ extern "C"
 
     typedef enum mxlFabricsProvider_t
     {
-        MXL_FABRICS_PROVIDER_AUTO = 0,  /**< Auto select the best provider. ** This might not be supported by all implementations. */
+        MXL_FABRICS_PROVIDER_ANY = 0,   /**< Auto select the best provider. ** This might not be supported by all implementations. */
         MXL_FABRICS_PROVIDER_TCP = 1,   /**< Provider that uses linux tcp sockets. */
         MXL_FABRICS_PROVIDER_VERBS = 2, /**< Provider for userspace verbs (libibverbs) and librdmcm for connection management. */
         MXL_FABRICS_PROVIDER_EFA = 3,   /**< Provider for AWS Elastic Fabric Adapter. */
@@ -63,24 +64,52 @@ extern "C"
         char const* service;
     } mxlFabricsEndpointAddress;
 
+    typedef enum mxlFabricsInterfaceCapFlags_t
+    {
+        MXL_FABRICS_IFACE_CAP_BLOCKING_OPERATIONS = MXL_FABRICS_FLAG(0), /**< The interface supports blocking operations */
+        MXL_FABRICS_IFACE_CAP_REMOTE_WRITE = MXL_FABRICS_FLAG(1),        /**< The interface supports remote-write operations */
+        MXL_FABRICS_IFACE_CAP_SEND_RECEIVE = MXL_FABRICS_FLAG(2),        /**< The interface supports send/receive type operations */
+    } mxlFabricsInterfaceCapFlags;
+
+    /** */
+    typedef struct mxlFabricsCaps_t
+    {
+        int version;             /**< Struct version, must be set to MXL_FABRICS_API_VERSION by the caller. */
+        uint64_t flags;          /**< Capabilities expressed as binary flags. Value can be a bitset of any of mxlFabricsInterfaceCapFlags */
+        uint64_t maxMessageSize; /**< Maximum message size supported on this interface. */
+    } mxlFabricsCaps;
+
+    typedef struct mxlFabricsInterfaceConfig_t
+    {
+        int version;                       /**< Struct version, must be set to MXL_FABRICS_API_VERSION by the caller. */
+        mxlFabricsProvider provider;       /**< The provider that the interface can be used with */
+        mxlFabricsCaps_t caps;             /**< Interface capabilities */
+        mxlFabricsEndpointAddress address; /**< Address (node/service) of this interface */
+
+        /**
+         * Extra information about the interface in a json document. Provided on a best-effort basis. Not all fields are available on certain
+         * platforms and hardware.
+         * Only provided by a call to mxlFabricsGetInterfaces, and ignored when provided through a setup function.
+         */
+        char const* attr;
+    } mxlFabricsInterfaceConfig;
+
     /** Configuration object required to set up a new target.
      */
     typedef struct mxlFabricsTargetConfig_t
     {
-        int version;                               /**< Struct version, must be set to MXL_FABRICS_API_VERSION by the caller */
-        mxlFabricsEndpointAddress endpointAddress; /**< Bind address for the local endpoint. */
-        mxlFabricsProvider provider;               /**< The provider that should be used */
-        mxlFlowWriter writer;                      /**< A flow writer for the flow that should be written to by remote initiators */
+        int version;                         /**< Struct version, must be set to MXL_FABRICS_API_VERSION by the caller */
+        mxlFabricsInterfaceConfig interface; /**< Bind address for the local endpoint. */
+        mxlFlowWriter writer;                /**< A flow writer for the flow that should be written to by remote initiators */
     } mxlFabricsTargetConfig;
 
     /** Configuration object required to set up an initiator.
      */
     typedef struct mxlFabricsInitiatorConfig_t
     {
-        int version;                               /**< Struct version, must be set to MXL_FABRICS_API_VERSION by the caller */
-        mxlFabricsEndpointAddress endpointAddress; /**< Bind address for the local endpoint. */
-        mxlFabricsProvider provider;               /**< The provider that should be used. */
-        mxlFlowReader reader;                      /**< A flow reader that will be used as the source of write operations to remote targets. */
+        int version;                         /**< Struct version, must be set to MXL_FABRICS_API_VERSION by the caller */
+        mxlFabricsInterfaceConfig interface; /**< Bind address for the local endpoint. */
+        mxlFlowReader reader;                /**< A flow reader that will be used as the source of write operations to remote targets. */
     } mxlFabricsInitiatorConfig;
 
     /**

--- a/lib/fabrics/ofi/src/fabrics.cpp
+++ b/lib/fabrics/ofi/src/fabrics.cpp
@@ -481,7 +481,7 @@ mxlStatus mxlFabricsProviderToString(mxlFabricsProvider in_provider, char* out_s
 
             switch (in_provider)
             {
-                case MXL_FABRICS_PROVIDER_AUTO:  return providerEnumValueToString(out_string, in_out_stringSize, "auto");
+                case MXL_FABRICS_PROVIDER_ANY:   return providerEnumValueToString(out_string, in_out_stringSize, "any");
                 case MXL_FABRICS_PROVIDER_TCP:   return providerEnumValueToString(out_string, in_out_stringSize, "tcp");
                 case MXL_FABRICS_PROVIDER_EFA:   return providerEnumValueToString(out_string, in_out_stringSize, "efa");
                 case MXL_FABRICS_PROVIDER_VERBS: return providerEnumValueToString(out_string, in_out_stringSize, "verbs");

--- a/lib/fabrics/ofi/src/internal/Format.hpp
+++ b/lib/fabrics/ofi/src/internal/Format.hpp
@@ -24,7 +24,7 @@ struct fmt::formatter<mxlFabricsProvider>
     {
         switch (provider)
         {
-            case MXL_FABRICS_PROVIDER_AUTO:  return fmt::format_to(ctx.out(), "auto");
+            case MXL_FABRICS_PROVIDER_ANY:   return fmt::format_to(ctx.out(), "any");
             case MXL_FABRICS_PROVIDER_TCP:   return fmt::format_to(ctx.out(), "tcp");
             case MXL_FABRICS_PROVIDER_VERBS: return fmt::format_to(ctx.out(), "verbs");
             case MXL_FABRICS_PROVIDER_EFA:   return fmt::format_to(ctx.out(), "efa");

--- a/lib/fabrics/ofi/src/internal/Initiator.cpp
+++ b/lib/fabrics/ofi/src/internal/Initiator.cpp
@@ -28,9 +28,9 @@ namespace mxl::lib::fabrics::ofi
             _inner.reset();
         }
 
-        switch (config.provider)
+        switch (config.interface.provider)
         {
-            case MXL_FABRICS_PROVIDER_AUTO:
+            case MXL_FABRICS_PROVIDER_ANY:
             case MXL_FABRICS_PROVIDER_TCP:
             case MXL_FABRICS_PROVIDER_VERBS:
             {

--- a/lib/fabrics/ofi/src/internal/Provider.cpp
+++ b/lib/fabrics/ofi/src/internal/Provider.cpp
@@ -34,7 +34,7 @@ namespace mxl::lib::fabrics::ofi
     {
         switch (api)
         {
-            case MXL_FABRICS_PROVIDER_ANY:
+            case MXL_FABRICS_PROVIDER_ANY:   [[fallthrough]];
             case MXL_FABRICS_PROVIDER_TCP:   return Provider::TCP;
             case MXL_FABRICS_PROVIDER_VERBS: return Provider::VERBS;
             case MXL_FABRICS_PROVIDER_EFA:   return Provider::EFA;

--- a/lib/fabrics/ofi/src/internal/Provider.cpp
+++ b/lib/fabrics/ofi/src/internal/Provider.cpp
@@ -27,14 +27,14 @@ namespace mxl::lib::fabrics::ofi
             case Provider::SHM:   return MXL_FABRICS_PROVIDER_SHM;
         }
 
-        return MXL_FABRICS_PROVIDER_AUTO;
+        return MXL_FABRICS_PROVIDER_ANY;
     }
 
     std::optional<Provider> providerFromAPI(mxlFabricsProvider api) noexcept
     {
         switch (api)
         {
-            case MXL_FABRICS_PROVIDER_AUTO:
+            case MXL_FABRICS_PROVIDER_ANY:
             case MXL_FABRICS_PROVIDER_TCP:   return Provider::TCP;
             case MXL_FABRICS_PROVIDER_VERBS: return Provider::VERBS;
             case MXL_FABRICS_PROVIDER_EFA:   return Provider::EFA;

--- a/lib/fabrics/ofi/src/internal/RCInitiator.cpp
+++ b/lib/fabrics/ofi/src/internal/RCInitiator.cpp
@@ -270,7 +270,7 @@ namespace mxl::lib::fabrics::ofi
 
     std::unique_ptr<RCInitiator> RCInitiator::setup(mxlFabricsInitiatorConfig const& config)
     {
-        auto provider = providerFromAPI(config.provider);
+        auto provider = providerFromAPI(config.interface.provider);
         if (!provider)
         {
             throw Exception::make(MXL_ERR_NO_FABRIC, "No provider available");
@@ -279,7 +279,7 @@ namespace mxl::lib::fabrics::ofi
         uint64_t caps = FI_RMA | FI_WRITE | FI_REMOTE_WRITE;
         // To enable device memory support:
         // caps |=  FI_HMEM;
-        auto fabricInfoList = FabricInfoList::get(config.endpointAddress.node, config.endpointAddress.service, provider.value(), caps, FI_EP_MSG);
+        auto fabricInfoList = FabricInfoList::get(config.interface.address.node, config.interface.address.service, provider.value(), caps, FI_EP_MSG);
 
         if (fabricInfoList.begin() == fabricInfoList.end())
         {

--- a/lib/fabrics/ofi/src/internal/RCTarget.cpp
+++ b/lib/fabrics/ofi/src/internal/RCTarget.cpp
@@ -28,13 +28,13 @@ namespace mxl::lib::fabrics::ofi
         // it as the exception out of setup() instead of MXL_ERR_NO_FABRIC, masking the real
         // failure. Substitute a printable sentinel for formatting only — the original
         // pointers still go to fi_getinfo so the wildcard semantics are preserved.
-        char const* const nodeStr = config.endpointAddress.node ? config.endpointAddress.node : "<unspecified>";
-        char const* const serviceStr = config.endpointAddress.service ? config.endpointAddress.service : "<unspecified>";
+        char const* const nodeStr = config.interface.address.node ? config.interface.address.node : "<unspecified>";
+        char const* const serviceStr = config.interface.address.service ? config.interface.address.service : "<unspecified>";
 
-        MXL_INFO("setting up target [endpoint = {}:{}, provider = {}]", nodeStr, serviceStr, config.provider);
+        MXL_INFO("setting up target [endpoint = {}:{}, provider = {}]", nodeStr, serviceStr, config.interface.provider);
 
         // Convert to our internal enum type.
-        auto provider = providerFromAPI(config.provider);
+        auto provider = providerFromAPI(config.interface.provider);
         if (!provider)
         {
             throw Exception::invalidArgument("Invalid provider passed");
@@ -44,11 +44,11 @@ namespace mxl::lib::fabrics::ofi
         std::uint64_t caps = FI_RMA | FI_REMOTE_WRITE;
         // To enable device memory support:
         // caps |=  FI_HMEM;
-        auto fabricInfoList = FabricInfoList::get(config.endpointAddress.node, config.endpointAddress.service, provider.value(), caps, FI_EP_MSG);
+        auto fabricInfoList = FabricInfoList::get(config.interface.address.node, config.interface.address.service, provider.value(), caps, FI_EP_MSG);
 
         if (fabricInfoList.begin() == fabricInfoList.end())
         {
-            throw Exception::make(MXL_ERR_NO_FABRIC, "No fabric available for provider {} at {}:{}", config.provider, nodeStr, serviceStr);
+            throw Exception::make(MXL_ERR_NO_FABRIC, "No fabric available for provider {} at {}:{}", config.interface.provider, nodeStr, serviceStr);
         }
 
         // Open fabric and domain. These represent the context of the local network fabric adapter that will be used

--- a/lib/fabrics/ofi/src/internal/RDMInitiator.cpp
+++ b/lib/fabrics/ofi/src/internal/RDMInitiator.cpp
@@ -119,7 +119,7 @@ namespace mxl::lib::fabrics::ofi
 
     std::unique_ptr<RDMInitiator> RDMInitiator::setup(mxlFabricsInitiatorConfig const& config)
     {
-        auto provider = providerFromAPI(config.provider);
+        auto provider = providerFromAPI(config.interface.provider);
         if (!provider)
         {
             throw Exception::make(MXL_ERR_NO_FABRIC, "No provider available.");
@@ -128,7 +128,7 @@ namespace mxl::lib::fabrics::ofi
         auto caps = FI_RMA | FI_WRITE;
         // To enable device memory support:
         // caps |=  FI_HMEM;
-        auto fabricInfoList = FabricInfoList::get(config.endpointAddress.node, config.endpointAddress.service, provider.value(), caps, FI_EP_RDM);
+        auto fabricInfoList = FabricInfoList::get(config.interface.address.node, config.interface.address.service, provider.value(), caps, FI_EP_RDM);
         if (fabricInfoList.begin() == fabricInfoList.end())
         {
             throw Exception::make(MXL_ERR_NO_FABRIC, "No suitable fabric available");

--- a/lib/fabrics/ofi/src/internal/RDMTarget.cpp
+++ b/lib/fabrics/ofi/src/internal/RDMTarget.cpp
@@ -24,12 +24,12 @@ namespace mxl::lib::fabrics::ofi
         // throws fmt::format_error("string pointer is null") on a nullptr, which MXL_INFO
         // silently swallows. Substitute a printable sentinel for the log only — the original
         // pointers still go to fi_getinfo so the wildcard semantics are preserved.
-        char const* const nodeStr = config.endpointAddress.node ? config.endpointAddress.node : "<unspecified>";
-        char const* const serviceStr = config.endpointAddress.service ? config.endpointAddress.service : "<unspecified>";
+        char const* const nodeStr = config.interface.address.node ? config.interface.address.node : "<unspecified>";
+        char const* const serviceStr = config.interface.address.service ? config.interface.address.service : "<unspecified>";
 
-        MXL_INFO("setting up target [endpoint = {}:{}, provider = {}]", nodeStr, serviceStr, config.provider);
+        MXL_INFO("setting up target [endpoint = {}:{}, provider = {}]", nodeStr, serviceStr, config.interface.provider);
 
-        auto provider = providerFromAPI(config.provider);
+        auto provider = providerFromAPI(config.interface.provider);
         if (!provider)
         {
             throw Exception::invalidArgument("Invalid provider specified");
@@ -38,7 +38,7 @@ namespace mxl::lib::fabrics::ofi
         std::uint64_t caps = FI_RMA | FI_REMOTE_WRITE;
         // To enable device memory support:
         // caps |=  FI_HMEM;
-        auto fabricInfoList = FabricInfoList::get(config.endpointAddress.node, config.endpointAddress.service, provider.value(), caps, FI_EP_RDM);
+        auto fabricInfoList = FabricInfoList::get(config.interface.address.node, config.interface.address.service, provider.value(), caps, FI_EP_RDM);
         if (fabricInfoList.begin() == fabricInfoList.end())
         {
             throw Exception::make(MXL_ERR_NO_FABRIC, "No suitable fabric available");

--- a/lib/fabrics/ofi/src/internal/Target.cpp
+++ b/lib/fabrics/ofi/src/internal/Target.cpp
@@ -82,10 +82,10 @@ namespace mxl::lib::fabrics::ofi
             _inner.reset();
         }
 
-        switch (config.provider)
+        switch (config.interface.provider)
         {
-            case MXL_FABRICS_PROVIDER_AUTO: [[fallthrough]];
-            case MXL_FABRICS_PROVIDER_TCP:  [[fallthrough]];
+            case MXL_FABRICS_PROVIDER_ANY: [[fallthrough]];
+            case MXL_FABRICS_PROVIDER_TCP: [[fallthrough]];
             case MXL_FABRICS_PROVIDER_VERBS:
             {
                 auto [target, info] = RCTarget::setup(config);

--- a/lib/tests/fabrics/ofi/Util.hpp
+++ b/lib/tests/fabrics/ofi/Util.hpp
@@ -24,9 +24,9 @@ namespace mxl::lib::fabrics::ofi
     inline mxlFabricsTargetConfig getDefaultTargetConfig(mxlFlowWriter writer)
     {
         auto config = mxlFabricsTargetConfig{};
-        config.endpointAddress.node = "127.0.0.1";
-        config.endpointAddress.service = "9090";
-        config.provider = MXL_FABRICS_PROVIDER_TCP;
+        config.interface.address.node = "127.0.0.1";
+        config.interface.address.service = "9090";
+        config.interface.provider = MXL_FABRICS_PROVIDER_TCP;
         config.writer = writer;
         return config;
     }
@@ -34,9 +34,9 @@ namespace mxl::lib::fabrics::ofi
     inline mxlFabricsInitiatorConfig getDefaultInitiatorConfig(mxlFlowReader reader)
     {
         auto config = mxlFabricsInitiatorConfig{};
-        config.endpointAddress.node = "127.0.0.1";
-        config.endpointAddress.service = "9091";
-        config.provider = MXL_FABRICS_PROVIDER_TCP;
+        config.interface.address.node = "127.0.0.1";
+        config.interface.address.service = "9091";
+        config.interface.provider = MXL_FABRICS_PROVIDER_TCP;
         config.reader = reader;
         return config;
     }

--- a/lib/tests/fabrics/test_basics.cpp
+++ b/lib/tests/fabrics/test_basics.cpp
@@ -224,7 +224,11 @@ TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Fabrics connection o
     {
         auto targetConfig = mxlFabricsTargetConfig{
             .version = MXL_FABRICS_API_VERSION,
-            .interface = {.version = MXL_FABRICS_API_VERSION, .provider = MXL_FABRICS_PROVIDER_TCP, .caps = {}, .address = {.node = "127.0.0.1", .service = "0"}, .attr = nullptr},
+            .interface = {.version = MXL_FABRICS_API_VERSION,
+                          .provider = MXL_FABRICS_PROVIDER_TCP,
+                          .caps = {},
+                          .address = {.node = "127.0.0.1", .service = "0"},
+                          .attr = nullptr},
             .writer = writer,
         };
         mxlFabricsTargetInfo targetInfo;
@@ -232,7 +236,11 @@ TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Fabrics connection o
 
         auto initiatorConfig = mxlFabricsInitiatorConfig{
             .version = MXL_FABRICS_API_VERSION,
-            .interface = {.version = MXL_FABRICS_API_VERSION, .provider = MXL_FABRICS_PROVIDER_TCP, .caps = {}, .address = {.node = "127.0.0.1", .service = "0"}, .attr = nullptr},
+            .interface = {.version = MXL_FABRICS_API_VERSION,
+                          .provider = MXL_FABRICS_PROVIDER_TCP,
+                          .caps = {},
+                          .address = {.node = "127.0.0.1", .service = "0"},
+                          .attr = nullptr},
             .reader = reader,
         };
         REQUIRE(mxlFabricsInitiatorSetup(initiator, &initiatorConfig, nullptr) == MXL_STATUS_OK);
@@ -294,7 +302,11 @@ TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Fabrics connectionle
 
     auto targetConfig = mxlFabricsTargetConfig{
         .version = MXL_FABRICS_API_VERSION,
-        .interface = {.version = MXL_FABRICS_API_VERSION, .provider = MXL_FABRICS_PROVIDER_SHM, .caps = {}, .address = {.node = "target", .service = "activation"}, .attr = nullptr},
+        .interface = {.version = MXL_FABRICS_API_VERSION,
+                      .provider = MXL_FABRICS_PROVIDER_SHM,
+                      .caps = {},
+                      .address = {.node = "target", .service = "activation"},
+                      .attr = nullptr},
         .writer = writer,
     };
     mxlFabricsTargetInfo targetInfo;
@@ -302,7 +314,11 @@ TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Fabrics connectionle
 
     auto initiatorConfig = mxlFabricsInitiatorConfig{
         .version = MXL_FABRICS_API_VERSION,
-        .interface = {.version = MXL_FABRICS_API_VERSION, .provider = MXL_FABRICS_PROVIDER_SHM, .caps = {}, .address = {.node = "initiator", .service = "activation"}, .attr = nullptr},
+        .interface = {.version = MXL_FABRICS_API_VERSION,
+                      .provider = MXL_FABRICS_PROVIDER_SHM,
+                      .caps = {},
+                      .address = {.node = "initiator", .service = "activation"},
+                      .attr = nullptr},
         .reader = reader,
     };
     REQUIRE(mxlFabricsInitiatorSetup(initiator, &initiatorConfig, nullptr) == MXL_STATUS_OK);
@@ -364,7 +380,11 @@ TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Fabrics: Transfer Gr
     {
         auto targetConfig = mxlFabricsTargetConfig{
             .version = MXL_FABRICS_API_VERSION,
-            .interface = {.version = MXL_FABRICS_API_VERSION, .provider = MXL_FABRICS_PROVIDER_TCP, .caps = {}, .address = {.node = "127.0.0.1", .service = "0"}, .attr = nullptr},
+            .interface = {.version = MXL_FABRICS_API_VERSION,
+                          .provider = MXL_FABRICS_PROVIDER_TCP,
+                          .caps = {},
+                          .address = {.node = "127.0.0.1", .service = "0"},
+                          .attr = nullptr},
             .writer = writer,
         };
         mxlFabricsTargetInfo targetInfo;
@@ -372,7 +392,11 @@ TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Fabrics: Transfer Gr
 
         auto initiatorConfig = mxlFabricsInitiatorConfig{
             .version = MXL_FABRICS_API_VERSION,
-            .interface = {.version = MXL_FABRICS_API_VERSION, .provider = MXL_FABRICS_PROVIDER_TCP, .caps = {}, .address = {.node = "127.0.0.1", .service = "0"}, .attr = nullptr},
+            .interface = {.version = MXL_FABRICS_API_VERSION,
+                          .provider = MXL_FABRICS_PROVIDER_TCP,
+                          .caps = {},
+                          .address = {.node = "127.0.0.1", .service = "0"},
+                          .attr = nullptr},
             .reader = reader,
         };
         REQUIRE(mxlFabricsInitiatorSetup(initiator, &initiatorConfig, nullptr) == MXL_STATUS_OK);
@@ -412,7 +436,11 @@ TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Fabrics: Transfer Gr
     {
         auto targetConfig = mxlFabricsTargetConfig{
             .version = MXL_FABRICS_API_VERSION,
-            .interface = {.version = MXL_FABRICS_API_VERSION, .provider = MXL_FABRICS_PROVIDER_SHM, .caps = {}, .address = {.node = "target", .service = "test"}, .attr = nullptr},
+            .interface = {.version = MXL_FABRICS_API_VERSION,
+                          .provider = MXL_FABRICS_PROVIDER_SHM,
+                          .caps = {},
+                          .address = {.node = "target", .service = "test"},
+                          .attr = nullptr},
             .writer = writer,
         };
         mxlFabricsTargetInfo targetInfo;
@@ -420,7 +448,11 @@ TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Fabrics: Transfer Gr
 
         auto initiatorConfig = mxlFabricsInitiatorConfig{
             .version = MXL_FABRICS_API_VERSION,
-            .interface = {.version = MXL_FABRICS_API_VERSION, .provider = MXL_FABRICS_PROVIDER_SHM, .caps = {}, .address = {.node = "initiator", .service = "test"}, .attr = nullptr},
+            .interface = {.version = MXL_FABRICS_API_VERSION,
+                          .provider = MXL_FABRICS_PROVIDER_SHM,
+                          .caps = {},
+                          .address = {.node = "initiator", .service = "test"},
+                          .attr = nullptr},
             .reader = reader,
         };
         REQUIRE(mxlFabricsInitiatorSetup(initiator, &initiatorConfig, nullptr) == MXL_STATUS_OK);
@@ -491,7 +523,11 @@ TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Fabrics: Transfer Sa
     {
         auto targetConfig = mxlFabricsTargetConfig{
             .version = MXL_FABRICS_API_VERSION,
-            .interface = {.version = MXL_FABRICS_API_VERSION, .provider = MXL_FABRICS_PROVIDER_TCP, .caps = {}, .address = {.node = "127.0.0.1", .service = "0"}, .attr = nullptr},
+            .interface = {.version = MXL_FABRICS_API_VERSION,
+                          .provider = MXL_FABRICS_PROVIDER_TCP,
+                          .caps = {},
+                          .address = {.node = "127.0.0.1", .service = "0"},
+                          .attr = nullptr},
             .writer = writer,
         };
         mxlFabricsTargetInfo targetInfo;
@@ -499,7 +535,11 @@ TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Fabrics: Transfer Sa
 
         auto initiatorConfig = mxlFabricsInitiatorConfig{
             .version = MXL_FABRICS_API_VERSION,
-            .interface = {.version = MXL_FABRICS_API_VERSION, .provider = MXL_FABRICS_PROVIDER_TCP, .caps = {}, .address = {.node = "127.0.0.1", .service = "0"}, .attr = nullptr},
+            .interface = {.version = MXL_FABRICS_API_VERSION,
+                          .provider = MXL_FABRICS_PROVIDER_TCP,
+                          .caps = {},
+                          .address = {.node = "127.0.0.1", .service = "0"},
+                          .attr = nullptr},
             .reader = reader,
         };
         REQUIRE(mxlFabricsInitiatorSetup(initiator, &initiatorConfig, nullptr) == MXL_STATUS_OK);
@@ -540,7 +580,11 @@ TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Fabrics: Transfer Sa
     {
         auto targetConfig = mxlFabricsTargetConfig{
             .version = MXL_FABRICS_API_VERSION,
-            .interface = {.version = MXL_FABRICS_API_VERSION, .provider = MXL_FABRICS_PROVIDER_SHM, .caps = {}, .address = {.node = "target", .service = "test"}, .attr = nullptr},
+            .interface = {.version = MXL_FABRICS_API_VERSION,
+                          .provider = MXL_FABRICS_PROVIDER_SHM,
+                          .caps = {},
+                          .address = {.node = "target", .service = "test"},
+                          .attr = nullptr},
             .writer = writer,
         };
         mxlFabricsTargetInfo targetInfo;
@@ -548,7 +592,11 @@ TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Fabrics: Transfer Sa
 
         auto initiatorConfig = mxlFabricsInitiatorConfig{
             .version = MXL_FABRICS_API_VERSION,
-            .interface = {.version = MXL_FABRICS_API_VERSION, .provider = MXL_FABRICS_PROVIDER_SHM, .caps = {}, .address = {.node = "initiator", .service = "test"}, .attr = nullptr},
+            .interface = {.version = MXL_FABRICS_API_VERSION,
+                          .provider = MXL_FABRICS_PROVIDER_SHM,
+                          .caps = {},
+                          .address = {.node = "initiator", .service = "test"},
+                          .attr = nullptr},
             .reader = reader,
         };
         REQUIRE(mxlFabricsInitiatorSetup(initiator, &initiatorConfig, nullptr) == MXL_STATUS_OK);
@@ -632,7 +680,11 @@ TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Fabrics: Transfer Gr
     {
         auto initiatorConfig = mxlFabricsInitiatorConfig{
             .version = MXL_FABRICS_API_VERSION,
-            .interface = {.version = MXL_FABRICS_API_VERSION, .provider = MXL_FABRICS_PROVIDER_TCP, .caps = {}, .address = {.node = "127.0.0.1", .service = "0"}, .attr = nullptr},
+            .interface = {.version = MXL_FABRICS_API_VERSION,
+                          .provider = MXL_FABRICS_PROVIDER_TCP,
+                          .caps = {},
+                          .address = {.node = "127.0.0.1", .service = "0"},
+                          .attr = nullptr},
             .reader = reader,
         };
 
@@ -644,7 +696,11 @@ TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Fabrics: Transfer Gr
         {
             targetConfig[i] = mxlFabricsTargetConfig{
                 .version = MXL_FABRICS_API_VERSION,
-                .interface = {.version = MXL_FABRICS_API_VERSION, .provider = MXL_FABRICS_PROVIDER_TCP, .caps = {}, .address = {.node = "127.0.0.1", .service = "0"}, .attr = nullptr},
+                .interface = {.version = MXL_FABRICS_API_VERSION,
+                              .provider = MXL_FABRICS_PROVIDER_TCP,
+                              .caps = {},
+                              .address = {.node = "127.0.0.1", .service = "0"},
+                              .attr = nullptr},
                 .writer = writer[i],
             };
             REQUIRE(mxlFabricsTargetSetup(targets[i], &targetConfig[i], nullptr, &targetInfo[i]) == MXL_STATUS_OK);
@@ -698,7 +754,11 @@ TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Fabrics: Transfer Gr
     {
         auto initiatorConfig = mxlFabricsInitiatorConfig{
             .version = MXL_FABRICS_API_VERSION,
-            .interface = {.version = MXL_FABRICS_API_VERSION, .provider = MXL_FABRICS_PROVIDER_SHM, .caps = {}, .address = {.node = "initiator", .service = "test"}, .attr = nullptr},
+            .interface = {.version = MXL_FABRICS_API_VERSION,
+                          .provider = MXL_FABRICS_PROVIDER_SHM,
+                          .caps = {},
+                          .address = {.node = "initiator", .service = "test"},
+                          .attr = nullptr},
             .reader = reader,
         };
         REQUIRE(mxlFabricsInitiatorSetup(initiator, &initiatorConfig, nullptr) == MXL_STATUS_OK);
@@ -709,7 +769,11 @@ TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Fabrics: Transfer Gr
         {
             targetConfig[i] = mxlFabricsTargetConfig{
                 .version = MXL_FABRICS_API_VERSION,
-                .interface = {.version = MXL_FABRICS_API_VERSION, .provider = MXL_FABRICS_PROVIDER_SHM, .caps = {}, .address = {.node = "target", .service = "test"}, .attr = nullptr},
+                .interface = {.version = MXL_FABRICS_API_VERSION,
+                              .provider = MXL_FABRICS_PROVIDER_SHM,
+                              .caps = {},
+                              .address = {.node = "target", .service = "test"},
+                              .attr = nullptr},
                 .writer = writer[i],
             };
             REQUIRE(mxlFabricsTargetSetup(targets[i], &targetConfig[i], nullptr, &targetInfo[i]) == MXL_STATUS_OK);
@@ -809,7 +873,11 @@ TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Fabrics: Transfer Sa
     {
         auto initiatorConfig = mxlFabricsInitiatorConfig{
             .version = MXL_FABRICS_API_VERSION,
-            .interface = {.version = MXL_FABRICS_API_VERSION, .provider = MXL_FABRICS_PROVIDER_TCP, .caps = {}, .address = {.node = "127.0.0.1", .service = "0"}, .attr = nullptr},
+            .interface = {.version = MXL_FABRICS_API_VERSION,
+                          .provider = MXL_FABRICS_PROVIDER_TCP,
+                          .caps = {},
+                          .address = {.node = "127.0.0.1", .service = "0"},
+                          .attr = nullptr},
             .reader = reader,
         };
 
@@ -821,7 +889,11 @@ TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Fabrics: Transfer Sa
         {
             targetConfig[i] = mxlFabricsTargetConfig{
                 .version = MXL_FABRICS_API_VERSION,
-                .interface = {.version = MXL_FABRICS_API_VERSION, .provider = MXL_FABRICS_PROVIDER_TCP, .caps = {}, .address = {.node = "127.0.0.1", .service = "0"}, .attr = nullptr},
+                .interface = {.version = MXL_FABRICS_API_VERSION,
+                              .provider = MXL_FABRICS_PROVIDER_TCP,
+                              .caps = {},
+                              .address = {.node = "127.0.0.1", .service = "0"},
+                              .attr = nullptr},
                 .writer = writer[i],
             };
             REQUIRE(mxlFabricsTargetSetup(targets[i], &targetConfig[i], nullptr, &targetInfo[i]) == MXL_STATUS_OK);
@@ -877,7 +949,11 @@ TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Fabrics: Transfer Sa
     {
         auto initiatorConfig = mxlFabricsInitiatorConfig{
             .version = MXL_FABRICS_API_VERSION,
-            .interface = {.version = MXL_FABRICS_API_VERSION, .provider = MXL_FABRICS_PROVIDER_SHM, .caps = {}, .address = {.node = "initiator", .service = "test"}, .attr = nullptr},
+            .interface = {.version = MXL_FABRICS_API_VERSION,
+                          .provider = MXL_FABRICS_PROVIDER_SHM,
+                          .caps = {},
+                          .address = {.node = "initiator", .service = "test"},
+                          .attr = nullptr},
             .reader = reader,
         };
         REQUIRE(mxlFabricsInitiatorSetup(initiator, &initiatorConfig, nullptr) == MXL_STATUS_OK);
@@ -888,7 +964,11 @@ TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Fabrics: Transfer Sa
         {
             targetConfig[i] = mxlFabricsTargetConfig{
                 .version = MXL_FABRICS_API_VERSION,
-                .interface = {.version = MXL_FABRICS_API_VERSION, .provider = MXL_FABRICS_PROVIDER_SHM, .caps = {}, .address = {.node = "target", .service = "test"}, .attr = nullptr},
+                .interface = {.version = MXL_FABRICS_API_VERSION,
+                              .provider = MXL_FABRICS_PROVIDER_SHM,
+                              .caps = {},
+                              .address = {.node = "target", .service = "test"},
+                              .attr = nullptr},
                 .writer = writer[i],
             };
             REQUIRE(mxlFabricsTargetSetup(targets[i], &targetConfig[i], nullptr, &targetInfo[i]) == MXL_STATUS_OK);
@@ -970,7 +1050,11 @@ TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Fabrics: TargetInfo 
 
     auto config = mxlFabricsTargetConfig{
         .version = MXL_FABRICS_API_VERSION,
-        .interface = {.version = MXL_FABRICS_API_VERSION, .provider = MXL_FABRICS_PROVIDER_TCP, .caps = {}, .address = {.node = "127.0.0.1", .service = "0"}, .attr = nullptr},
+        .interface = {.version = MXL_FABRICS_API_VERSION,
+                      .provider = MXL_FABRICS_PROVIDER_TCP,
+                      .caps = {},
+                      .address = {.node = "127.0.0.1", .service = "0"},
+                      .attr = nullptr},
         .writer = writer,
     };
 

--- a/lib/tests/fabrics/test_basics.cpp
+++ b/lib/tests/fabrics/test_basics.cpp
@@ -224,8 +224,7 @@ TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Fabrics connection o
     {
         auto targetConfig = mxlFabricsTargetConfig{
             .version = MXL_FABRICS_API_VERSION,
-            .endpointAddress = mxlFabricsEndpointAddress{.node = "127.0.0.1", .service = "0"},
-            .provider = MXL_FABRICS_PROVIDER_TCP,
+            .interface = {.version = MXL_FABRICS_API_VERSION, .provider = MXL_FABRICS_PROVIDER_TCP, .caps = {}, .address = {.node = "127.0.0.1", .service = "0"}, .attr = nullptr},
             .writer = writer,
         };
         mxlFabricsTargetInfo targetInfo;
@@ -233,8 +232,7 @@ TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Fabrics connection o
 
         auto initiatorConfig = mxlFabricsInitiatorConfig{
             .version = MXL_FABRICS_API_VERSION,
-            .endpointAddress = mxlFabricsEndpointAddress{.node = "127.0.0.1", .service = "0"},
-            .provider = MXL_FABRICS_PROVIDER_TCP,
+            .interface = {.version = MXL_FABRICS_API_VERSION, .provider = MXL_FABRICS_PROVIDER_TCP, .caps = {}, .address = {.node = "127.0.0.1", .service = "0"}, .attr = nullptr},
             .reader = reader,
         };
         REQUIRE(mxlFabricsInitiatorSetup(initiator, &initiatorConfig, nullptr) == MXL_STATUS_OK);
@@ -296,8 +294,7 @@ TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Fabrics connectionle
 
     auto targetConfig = mxlFabricsTargetConfig{
         .version = MXL_FABRICS_API_VERSION,
-        .endpointAddress = mxlFabricsEndpointAddress{.node = "target", .service = "activation"},
-        .provider = MXL_FABRICS_PROVIDER_SHM,
+        .interface = {.version = MXL_FABRICS_API_VERSION, .provider = MXL_FABRICS_PROVIDER_SHM, .caps = {}, .address = {.node = "target", .service = "activation"}, .attr = nullptr},
         .writer = writer,
     };
     mxlFabricsTargetInfo targetInfo;
@@ -305,8 +302,7 @@ TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Fabrics connectionle
 
     auto initiatorConfig = mxlFabricsInitiatorConfig{
         .version = MXL_FABRICS_API_VERSION,
-        .endpointAddress = mxlFabricsEndpointAddress{.node = "initiator", .service = "activation"},
-        .provider = MXL_FABRICS_PROVIDER_SHM,
+        .interface = {.version = MXL_FABRICS_API_VERSION, .provider = MXL_FABRICS_PROVIDER_SHM, .caps = {}, .address = {.node = "initiator", .service = "activation"}, .attr = nullptr},
         .reader = reader,
     };
     REQUIRE(mxlFabricsInitiatorSetup(initiator, &initiatorConfig, nullptr) == MXL_STATUS_OK);
@@ -368,8 +364,7 @@ TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Fabrics: Transfer Gr
     {
         auto targetConfig = mxlFabricsTargetConfig{
             .version = MXL_FABRICS_API_VERSION,
-            .endpointAddress = mxlFabricsEndpointAddress{.node = "127.0.0.1", .service = "0"},
-            .provider = MXL_FABRICS_PROVIDER_TCP,
+            .interface = {.version = MXL_FABRICS_API_VERSION, .provider = MXL_FABRICS_PROVIDER_TCP, .caps = {}, .address = {.node = "127.0.0.1", .service = "0"}, .attr = nullptr},
             .writer = writer,
         };
         mxlFabricsTargetInfo targetInfo;
@@ -377,8 +372,7 @@ TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Fabrics: Transfer Gr
 
         auto initiatorConfig = mxlFabricsInitiatorConfig{
             .version = MXL_FABRICS_API_VERSION,
-            .endpointAddress = mxlFabricsEndpointAddress{.node = "127.0.0.1", .service = "0"},
-            .provider = MXL_FABRICS_PROVIDER_TCP,
+            .interface = {.version = MXL_FABRICS_API_VERSION, .provider = MXL_FABRICS_PROVIDER_TCP, .caps = {}, .address = {.node = "127.0.0.1", .service = "0"}, .attr = nullptr},
             .reader = reader,
         };
         REQUIRE(mxlFabricsInitiatorSetup(initiator, &initiatorConfig, nullptr) == MXL_STATUS_OK);
@@ -418,8 +412,7 @@ TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Fabrics: Transfer Gr
     {
         auto targetConfig = mxlFabricsTargetConfig{
             .version = MXL_FABRICS_API_VERSION,
-            .endpointAddress = mxlFabricsEndpointAddress{.node = "target", .service = "test"},
-            .provider = MXL_FABRICS_PROVIDER_SHM,
+            .interface = {.version = MXL_FABRICS_API_VERSION, .provider = MXL_FABRICS_PROVIDER_SHM, .caps = {}, .address = {.node = "target", .service = "test"}, .attr = nullptr},
             .writer = writer,
         };
         mxlFabricsTargetInfo targetInfo;
@@ -427,8 +420,7 @@ TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Fabrics: Transfer Gr
 
         auto initiatorConfig = mxlFabricsInitiatorConfig{
             .version = MXL_FABRICS_API_VERSION,
-            .endpointAddress = mxlFabricsEndpointAddress{.node = "initiator", .service = "test"},
-            .provider = MXL_FABRICS_PROVIDER_SHM,
+            .interface = {.version = MXL_FABRICS_API_VERSION, .provider = MXL_FABRICS_PROVIDER_SHM, .caps = {}, .address = {.node = "initiator", .service = "test"}, .attr = nullptr},
             .reader = reader,
         };
         REQUIRE(mxlFabricsInitiatorSetup(initiator, &initiatorConfig, nullptr) == MXL_STATUS_OK);
@@ -499,8 +491,7 @@ TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Fabrics: Transfer Sa
     {
         auto targetConfig = mxlFabricsTargetConfig{
             .version = MXL_FABRICS_API_VERSION,
-            .endpointAddress = mxlFabricsEndpointAddress{.node = "127.0.0.1", .service = "0"},
-            .provider = MXL_FABRICS_PROVIDER_TCP,
+            .interface = {.version = MXL_FABRICS_API_VERSION, .provider = MXL_FABRICS_PROVIDER_TCP, .caps = {}, .address = {.node = "127.0.0.1", .service = "0"}, .attr = nullptr},
             .writer = writer,
         };
         mxlFabricsTargetInfo targetInfo;
@@ -508,8 +499,7 @@ TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Fabrics: Transfer Sa
 
         auto initiatorConfig = mxlFabricsInitiatorConfig{
             .version = MXL_FABRICS_API_VERSION,
-            .endpointAddress = mxlFabricsEndpointAddress{.node = "127.0.0.1", .service = "0"},
-            .provider = MXL_FABRICS_PROVIDER_TCP,
+            .interface = {.version = MXL_FABRICS_API_VERSION, .provider = MXL_FABRICS_PROVIDER_TCP, .caps = {}, .address = {.node = "127.0.0.1", .service = "0"}, .attr = nullptr},
             .reader = reader,
         };
         REQUIRE(mxlFabricsInitiatorSetup(initiator, &initiatorConfig, nullptr) == MXL_STATUS_OK);
@@ -550,8 +540,7 @@ TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Fabrics: Transfer Sa
     {
         auto targetConfig = mxlFabricsTargetConfig{
             .version = MXL_FABRICS_API_VERSION,
-            .endpointAddress = mxlFabricsEndpointAddress{.node = "target", .service = "test"},
-            .provider = MXL_FABRICS_PROVIDER_SHM,
+            .interface = {.version = MXL_FABRICS_API_VERSION, .provider = MXL_FABRICS_PROVIDER_SHM, .caps = {}, .address = {.node = "target", .service = "test"}, .attr = nullptr},
             .writer = writer,
         };
         mxlFabricsTargetInfo targetInfo;
@@ -559,8 +548,7 @@ TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Fabrics: Transfer Sa
 
         auto initiatorConfig = mxlFabricsInitiatorConfig{
             .version = MXL_FABRICS_API_VERSION,
-            .endpointAddress = mxlFabricsEndpointAddress{.node = "initiator", .service = "test"},
-            .provider = MXL_FABRICS_PROVIDER_SHM,
+            .interface = {.version = MXL_FABRICS_API_VERSION, .provider = MXL_FABRICS_PROVIDER_SHM, .caps = {}, .address = {.node = "initiator", .service = "test"}, .attr = nullptr},
             .reader = reader,
         };
         REQUIRE(mxlFabricsInitiatorSetup(initiator, &initiatorConfig, nullptr) == MXL_STATUS_OK);
@@ -644,8 +632,7 @@ TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Fabrics: Transfer Gr
     {
         auto initiatorConfig = mxlFabricsInitiatorConfig{
             .version = MXL_FABRICS_API_VERSION,
-            .endpointAddress = mxlFabricsEndpointAddress{.node = "127.0.0.1", .service = "0"},
-            .provider = MXL_FABRICS_PROVIDER_TCP,
+            .interface = {.version = MXL_FABRICS_API_VERSION, .provider = MXL_FABRICS_PROVIDER_TCP, .caps = {}, .address = {.node = "127.0.0.1", .service = "0"}, .attr = nullptr},
             .reader = reader,
         };
 
@@ -657,8 +644,7 @@ TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Fabrics: Transfer Gr
         {
             targetConfig[i] = mxlFabricsTargetConfig{
                 .version = MXL_FABRICS_API_VERSION,
-                .endpointAddress = mxlFabricsEndpointAddress{.node = "127.0.0.1", .service = "0"},
-                .provider = MXL_FABRICS_PROVIDER_TCP,
+                .interface = {.version = MXL_FABRICS_API_VERSION, .provider = MXL_FABRICS_PROVIDER_TCP, .caps = {}, .address = {.node = "127.0.0.1", .service = "0"}, .attr = nullptr},
                 .writer = writer[i],
             };
             REQUIRE(mxlFabricsTargetSetup(targets[i], &targetConfig[i], nullptr, &targetInfo[i]) == MXL_STATUS_OK);
@@ -712,8 +698,7 @@ TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Fabrics: Transfer Gr
     {
         auto initiatorConfig = mxlFabricsInitiatorConfig{
             .version = MXL_FABRICS_API_VERSION,
-            .endpointAddress = mxlFabricsEndpointAddress{.node = "initiator", .service = "test"},
-            .provider = MXL_FABRICS_PROVIDER_SHM,
+            .interface = {.version = MXL_FABRICS_API_VERSION, .provider = MXL_FABRICS_PROVIDER_SHM, .caps = {}, .address = {.node = "initiator", .service = "test"}, .attr = nullptr},
             .reader = reader,
         };
         REQUIRE(mxlFabricsInitiatorSetup(initiator, &initiatorConfig, nullptr) == MXL_STATUS_OK);
@@ -724,8 +709,7 @@ TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Fabrics: Transfer Gr
         {
             targetConfig[i] = mxlFabricsTargetConfig{
                 .version = MXL_FABRICS_API_VERSION,
-                .endpointAddress = mxlFabricsEndpointAddress{.node = "target", .service = "test"},
-                .provider = MXL_FABRICS_PROVIDER_SHM,
+                .interface = {.version = MXL_FABRICS_API_VERSION, .provider = MXL_FABRICS_PROVIDER_SHM, .caps = {}, .address = {.node = "target", .service = "test"}, .attr = nullptr},
                 .writer = writer[i],
             };
             REQUIRE(mxlFabricsTargetSetup(targets[i], &targetConfig[i], nullptr, &targetInfo[i]) == MXL_STATUS_OK);
@@ -825,8 +809,7 @@ TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Fabrics: Transfer Sa
     {
         auto initiatorConfig = mxlFabricsInitiatorConfig{
             .version = MXL_FABRICS_API_VERSION,
-            .endpointAddress = mxlFabricsEndpointAddress{.node = "127.0.0.1", .service = "0"},
-            .provider = MXL_FABRICS_PROVIDER_TCP,
+            .interface = {.version = MXL_FABRICS_API_VERSION, .provider = MXL_FABRICS_PROVIDER_TCP, .caps = {}, .address = {.node = "127.0.0.1", .service = "0"}, .attr = nullptr},
             .reader = reader,
         };
 
@@ -838,8 +821,7 @@ TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Fabrics: Transfer Sa
         {
             targetConfig[i] = mxlFabricsTargetConfig{
                 .version = MXL_FABRICS_API_VERSION,
-                .endpointAddress = mxlFabricsEndpointAddress{.node = "127.0.0.1", .service = "0"},
-                .provider = MXL_FABRICS_PROVIDER_TCP,
+                .interface = {.version = MXL_FABRICS_API_VERSION, .provider = MXL_FABRICS_PROVIDER_TCP, .caps = {}, .address = {.node = "127.0.0.1", .service = "0"}, .attr = nullptr},
                 .writer = writer[i],
             };
             REQUIRE(mxlFabricsTargetSetup(targets[i], &targetConfig[i], nullptr, &targetInfo[i]) == MXL_STATUS_OK);
@@ -895,8 +877,7 @@ TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Fabrics: Transfer Sa
     {
         auto initiatorConfig = mxlFabricsInitiatorConfig{
             .version = MXL_FABRICS_API_VERSION,
-            .endpointAddress = mxlFabricsEndpointAddress{.node = "initiator", .service = "test"},
-            .provider = MXL_FABRICS_PROVIDER_SHM,
+            .interface = {.version = MXL_FABRICS_API_VERSION, .provider = MXL_FABRICS_PROVIDER_SHM, .caps = {}, .address = {.node = "initiator", .service = "test"}, .attr = nullptr},
             .reader = reader,
         };
         REQUIRE(mxlFabricsInitiatorSetup(initiator, &initiatorConfig, nullptr) == MXL_STATUS_OK);
@@ -907,8 +888,7 @@ TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Fabrics: Transfer Sa
         {
             targetConfig[i] = mxlFabricsTargetConfig{
                 .version = MXL_FABRICS_API_VERSION,
-                .endpointAddress = mxlFabricsEndpointAddress{.node = "target", .service = "test"},
-                .provider = MXL_FABRICS_PROVIDER_SHM,
+                .interface = {.version = MXL_FABRICS_API_VERSION, .provider = MXL_FABRICS_PROVIDER_SHM, .caps = {}, .address = {.node = "target", .service = "test"}, .attr = nullptr},
                 .writer = writer[i],
             };
             REQUIRE(mxlFabricsTargetSetup(targets[i], &targetConfig[i], nullptr, &targetInfo[i]) == MXL_STATUS_OK);
@@ -990,8 +970,7 @@ TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Fabrics: TargetInfo 
 
     auto config = mxlFabricsTargetConfig{
         .version = MXL_FABRICS_API_VERSION,
-        .endpointAddress = mxlFabricsEndpointAddress{.node = "127.0.0.1", .service = "0"},
-        .provider = MXL_FABRICS_PROVIDER_TCP,
+        .interface = {.version = MXL_FABRICS_API_VERSION, .provider = MXL_FABRICS_PROVIDER_TCP, .caps = {}, .address = {.node = "127.0.0.1", .service = "0"}, .attr = nullptr},
         .writer = writer,
     };
 

--- a/tools/mxl-fabrics-demo/demo.cpp
+++ b/tools/mxl-fabrics-demo/demo.cpp
@@ -6,6 +6,7 @@
 #include <csignal>
 #include <cstdint>
 #include <cstdlib>
+#include <fstream>
 #include <optional>
 #include <string>
 #include <uuid.h>
@@ -17,7 +18,6 @@
 #include <mxl/flow.h>
 #include <mxl/mxl.h>
 #include <mxl/time.h>
-#include "CLI/CLI.hpp"
 #include "mxl/dataformat.h"
 #include "mxl/flowinfo.h"
 #include "../../lib/fabrics/ofi/src/internal/Base64.hpp"
@@ -153,21 +153,22 @@ public:
             return status;
         }
 
+        // clang-format off
         mxlFabricsInitiatorConfig initiatorConfig = {
             .version = MXL_FABRICS_API_VERSION,
-            .interface =
-                {
-                            .version = MXL_FABRICS_API_VERSION,
-                            .provider = _config.provider,
-                            .caps = {.version = MXL_FABRICS_API_VERSION,
-                        .flags = MXL_FABRICS_IFACE_CAP_BLOCKING_OPERATIONS | MXL_FABRICS_IFACE_CAP_REMOTE_WRITE,
-                        .maxMessageSize = 0},
-                            .address = {.node = _config.node ? _config.node->c_str() : nullptr,
-                        .service = _config.service ? _config.service->c_str() : nullptr},
-                            .attr = nullptr,
-                            },
+            .interface = {
+                .version = MXL_FABRICS_API_VERSION,
+                .provider = _config.provider,
+                .caps = {},
+                .address = {
+                    .node = _config.node ? _config.node.value().c_str() : nullptr,
+                    .service = _config.service ? _config.service.value().c_str() : nullptr
+                },
+                .attr = nullptr,
+            },
             .reader = _reader,
         };
+        // clang-format on
 
         status = mxlFabricsInitiatorSetup(_initiator, &initiatorConfig, nullptr);
         if (status != MXL_STATUS_OK)
@@ -524,21 +525,22 @@ public:
             return status;
         }
 
+        // clang-format off
         mxlFabricsTargetConfig targetConfig = {
             .version = MXL_FABRICS_API_VERSION,
-            .interface =
-                {
-                            .version = MXL_FABRICS_API_VERSION,
-                            .provider = _config.provider,
-                            .caps = {.version = MXL_FABRICS_API_VERSION,
-                        .flags = MXL_FABRICS_IFACE_CAP_BLOCKING_OPERATIONS | MXL_FABRICS_IFACE_CAP_REMOTE_WRITE,
-                        .maxMessageSize = 0},
-                            .address = {.node = _config.node ? _config.node.value().c_str() : nullptr,
-                        .service = _config.service ? _config.service.value().c_str() : nullptr},
-                            .attr = nullptr,
-                            },
+            .interface = {
+                .version = MXL_FABRICS_API_VERSION,
+                .provider = _config.provider,
+                .caps = {},
+                .address = {
+                    .node = _config.node ? _config.node.value().c_str() : nullptr,
+                    .service = _config.service ? _config.service.value().c_str() : nullptr
+                },
+                .attr = nullptr,
+            },
             .writer = _writer,
         };
+        // clang-format on
         status = mxlFabricsTargetSetup(_target, &targetConfig, nullptr, &_targetInfo);
         if (status != MXL_STATUS_OK)
         {
@@ -549,7 +551,7 @@ public:
         return MXL_STATUS_OK;
     }
 
-    mxlStatus printInfo()
+    mxlStatus printInfo(std::string const& targetInfoFile = {})
     {
         auto targetInfoStr = std::string{};
         size_t targetInfoStrSize;
@@ -568,8 +570,20 @@ public:
             MXL_ERROR("Failed to convert target info to string with status '{}'", static_cast<int>(status));
             return status;
         }
+        targetInfoStr.pop_back();
 
         MXL_INFO("Target info:  {}", base64::to_base64(targetInfoStr));
+
+        if (!targetInfoFile.empty())
+        {
+            auto of = std::ofstream{targetInfoFile};
+            of << targetInfoStr;
+            if (of.fail())
+            {
+                MXL_ERROR("Failed to write target info to '{}'", targetInfoFile);
+                return MXL_ERR_INTERNAL;
+            }
+        }
 
         return MXL_STATUS_OK;
     }
@@ -774,8 +788,8 @@ int main(int argc, char** argv)
     std::string targetInfo;
     app.add_option("--target-info",
         targetInfo,
-        "The target information. This is used when configured as an initiator . This is the target information to send to."
-        "You first start the target and it will print the targetInfo that you paste to this argument");
+        "As target: output file path for raw target info (optional, always logged as base64). "
+        "As initiator: base64-encoded target info, or a path prefixed with '@' to read raw target info from a file.");
 
     CLI11_PARSE(app, argc, argv);
 
@@ -800,6 +814,24 @@ int main(int argc, char** argv)
         std::string flowDescriptor{std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>()};
         mxl::lib::FlowParser descriptorParser{flowDescriptor};
 
+        auto resolvedTargetInfo = std::string{};
+        if (!targetInfo.empty() && targetInfo.starts_with('@'))
+        {
+            // Read raw target info from file
+            auto filePath = std::string{targetInfo.begin() + 1, targetInfo.end()};
+            auto of = std::ifstream{filePath};
+            if (of.fail())
+            {
+                MXL_ERROR("Failed to open target info file '{}'", filePath);
+                return MXL_ERR_INTERNAL;
+            }
+            resolvedTargetInfo = std::string{std::istreambuf_iterator<char>{of}, std::istreambuf_iterator<char>{}};
+        }
+        else
+        {
+            resolvedTargetInfo = base64::from_base64(targetInfo);
+        }
+
         auto app = AppInitator{
             Config{
                    .domain = domain,
@@ -810,7 +842,7 @@ int main(int argc, char** argv)
                    },
         };
 
-        if (status = app.setup(base64::from_base64(targetInfo)); status != MXL_STATUS_OK)
+        if (status = app.setup(resolvedTargetInfo); status != MXL_STATUS_OK)
         {
             MXL_ERROR("Failed to setup initiator with status '{}'", static_cast<int>(status));
             return status;
@@ -865,7 +897,8 @@ int main(int argc, char** argv)
             return status;
         }
 
-        if (status = app.printInfo(); status != MXL_STATUS_OK)
+        auto targetInfoPath = targetInfo.empty() || targetInfo[0] != '@' ? targetInfo : std::string{targetInfo.begin() + 1, targetInfo.end()};
+        if (status = app.printInfo(targetInfoPath); status != MXL_STATUS_OK)
         {
             MXL_ERROR("Failed to print target info with status '{}'", static_cast<int>(status));
             return status;

--- a/tools/mxl-fabrics-demo/demo.cpp
+++ b/tools/mxl-fabrics-demo/demo.cpp
@@ -6,7 +6,6 @@
 #include <csignal>
 #include <cstdint>
 #include <cstdlib>
-#include <fstream>
 #include <optional>
 #include <string>
 #include <uuid.h>
@@ -18,6 +17,7 @@
 #include <mxl/flow.h>
 #include <mxl/mxl.h>
 #include <mxl/time.h>
+#include "CLI/CLI.hpp"
 #include "mxl/dataformat.h"
 #include "mxl/flowinfo.h"
 #include "../../lib/fabrics/ofi/src/internal/Base64.hpp"
@@ -155,9 +155,17 @@ public:
 
         mxlFabricsInitiatorConfig initiatorConfig = {
             .version = MXL_FABRICS_API_VERSION,
-            .endpointAddress = {.node = _config.node ? _config.node.value().c_str() : nullptr,
-                                .service = _config.service ? _config.service.value().c_str() : nullptr},
-            .provider = _config.provider,
+            .interface =
+                {
+                            .version = MXL_FABRICS_API_VERSION,
+                            .provider = _config.provider,
+                            .caps = {.version = MXL_FABRICS_API_VERSION,
+                        .flags = MXL_FABRICS_IFACE_CAP_BLOCKING_OPERATIONS | MXL_FABRICS_IFACE_CAP_REMOTE_WRITE,
+                        .maxMessageSize = 0},
+                            .address = {.node = _config.node ? _config.node->c_str() : nullptr,
+                        .service = _config.service ? _config.service->c_str() : nullptr},
+                            .attr = nullptr,
+                            },
             .reader = _reader,
         };
 
@@ -518,9 +526,17 @@ public:
 
         mxlFabricsTargetConfig targetConfig = {
             .version = MXL_FABRICS_API_VERSION,
-            .endpointAddress = {.node = _config.node ? _config.node.value().c_str() : nullptr,
-                                .service = _config.service ? _config.service.value().c_str() : nullptr},
-            .provider = _config.provider,
+            .interface =
+                {
+                            .version = MXL_FABRICS_API_VERSION,
+                            .provider = _config.provider,
+                            .caps = {.version = MXL_FABRICS_API_VERSION,
+                        .flags = MXL_FABRICS_IFACE_CAP_BLOCKING_OPERATIONS | MXL_FABRICS_IFACE_CAP_REMOTE_WRITE,
+                        .maxMessageSize = 0},
+                            .address = {.node = _config.node ? _config.node.value().c_str() : nullptr,
+                        .service = _config.service ? _config.service.value().c_str() : nullptr},
+                            .attr = nullptr,
+                            },
             .writer = _writer,
         };
         status = mxlFabricsTargetSetup(_target, &targetConfig, nullptr, &_targetInfo);
@@ -533,7 +549,7 @@ public:
         return MXL_STATUS_OK;
     }
 
-    mxlStatus printInfo(std::string const& targetInfoFile = {})
+    mxlStatus printInfo()
     {
         auto targetInfoStr = std::string{};
         size_t targetInfoStrSize;
@@ -552,20 +568,8 @@ public:
             MXL_ERROR("Failed to convert target info to string with status '{}'", static_cast<int>(status));
             return status;
         }
-        targetInfoStr.pop_back();
 
         MXL_INFO("Target info:  {}", base64::to_base64(targetInfoStr));
-
-        if (!targetInfoFile.empty())
-        {
-            auto of = std::ofstream{targetInfoFile};
-            of << targetInfoStr;
-            if (of.fail())
-            {
-                MXL_ERROR("Failed to write target info to '{}'", targetInfoFile);
-                return MXL_ERR_INTERNAL;
-            }
-        }
 
         return MXL_STATUS_OK;
     }
@@ -770,8 +774,8 @@ int main(int argc, char** argv)
     std::string targetInfo;
     app.add_option("--target-info",
         targetInfo,
-        "As target: output file path for raw target info (optional, always logged as base64). "
-        "As initiator: base64-encoded target info, or a path prefixed with '@' to read raw target info from a file.");
+        "The target information. This is used when configured as an initiator . This is the target information to send to."
+        "You first start the target and it will print the targetInfo that you paste to this argument");
 
     CLI11_PARSE(app, argc, argv);
 
@@ -796,24 +800,6 @@ int main(int argc, char** argv)
         std::string flowDescriptor{std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>()};
         mxl::lib::FlowParser descriptorParser{flowDescriptor};
 
-        auto resolvedTargetInfo = std::string{};
-        if (!targetInfo.empty() && targetInfo.starts_with('@'))
-        {
-            // Read raw target info from file
-            auto filePath = std::string{targetInfo.begin() + 1, targetInfo.end()};
-            auto of = std::ifstream{filePath};
-            if (of.fail())
-            {
-                MXL_ERROR("Failed to open target info file '{}'", filePath);
-                return MXL_ERR_INTERNAL;
-            }
-            resolvedTargetInfo = std::string{std::istreambuf_iterator<char>{of}, std::istreambuf_iterator<char>{}};
-        }
-        else
-        {
-            resolvedTargetInfo = base64::from_base64(targetInfo);
-        }
-
         auto app = AppInitator{
             Config{
                    .domain = domain,
@@ -824,7 +810,7 @@ int main(int argc, char** argv)
                    },
         };
 
-        if (status = app.setup(resolvedTargetInfo); status != MXL_STATUS_OK)
+        if (status = app.setup(base64::from_base64(targetInfo)); status != MXL_STATUS_OK)
         {
             MXL_ERROR("Failed to setup initiator with status '{}'", static_cast<int>(status));
             return status;
@@ -879,8 +865,7 @@ int main(int argc, char** argv)
             return status;
         }
 
-        auto targetInfoPath = targetInfo.empty() || targetInfo[0] != '@' ? targetInfo : std::string{targetInfo.begin() + 1, targetInfo.end()};
-        if (status = app.printInfo(targetInfoPath); status != MXL_STATUS_OK)
+        if (status = app.printInfo(); status != MXL_STATUS_OK)
         {
             MXL_ERROR("Failed to print target info with status '{}'", static_cast<int>(status));
             return status;


### PR DESCRIPTION
# Details
Update the API for the upcomming capabilities feature.
The next PR will include a proper implementation of the interface handling and an `mxlFabricsGetInterfaces()` function to query available interfaces.  

# Backport requirements
None
