### PR TITLE
[Backport to release/v1.1] fix(fabrics/ofi): make endpoint ids collision-free

### DIFF
--- a/lib/fabrics/ofi/src/internal/Endpoint.cpp
+++ b/lib/fabrics/ofi/src/internal/Endpoint.cpp
@@ -33,12 +33,7 @@ namespace mxl::lib::fabrics::ofi
     {
         // Use a global static random engine to prevent endpoint id collisions.
         static auto mu = std::mutex{};
-        static auto engine = []
-        {
-            std::random_device rd;
-            std::seed_seq seq{rd(), rd(), rd(), rd(), rd(), rd(), rd(), rd()};
-            return std::mt19937_64{seq};
-        }();
+        static auto engine = std::mt19937_64{std::random_device{}()};
         auto const lock = std::scoped_lock{mu};
         return std::uniform_int_distribution<Endpoint::Id>{}(engine);
     }

--- a/lib/fabrics/ofi/src/internal/Endpoint.cpp
+++ b/lib/fabrics/ofi/src/internal/Endpoint.cpp
@@ -31,30 +31,15 @@ namespace mxl::lib::fabrics::ofi
 {
     Endpoint::Id Endpoint::randomId() noexcept
     {
-        // Endpoint::Id is a process-local dispatch key: an initiator routes
-        // connection and completion events to the correct target by this id
-        // (see RCInitiator's id-keyed _targets map). It must be unique across
-        // every endpoint a single initiator talks to; it is not a wire value.
-        //
-        // The previous implementation reseeded a fresh std::mt19937 from ONE
-        // 32-bit, time-correlated std::random_device draw on every call. Targets
-        // set up in the same tight window (e.g. a gateway bringing up many
-        // mirrors at once) could draw the same 32-bit seed -> the same id; the
-        // initiator's id-keyed map then collapsed two endpoints and one mirror
-        // never connected -- an intermittent wedge that scaled with the number
-        // of concurrent setups.
-        //
-        // Seed one 64-bit engine ONCE from full-width entropy and serialize the
-        // draws. randomId() runs only at setup/reconnect, never on the hot path,
-        // so the lock is uncontended in steady state.
-        static std::mutex mu;
-        static std::mt19937_64 engine = []
+        // Use a global static random engine to prevent endpoint id collisions.
+        static auto mu = std::mutex{};
+        static auto engine = []
         {
             std::random_device rd;
             std::seed_seq seq{rd(), rd(), rd(), rd(), rd(), rd(), rd(), rd()};
             return std::mt19937_64{seq};
         }();
-        std::scoped_lock const lock{mu};
+        auto const lock = std::scoped_lock{mu};
         return std::uniform_int_distribution<Endpoint::Id>{}(engine);
     }
 

--- a/lib/fabrics/ofi/src/internal/Endpoint.cpp
+++ b/lib/fabrics/ofi/src/internal/Endpoint.cpp
@@ -6,7 +6,9 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <mutex>
 #include <optional>
+#include <random>
 #include <utility>
 #include <uuid.h>
 #include <sys/uio.h>
@@ -29,11 +31,31 @@ namespace mxl::lib::fabrics::ofi
 {
     Endpoint::Id Endpoint::randomId() noexcept
     {
-        std::uniform_int_distribution<Endpoint::Id> dist;
-        std::random_device rd;
-        std::mt19937 eng{rd()};
-
-        return dist(eng);
+        // Endpoint::Id is a process-local dispatch key: an initiator routes
+        // connection and completion events to the correct target by this id
+        // (see RCInitiator's id-keyed _targets map). It must be unique across
+        // every endpoint a single initiator talks to; it is not a wire value.
+        //
+        // The previous implementation reseeded a fresh std::mt19937 from ONE
+        // 32-bit, time-correlated std::random_device draw on every call. Targets
+        // set up in the same tight window (e.g. a gateway bringing up many
+        // mirrors at once) could draw the same 32-bit seed -> the same id; the
+        // initiator's id-keyed map then collapsed two endpoints and one mirror
+        // never connected -- an intermittent wedge that scaled with the number
+        // of concurrent setups.
+        //
+        // Seed one 64-bit engine ONCE from full-width entropy and serialize the
+        // draws. randomId() runs only at setup/reconnect, never on the hot path,
+        // so the lock is uncontended in steady state.
+        static std::mutex mu;
+        static std::mt19937_64 engine = []
+        {
+            std::random_device rd;
+            std::seed_seq seq{rd(), rd(), rd(), rd(), rd(), rd(), rd(), rd()};
+            return std::mt19937_64{seq};
+        }();
+        std::scoped_lock const lock{mu};
+        return std::uniform_int_distribution<Endpoint::Id>{}(engine);
     }
 
     Endpoint::Id Endpoint::idFromFID(::fid_t fid) noexcept

--- a/lib/fabrics/ofi/src/internal/FabricInfo.cpp
+++ b/lib/fabrics/ofi/src/internal/FabricInfo.cpp
@@ -174,13 +174,10 @@ namespace mxl::lib::fabrics::ofi
 
         // hints: add condition to append FI_HMEM capability if needed!
 
-        // libfabric performs lazy, process-global provider initialization on the
-        // first fi_getinfo. Concurrent first calls from several target/initiator
-        // setups can race that init and intermittently fail (or hand back a
-        // malformed fi_info) for one caller. fi_getinfo only runs at setup, so
-        // serialize it -- the steady-state hot path never touches this.
-        static std::mutex getInfoMutex;
-        std::scoped_lock const getInfoLock{getInfoMutex};
+        // Serialize ::fi_getinfo: its per-provider getinfo callbacks run unlocked
+        // (only fi_ini itself is mutex-protected upstream). Defensive, setup-only.
+        static auto getInfoMutex = std::mutex{};
+        auto const getInfoLock = std::scoped_lock{getInfoMutex};
 
         fiCall(::fi_getinfo, "Failed to get provider information", fiVersion(), node, service, FI_SOURCE, hints.raw(), &info);
 

--- a/lib/fabrics/ofi/src/internal/FabricInfo.cpp
+++ b/lib/fabrics/ofi/src/internal/FabricInfo.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "FabricInfo.hpp"
+#include <mutex>
 #include <rdma/fabric.h>
 #include <rdma/fi_errno.h>
 #include "Exception.hpp"
@@ -172,6 +173,14 @@ namespace mxl::lib::fabrics::ofi
         hints->fabric_attr->prov_name = strdup(fmt::to_string(provider).c_str());
 
         // hints: add condition to append FI_HMEM capability if needed!
+
+        // libfabric performs lazy, process-global provider initialization on the
+        // first fi_getinfo. Concurrent first calls from several target/initiator
+        // setups can race that init and intermittently fail (or hand back a
+        // malformed fi_info) for one caller. fi_getinfo only runs at setup, so
+        // serialize it -- the steady-state hot path never touches this.
+        static std::mutex getInfoMutex;
+        std::scoped_lock const getInfoLock{getInfoMutex};
 
         fiCall(::fi_getinfo, "Failed to get provider information", fiVersion(), node, service, FI_SOURCE, hints.raw(), &info);
 

--- a/lib/fabrics/ofi/src/internal/FabricInfo.cpp
+++ b/lib/fabrics/ofi/src/internal/FabricInfo.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "FabricInfo.hpp"
-#include <mutex>
 #include <rdma/fabric.h>
 #include <rdma/fi_errno.h>
 #include "Exception.hpp"
@@ -173,11 +172,6 @@ namespace mxl::lib::fabrics::ofi
         hints->fabric_attr->prov_name = strdup(fmt::to_string(provider).c_str());
 
         // hints: add condition to append FI_HMEM capability if needed!
-
-        // Serialize ::fi_getinfo: its per-provider getinfo callbacks run unlocked
-        // (only fi_ini itself is mutex-protected upstream). Defensive, setup-only.
-        static auto getInfoMutex = std::mutex{};
-        auto const getInfoLock = std::scoped_lock{getInfoMutex};
 
         fiCall(::fi_getinfo, "Failed to get provider information", fiVersion(), node, service, FI_SOURCE, hints.raw(), &info);
 


### PR DESCRIPTION
Backport of #574 to `release/v1.1`, as requested via the `backport/v1.1` label.

Cherry-picked (`-x`, in order):
- 93d62c0ab6ac0952978c9c33a99ae718d396f29b
- 7234f9a68bafe6743c5e1f6aa9c431c0ad4a0bdf
- 45f49fe7148aef7e721862b500030c1e2a6d0d9c

Notes:
- `d3771a47` (clang-format) from the suggested command list was skipped — it is already on `release/v1.1` as `6ffa806` (cherry-picked earlier).
- All picks applied cleanly; the net diff against `release/v1.1` is byte-identical to the net diff of #574 on `main`.

Fixes the intermittent MxlFlowMirror "stuck forever" wedge when many cross-node mirrors are set up concurrently (32-bit seed birthday collision in `Endpoint::randomId()`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)