### PR TITLE
Ensure CMAKE install directory matches link search directory

### DIFF
--- a/rust/mxl-sys/build.rs
+++ b/rust/mxl-sys/build.rs
@@ -50,6 +50,7 @@ fn get_bindgen_specs() -> BindgenSpecs {
             .define("BUILD_DOCS", "OFF")
             .define("BUILD_TESTS", "OFF")
             .define("BUILD_TOOLS", "OFF")
+            .define("CMAKE_INSTALL_LIBDIR", "lib")
             .build();
 
         println!("cargo:rustc-link-search={}", dst.join("lib").display());


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2026 Contributors to the Media eXchange Layer project. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- Before submitting a pull request, please check that:
- it has a suitably descriptive title
- it mentions any issue(s) that it addresses
- you have considered whether it should be backported (specify how far back below)
- all commits are signed
-->

# Details

On Linux distributions that default to `lib64` for 64-bit libraries (Fedora, RHEL, openSUSE, Arch), CMake installs `libmxl.so` under `out/lib64` while the `mxl-sys` build script unconditionally emits `cargo:rustc-link-search=.../out/lib`, causing the linker to fail with unable to find library `-lmxl`.
This fix explicitly sets `CMAKE_INSTALL_LIBDIR=lib` in the CMake invocation, ensuring the install path and the link search path always agree regardless of system defaults.

### Changed:
- `rust/mxl-sys/build.rs`: added `.define("CMAKE_INSTALL_LIBDIR", "lib")` to the `cmake::Config` builder

# Backport requirements

This is a build system bug affecting any `lib64`-defaulting distro. Recommend backporting to all supported release branches.