### PR TITLE
Bump crossbeam-epoch to version 0.9.20 to fix RUSTSEC-2026-0204.

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -234,9 +234,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2026 Contributors to the Media eXchange Layer project. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- Before submitting a pull request, please check that:
- it has a suitably descriptive title
- it mentions any issue(s) that it addresses
- you have considered whether it should be backported (specify how far back below)
- all commits are signed
-->

# Details

Update the package `crossbeam-epoch` to `0.9.20` which is a dependency of `gst-mxl-rs`. This fixes the `cargo audit` vulnerability observed in the CI pipeline (https://github.com/dmf-mxl/mxl/pull/579).

Vulnerability: https://rustsec.org/advisories/RUSTSEC-2026-0204

# Backport requirements
v1.1