### PR TITLE
fix: disable a mxlsink test that is failing on CI

### DIFF
--- a/rust/gst-mxl-rs/src/mxlsink/sink_tests.rs
+++ b/rust/gst-mxl-rs/src/mxlsink/sink_tests.rs
@@ -123,6 +123,7 @@ mod tests {
 
     #[test]
     #[cfg_attr(feature = "tracing", tracing_test::traced_test)]
+    #[ignore = "MXL + GStreamer integration - failing on CI but not reproducible; opt-in with cargo test -- --ignored"]
     fn valid_gray_pipeline() -> Result<(), glib::Error> {
         gst::init()?;
         gst::Element::register(


### PR DESCRIPTION
# Details

'mxlsink::sink_tests::tests::valid_gray_pipeline' is failing on CI, but we cannot reproduce it locally. This commit disables it.

Fixes #538.

# Backport requirements

Not needed, as this only impacts CI.