### PR TITLE
Added MXL rust gstreamer plugin deb package generation system

### DIFF
--- a/rust/gst-mxl-rs/Cargo.toml
+++ b/rust/gst-mxl-rs/Cargo.toml
@@ -10,8 +10,18 @@ publish.workspace = true
 version.workspace = true
 license.workspace = true
 
+[package.metadata]
+install-subcommands = "cargo install cargo-deb"
+
 [package.metadata.cargo-machete]
 ignored = ["regex"]
+
+[package.metadata.deb]
+depends = "$auto, dmfmxl-dev"
+assets = [
+    ["target/release/libgstmxl.so", "/usr/lib/x86_64-linux-gnu/gstreamer-1.0/", "755"],
+]
+
 
 [dependencies]
 bitstream-io = "4"

--- a/rust/mxl-sys/build.rs
+++ b/rust/mxl-sys/build.rs
@@ -41,7 +41,7 @@ fn get_bindgen_specs() -> BindgenSpecs {
         let lib_root = repo_root.join("lib");
         println!("cargo:rerun-if-changed={}", lib_root.display());
 
-        let dst = cmake::Config::new(repo_root)
+        cmake::Config::new(repo_root)
             .generator("Ninja")
             .configure_arg("--preset")
             .configure_arg(BUILD_VARIANT)
@@ -51,9 +51,6 @@ fn get_bindgen_specs() -> BindgenSpecs {
             .define("BUILD_TESTS", "OFF")
             .define("BUILD_TOOLS", "OFF")
             .build();
-
-        println!("cargo:rustc-link-search={}", dst.join("lib").display());
-        println!("cargo:rustc-link-lib=mxl");
     }
 
     BindgenSpecs {


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2026 Contributors to the Media eXchange Layer project. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- Before submitting a pull request, please check that:
- it has a suitably descriptive title
- it mentions any issue(s) that it addresses
- you have considered whether it should be backported (specify how far back below)
- all commits are signed
-->

# Details
There was no way to package and distribute the rust mxl gstreamer plugins. This PR adds the ability to generate a deb package that contains the dynamic lib file that holds both `mxlsrc` and `mxlsink. The plugins are installed to `/usr/lib/x86_64-linux-gnu/gstreamer-1.0/libgstmxl.so` which is one of the default gstreamer plugin paths, which means that after the installation, gstreamer should automatically detect them (run `gst-inspect-1.0 mxl` to validate).

There is the question of this being a completely new deb package, separate from dmfmxl-dev. The main reason for this is that it would be complicated to create a system that include all artifacts from both `lib/` and `rust/` without making compromises on the build system as a whole.

A small change to the `mxl-sys` build.rs file was also made. Since in rust, you are required to load `libmxl` at runtime, there is no reason for it to be dynamically linked during build as well 

# Backport requirements
There are no backport requirements