### PR TITLE
allow for audio and video id on the looping_filesrc cmd line

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,8 +57,9 @@ jobs:
           HASH_INPUT=$(cat -- .devcontainer/Dockerfile $(find .devcontainer/scripts/ -type f) vcpkg.json)
           HASH_INPUT="${HASH_INPUT}${{ matrix.version }}${{ matrix.architecture }}${{ matrix.compiler }}"
           DOCKER_HASH=$(echo -n "$HASH_INPUT" | sha256sum | cut -d' ' -f1)
+          OWNER_LC=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
           echo "hash=$DOCKER_HASH" >> $GITHUB_OUTPUT
-          echo "image-tag=ghcr.io/${{ github.repository_owner }}/mxl-build:$DOCKER_HASH" >> $GITHUB_OUTPUT
+          echo "image-tag=ghcr.io/${OWNER_LC}/mxl-build:$DOCKER_HASH" >> $GITHUB_OUTPUT
 
       - name: Check if Docker image exists
         id: check-image
@@ -218,8 +219,9 @@ jobs:
           HASH_INPUT=$(cat -- .devcontainer/Dockerfile $(find .devcontainer/scripts/ -type f) vcpkg.json)
           HASH_INPUT="${HASH_INPUT}${{ matrix.version }}${{ matrix.architecture }}${{ matrix.compiler }}"
           DOCKER_HASH=$(echo -n "$HASH_INPUT" | sha256sum | cut -d' ' -f1)
+          OWNER_LC=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
           echo "hash=$DOCKER_HASH" >> $GITHUB_OUTPUT
-          echo "image-tag=ghcr.io/${{ github.repository_owner }}/mxl-build:$DOCKER_HASH" >> $GITHUB_OUTPUT
+          echo "image-tag=ghcr.io/${OWNER_LC}/mxl-build:$DOCKER_HASH" >> $GITHUB_OUTPUT
 
       - name: Check if Docker image exists
         id: check-image

--- a/tools/mxl-gst/looping_filesrc.cpp
+++ b/tools/mxl-gst/looping_filesrc.cpp
@@ -219,7 +219,7 @@ public:
         }
     }
 
-    bool open(std::string const& in_uri)
+    bool open(std::string const& in_uri, std::optional<uuids::uuid> const& in_videoId, std::optional<uuids::uuid> const& in_audioId)
     {
         uri = in_uri;
         MXL_DEBUG("Opening URI: {}", uri);
@@ -371,9 +371,12 @@ public:
 
             gst_object_unref(pad);
 
+            // make sure the videoFlowId is set
+            videoFlowId = in_videoId.value_or(uuids::uuid_system_generator{}());
+
             std::string flowDef;
             videoGrainRate = mxlRational{fps_n, fps_d};
-            videoFlowId = createVideoFlowJson(uri, width, height, videoGrainRate, true, colorimetry, flowDef);
+            createVideoFlowJson(videoFlowId, uri, width, height, videoGrainRate, true, colorimetry, flowDef);
 
             mxlFlowConfigInfo configInfo;
             bool flowCreated = false;
@@ -455,10 +458,13 @@ public:
 
             gst_object_unref(pad);
 
+            // make sure the audioFlowId is set
+            audioFlowId = in_audioId.value_or(uuids::uuid_system_generator{}());
+
             std::string flowDef;
             audioGrainRate = mxlRational{rate, 1};
             audioChannels = channels;
-            audioFlowId = createAudioFlowJson(uri, audioGrainRate, channels, depth, format, flowDef);
+            createAudioFlowJson(audioFlowId, uri, audioGrainRate, channels, depth, format, flowDef);
 
             // The pipeline is PAUSED and the appSinkAudio should have received its preroll buffer.
             // We can try to pull this preroll sample to inspect the first decoded audio buffer
@@ -531,15 +537,14 @@ public:
     }
 
 private:
-    static uuids::uuid createVideoFlowJson(std::string const& in_uri, int in_width, int in_height, mxlRational in_rate, bool in_progressive,
-        std::string const& in_colorspace, std::string& out_flowDef)
+    static void createVideoFlowJson(uuids::uuid const& in_id, std::string const& in_uri, int in_width, int in_height, mxlRational in_rate,
+        bool in_progressive, std::string const& in_colorspace, std::string& out_flowDef)
     {
         auto root = picojson::object{};
         auto label = std::string{"Video flow for "} + in_uri;
         root["description"] = picojson::value(label);
 
-        auto id = uuids::uuid_system_generator{}();
-        root["id"] = picojson::value(uuids::to_string(id));
+        root["id"] = picojson::value(uuids::to_string(in_id));
         root["tags"] = picojson::value(picojson::object());
         root["format"] = picojson::value("urn:x-nmos:format:video");
         root["label"] = picojson::value(label);
@@ -580,18 +585,16 @@ private:
         root["components"] = picojson::value(components);
 
         out_flowDef = picojson::value(root).serialize(true);
-        return id;
     }
 
-    static uuids::uuid createAudioFlowJson(std::string const& in_uri, mxlRational in_rate, int ch_count, int depth, std::string const& format,
-        std::string& out_flowDef)
+    static void createAudioFlowJson(uuids::uuid const& in_id, std::string const& in_uri, mxlRational in_rate, int ch_count, int depth,
+        std::string const& format, std::string& out_flowDef)
     {
         auto root = picojson::object{};
         auto label = std::string{"Audio flow for "} + in_uri;
         root["description"] = picojson::value(label);
 
-        auto id = uuids::uuid_system_generator{}();
-        root["id"] = picojson::value(uuids::to_string(id));
+        root["id"] = picojson::value(uuids::to_string(in_id));
         root["tags"] = picojson::value(picojson::object());
         root["format"] = picojson::value("urn:x-nmos:format:audio");
         root["label"] = picojson::value(label);
@@ -612,7 +615,6 @@ private:
         root["bit_depth"] = picojson::value(static_cast<double>(depth));
 
         out_flowDef = picojson::value(root).serialize(true);
-        return id;
     }
 
     static std::string getFlowOptions(std::uint32_t maxCommitBatchSizeHint, std::uint32_t maxSyncBatchSizeHint)
@@ -977,7 +979,7 @@ int main(int argc, char* argv[])
     //
     // Command line argument parsing
     //
-    std::string inputFile, domain;
+    std::string inputFile, domain, audioId, videoId;
 
     CLI::App cli{"mxl-gst-looping-filesrc"};
     auto domainOpt = cli.add_option("-d,--domain", domain, "The MXL domain directory")->required();
@@ -986,6 +988,18 @@ int main(int argc, char* argv[])
     auto inputOpt = cli.add_option("-i,--input", inputFile, "MPEGTS media file location")->required();
     inputOpt->required(true);
     inputOpt->check(CLI::ExistingFile);
+
+    auto const uuidValidator = CLI::Validator([](std::string const& value) -> std::string
+        { return uuids::uuid::from_string(value).has_value() ? std::string{} : std::string{"Value is not a valid UUID"}; },
+        "UUID");
+
+    auto videoIdOpt = cli.add_option("--video-id", videoId, "The MXL video flow id");
+    videoIdOpt->required(false);
+    videoIdOpt->check(uuidValidator);
+
+    auto audioIdOpt = cli.add_option("--audio-id", audioId, "The MXL audio flow id");
+    audioIdOpt->required(false);
+    audioIdOpt->check(uuidValidator);
 
     CLI11_PARSE(cli, argc, argv);
 
@@ -1002,7 +1016,12 @@ int main(int argc, char* argv[])
     // Create the Player and open the input uri
     //
     auto player = std::make_unique<LoopingFilePlayer>(domain);
-    if (!player->open(inputFile))
+
+    // The CLI validator above guarantees these parse successfully when provided.
+    auto const videoFlowId = videoId.empty() ? std::optional<uuids::uuid>{} : uuids::uuid::from_string(videoId);
+    auto const audioFlowId = audioId.empty() ? std::optional<uuids::uuid>{} : uuids::uuid::from_string(audioId);
+
+    if (!player->open(inputFile, videoFlowId, audioFlowId))
     {
         MXL_ERROR("Failed to open input file: {}", inputFile);
         return -1;


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2026 Contributors to the Media eXchange Layer project. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

# Details

Add `--video-id` and `--audio-id` optional CLI arguments to `mxl-gst-looping-filesrc`, allowing users to specify stable, known MXL flow UUIDs rather than always generating random ones.

When deploying `looping_filesrc` via an orchestrator (e.g. OpenTofu), it is useful to assign stable, known flow IDs so that downstream consumers can be preconfigured to connect to specific flows without relying on runtime discovery. This enables a "discovery by orchestration" pattern where the orchestrator assigns and injects flow IDs across the media pipeline topology.

When omitted, behaviour is unchanged (random UUIDs are generated).

## Changes

- Added `--video-id` and `--audio-id` optional CLI arguments with UUID validation
- Refactored `createVideoFlowJson` and `createAudioFlowJson` to accept the ID as a parameter rather than generating one internally
- Updated `open()` to accept optional UUIDs; a random UUID is still generated if none is provided (preserving backward compatibility)
- CI fix: lowercased `github.repository_owner` in the build workflow image tag to comply with GHCR naming requirements (my username has uppercase characters)

## Usage

```bash
mxl-gst-looping-filesrc -d /tmp/mxl -i media.ts \
  --video-id "11111111-1111-1111-1111-111111111111" \
  --audio-id "22222222-2222-2222-2222-222222222222"
```

Both options are optional. Omitting them retains the existing random UUID behaviour.

# Backport requirements

This is a new feature with no breaking changes. Backporting to release/v1.1 should be a simple cherry pick. There are conflicts with release/v1.0.