### PR TITLE
Fix audio testsrc busy-spinning at 100% CPU

### DIFF
--- a/tools/mxl-gst/testsrc.cpp
+++ b/tools/mxl-gst/testsrc.cpp
@@ -628,12 +628,15 @@ namespace
             gstPipeline.start();
 
             auto const samplesPerBatch = gstPipeline.config().samplesPerBatch;
+            auto const batchPeriodNs = static_cast<std::uint64_t>(samplesPerBatch) *
+                                       1'000'000'000ULL * gstPipeline.config().sampleRate.denominator /
+                                       gstPipeline.config().sampleRate.numerator;
 
             auto sampleIndex = std::uint64_t{MXL_UNDEFINED_INDEX};
             while (!g_exit_requested)
             {
                 auto const timeoutNs = (sampleIndex != MXL_UNDEFINED_INDEX)
-                                         ? mxlGetNsUntilIndex(sampleIndex + samplesPerBatch, &gstPipeline.config().sampleRate)
+                                         ? std::max<std::uint64_t>(mxlGetNsUntilIndex(sampleIndex + samplesPerBatch, &gstPipeline.config().sampleRate), batchPeriodNs)
                                          : 100'000'000ULL; // arbitrary high timeout for the first sample
 
                 if (auto const pipelineSample = gstPipeline.pull(timeoutNs); pipelineSample)

--- a/tools/mxl-gst/testsrc.cpp
+++ b/tools/mxl-gst/testsrc.cpp
@@ -628,16 +628,16 @@ namespace
             gstPipeline.start();
 
             auto const samplesPerBatch = gstPipeline.config().samplesPerBatch;
-            auto const batchPeriodNs = static_cast<std::uint64_t>(samplesPerBatch) *
-                                       1'000'000'000ULL * gstPipeline.config().sampleRate.denominator /
+            auto const batchPeriodNs = static_cast<std::uint64_t>(samplesPerBatch) * 1'000'000'000ULL * gstPipeline.config().sampleRate.denominator /
                                        gstPipeline.config().sampleRate.numerator;
 
             auto sampleIndex = std::uint64_t{MXL_UNDEFINED_INDEX};
             while (!g_exit_requested)
             {
-                auto const timeoutNs = (sampleIndex != MXL_UNDEFINED_INDEX)
-                                         ? std::max<std::uint64_t>(mxlGetNsUntilIndex(sampleIndex + samplesPerBatch, &gstPipeline.config().sampleRate), batchPeriodNs)
-                                         : 100'000'000ULL; // arbitrary high timeout for the first sample
+                auto const timeoutNs =
+                    (sampleIndex != MXL_UNDEFINED_INDEX)
+                        ? std::max<std::uint64_t>(mxlGetNsUntilIndex(sampleIndex + samplesPerBatch, &gstPipeline.config().sampleRate), batchPeriodNs)
+                        : 100'000'000ULL; // arbitrary high timeout for the first sample
 
                 if (auto const pipelineSample = gstPipeline.pull(timeoutNs); pipelineSample)
                 {


### PR DESCRIPTION
When pull() returned no sample and the next batch time had already passed, mxlGetNsUntilIndex() returned 0, making the next pull() non-blocking. With no sleep on the empty-pull path this caused the loop to spin. Clamp the pull timeout to at least one batch period so the thread always blocks between retries.

# Backport requirements
Would make sense to backport to v1.1