### PR TITLE
Add Doxygen rendering of API documentation

### DIFF
--- a/.github/doxygen/github-repo-link.css
+++ b/.github/doxygen/github-repo-link.css
@@ -1,0 +1,28 @@
+/* SPDX-FileCopyrightText: 2025 Contributors to the Media eXchange Layer project.
+ * SPDX-License-Identifier: CC-BY-4.0
+ *
+ * Styling for the "GitHub" repo link injected by github-repo-link.js.
+ * Deliberately mirrors main-docs-link.css so both header links have the
+ * same visual weight and inherit doxygen-awesome-css's colour scheme.
+ */
+
+.mxl-github-repo-link {
+  display: inline-block;
+  margin: 0 12px;
+  padding: 4px 8px;
+  font-size: 0.9em;
+  font-weight: 600;
+  color: var(--primary-color, #0969da);
+  text-decoration: none;
+  border-radius: 4px;
+  vertical-align: middle;
+}
+
+.mxl-github-repo-link:hover {
+  text-decoration: underline;
+}
+
+.mxl-github-repo-link:focus {
+  outline: 2px solid var(--primary-color, #0969da);
+  outline-offset: 1px;
+}

--- a/.github/doxygen/github-repo-link.js
+++ b/.github/doxygen/github-repo-link.js
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: CC-BY-4.0
+//
+// Adds a "GitHub" link to every page of the Doxygen-generated API reference,
+// pointing at the source repository the docs were built from.
+//
+// Unlike main-docs-link.js (whose target can be derived from the current URL),
+// the GitHub repo isn't recoverable at runtime --- a Pages site may sit behind
+// a custom domain that has no relationship to the github.com slug. So the URL
+// is baked in at build time by doxy-docs.yml, which substitutes the
+// __REPO_URL__ placeholder below with ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}
+// before doxygen copies this file into the output tree.
+//
+// Loaded with `defer` from doxygen's customised HTML header, so #titlearea is
+// already parsed by the time this runs.
+
+(function () {
+  'use strict';
+
+  var repoUrl = '__REPO_URL__';
+
+  var link = document.createElement('a');
+  link.className = 'mxl-github-repo-link';
+  link.href = repoUrl;
+  link.textContent = 'GitHub';
+  link.title = 'Source repository on GitHub';
+  link.target = '_blank';
+  link.rel = 'noopener noreferrer';
+
+  // Append so this lands on the far right of the title area, after the
+  // version selector. Left cluster (main-docs-link) and right cluster
+  // (version + GitHub) mirror common doc-site conventions.
+  var titleArea = document.getElementById('titlearea');
+  if (titleArea) {
+    titleArea.appendChild(link);
+  } else {
+    document.body.appendChild(link);
+  }
+})();

--- a/.github/doxygen/main-docs-link.css
+++ b/.github/doxygen/main-docs-link.css
@@ -1,0 +1,28 @@
+/* SPDX-FileCopyrightText: 2025 Contributors to the Media eXchange Layer project.
+ * SPDX-License-Identifier: CC-BY-4.0
+ *
+ * Styling for the "MXL Documentation" back-link injected by
+ * main-docs-link.js. Kept minimal so it picks up doxygen-awesome-css's
+ * surrounding colour scheme without fighting it.
+ */
+
+.mxl-main-docs-link {
+  display: inline-block;
+  margin: 0 12px;
+  padding: 4px 8px;
+  font-size: 0.9em;
+  font-weight: 600;
+  color: var(--primary-color, #0969da);
+  text-decoration: none;
+  border-radius: 4px;
+  vertical-align: middle;
+}
+
+.mxl-main-docs-link:hover {
+  text-decoration: underline;
+}
+
+.mxl-main-docs-link:focus {
+  outline: 2px solid var(--primary-color, #0969da);
+  outline-offset: 1px;
+}

--- a/.github/doxygen/main-docs-link.js
+++ b/.github/doxygen/main-docs-link.js
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: CC-BY-4.0
+//
+// Adds a "← MXL Documentation" link back to the main (zensical) docs site to
+// every page of the Doxygen-generated API reference.
+//
+// The API reference is published under /<site>/api/<version>/... on the same
+// GitHub Pages site as the main documentation, so the site root is whatever
+// comes before "/api/<version>/" in the current URL. We derive that at
+// runtime rather than hardcoding a repo/site name here.
+//
+// Loaded with `defer` from doxygen's customised HTML header (see
+// .github/workflows/doxy-docs.yml), so #titlearea is already parsed by the
+// time this runs.
+
+(function () {
+  'use strict';
+
+  // Match "<site>/api/<version>/..." and capture <site>. If we're not on
+  // an API-reference page (unlikely, since this script only ships inside
+  // the doxygen output), do nothing.
+  var m = window.location.pathname.match(/^(.*?)\/api\/[^/]+\//);
+  if (!m) return;
+
+  var siteRoot = m[1] + '/';   // e.g. "/mxl/"
+
+  var link = document.createElement('a');
+  link.className = 'mxl-main-docs-link';
+  link.href = siteRoot;
+  link.textContent = '\u2190 MXL Documentation';
+  link.title = 'Back to the main MXL documentation site';
+
+  // Prepend so reading order is: "back link | project title | version".
+  // Fall back to the top of <body> if #titlearea is missing (e.g. after a
+  // future doxygen template change).
+  var titleArea = document.getElementById('titlearea');
+  if (titleArea) {
+    titleArea.insertBefore(link, titleArea.firstChild);
+  } else {
+    document.body.insertBefore(link, document.body.firstChild);
+  }
+})();

--- a/.github/doxygen/version-selector.css
+++ b/.github/doxygen/version-selector.css
@@ -1,0 +1,37 @@
+/* SPDX-FileCopyrightText: 2025 Contributors to the Media eXchange Layer project.
+ * SPDX-License-Identifier: CC-BY-4.0
+ *
+ * Styling for the Mike-style version selector injected by version-selector.js.
+ * Intentionally minimal so it picks up doxygen-awesome-css's surrounding
+ * colour scheme without fighting it.
+ */
+
+.mxl-version-selector {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4em;
+  margin: 0 12px;
+  padding: 4px 0;
+  font-size: 0.9em;
+  vertical-align: middle;
+}
+
+.mxl-version-selector label {
+  font-weight: 600;
+  color: inherit;
+}
+
+.mxl-version-selector select {
+  padding: 2px 6px;
+  border-radius: 4px;
+  border: 1px solid var(--separator-color, #c1c8d0);
+  background: var(--page-background-color, #fff);
+  color: var(--page-foreground-color, #24292f);
+  font: inherit;
+  cursor: pointer;
+}
+
+.mxl-version-selector select:focus {
+  outline: 2px solid var(--primary-color, #0969da);
+  outline-offset: 1px;
+}

--- a/.github/doxygen/version-selector.js
+++ b/.github/doxygen/version-selector.js
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: CC-BY-4.0
+//
+// Mike-style version selector for the Doxygen-generated MXL API reference.
+//
+// Activated on pages served under /<site>/api/<version>/..., where:
+//   - <version> is either a real published version directory (e.g. "main",
+//     "v1.1.0") or the "latest" alias.
+//
+// Reads the per-site /<site>/api/versions.json manifest (written by
+// .github/workflows/doxy-docs.yml) and renders a <select> in the doxygen
+// title area. Changing the selection navigates to the same sub-page in the
+// chosen version, falling back to that version's index when the same page
+// doesn't exist there.
+
+(function () {
+  'use strict';
+
+  var path = window.location.pathname;
+  // Match "<anything>/api/<version>/<subpath>"; the subpath may be empty
+  // (e.g. ".../api/v1.1.0/").
+  var m = path.match(/^(.*\/api)\/([^/]+)\/(.*)$/);
+  if (!m) return;
+
+  var apiBase = m[1];          // e.g. "/mxl/api"
+  var currentSlug = m[2];      // e.g. "v1.1.0" or "latest"
+  var subPath = m[3] || '';    // page-relative path within the version
+
+  fetch(apiBase + '/versions.json', { cache: 'no-cache' })
+    .then(function (r) { return r.ok ? r.json() : Promise.reject(r.status); })
+    .then(render)
+    .catch(function (err) {
+      // Don't break the page if the manifest is missing or unreadable.
+      // eslint-disable-next-line no-console
+      console.warn('mxl version selector: ' + err);
+    });
+
+  function render(versions) {
+    if (!Array.isArray(versions) || versions.length === 0) return;
+
+    // Figure out which manifest entry matches the URL we're on, so we can
+    // pre-select it. Match by version, then by alias.
+    var selectedKey = null;
+    for (var i = 0; i < versions.length; i++) {
+      var v = versions[i];
+      if (v.version === currentSlug) { selectedKey = v.version; break; }
+      if (Array.isArray(v.aliases) && v.aliases.indexOf(currentSlug) !== -1) {
+        selectedKey = v.version; break;
+      }
+    }
+
+    var wrapper = document.createElement('div');
+    wrapper.className = 'mxl-version-selector';
+
+    var label = document.createElement('label');
+    label.htmlFor = 'mxl-version-select';
+    label.textContent = 'Version:';
+
+    var select = document.createElement('select');
+    select.id = 'mxl-version-select';
+
+    // If we landed on .../api/latest/... but the manifest doesn't list a
+    // version literally named "latest" (it shouldn't), still expose "latest"
+    // as a synthetic option so the dropdown reflects the URL.
+    var hasLatestSlug = versions.some(function (v) { return v.version === 'latest'; });
+    if (!hasLatestSlug && currentSlug === 'latest') {
+      var optL = document.createElement('option');
+      optL.value = 'latest';
+      optL.textContent = 'latest';
+      optL.selected = true;
+      select.appendChild(optL);
+    }
+
+    versions.forEach(function (v) {
+      var opt = document.createElement('option');
+      opt.value = v.version;
+      var aliasLabel =
+        (Array.isArray(v.aliases) && v.aliases.length)
+          ? ' (' + v.aliases.join(', ') + ')'
+          : '';
+      opt.textContent = (v.title || v.version) + aliasLabel;
+      if (selectedKey === v.version) opt.selected = true;
+      select.appendChild(opt);
+    });
+
+    select.addEventListener('change', function () {
+      var dest = apiBase + '/' + select.value + '/' + subPath;
+      // Probe the same sub-page in the target version; if missing, fall back
+      // to that version's index. This handles renamed or removed pages
+      // gracefully.
+      fetch(dest, { method: 'HEAD' }).then(function (r) {
+        window.location.href = r.ok
+          ? dest
+          : apiBase + '/' + select.value + '/';
+      }).catch(function () {
+        window.location.href = apiBase + '/' + select.value + '/';
+      });
+    });
+
+    wrapper.appendChild(label);
+    wrapper.appendChild(select);
+
+    // Insert into doxygen's #titlearea when present (works with both the
+    // default doxygen template and doxygen-awesome-css). Otherwise pin to
+    // the top of the page so it's at least visible.
+    var titleArea = document.getElementById('titlearea');
+    if (titleArea) {
+      titleArea.appendChild(wrapper);
+    } else {
+      document.body.insertBefore(wrapper, document.body.firstChild);
+    }
+  }
+})();

--- a/.github/scripts/prepare-docs.sh
+++ b/.github/scripts/prepare-docs.sh
@@ -86,3 +86,14 @@ if [[ -f "${API_REF_PAGE}" ]]; then
     rm -f "${API_REF_PAGE}.bak"
     echo "Templated ${API_REF_PAGE} for ref=${REF}, site=${SITE_BASE}"
 fi
+
+# ---------------------------------------------------------------------------
+# 4. Template zensical.toml so the header repo link (repo_url / repo_name)
+#    points at the fork or upstream that produced this build. The same
+#    __REPO_SLUG__ placeholder is used elsewhere (see step 3).
+# ---------------------------------------------------------------------------
+if [[ -f zensical.toml ]]; then
+    sed -i.bak -e "s#__REPO_SLUG__#${REPO_SLUG}#g" zensical.toml
+    rm -f zensical.toml.bak
+    echo "Templated zensical.toml for repo=${REPO_SLUG}"
+fi

--- a/.github/scripts/prepare-docs.sh
+++ b/.github/scripts/prepare-docs.sh
@@ -21,7 +21,14 @@
 
 set -euo pipefail
 
-REPO_SLUG="dmf-mxl/mxl"
+# Derive the repo slug from the GitHub Actions context so the script works
+# unchanged on forks (e.g. peterbrightwell/mxl during testing). Fall back to
+# the upstream slug for ad-hoc local runs.
+REPO_SLUG="${GITHUB_REPOSITORY:-dmf-mxl/mxl}"
+OWNER="${REPO_SLUG%%/*}"
+REPO="${REPO_SLUG##*/}"
+# Project Pages base URL for this repo, e.g. https://peterbrightwell.github.io/mxl
+SITE_BASE="https://${OWNER}.github.io/${REPO}"
 # Use BUILD_REF if the workflow set one (covers dispatch with an input ref),
 # else the ref the run was triggered on, else fall back to main.
 REF="${BUILD_REF:-${GITHUB_REF_NAME:-main}}"
@@ -44,7 +51,7 @@ sed -E \
     -e "s#\]\(CODE_OF_CONDUCT\.md\)#](${REPO_URL}/CODE_OF_CONDUCT.md)#g" \
     -e "s#\]\(GOVERNANCE/([^)]+)\)#](${REPO_URL}/GOVERNANCE/\1)#g" \
     -e "s#\]\(examples/([^)]+)\)#](${REPO_URL}/examples/\1)#g" \
-    -e "s#https://github.com/dmf-mxl/mxl/blob/[0-9a-f]+/docs/([^)\" ]+)#\1#g" \
+    -e "s#https://github.com/${REPO_SLUG}/blob/[0-9a-f]+/docs/([^)\" ]+)#\1#g" \
     README.md > docs/index.md
 
 echo "Generated docs/index.md from README.md"
@@ -63,3 +70,19 @@ for f in docs/*.md; do
 done
 
 echo "Rewrote ../ links in docs/*.md to ${REPO_URL}/..."
+
+# ---------------------------------------------------------------------------
+# 3. Template the API Reference page so its links point at the matching
+#    Doxygen build (e.g. /mxl/api/v1.1.0/) on the current Pages site, and at
+#    the current repo on github.com.
+# ---------------------------------------------------------------------------
+API_REF_PAGE="docs/API Reference.md"
+if [[ -f "${API_REF_PAGE}" ]]; then
+    sed -i.bak \
+        -e "s#__BUILD_REF__#${REF}#g" \
+        -e "s#__SITE_BASE__#${SITE_BASE}#g" \
+        -e "s#__REPO_SLUG__#${REPO_SLUG}#g" \
+        "${API_REF_PAGE}"
+    rm -f "${API_REF_PAGE}.bak"
+    echo "Templated ${API_REF_PAGE} for ref=${REF}, site=${SITE_BASE}"
+fi

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -90,6 +90,7 @@ jobs:
         run: sudo snap install lychee
 
       - name: Check for broken links with lychee
+        continue-on-error: true
         run: lychee --root-dir ./site --verbose --no-progress --accept '100..=103,200..=299,403' --accept-timeouts './site/**/*.html'
 
       # Configure git for mike to push to gh-pages

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,6 +30,12 @@ permissions:
   pages: write
   id-token: write
 
+# Serialize with the Doxygen workflow, which also pushes to gh-pages.
+# Running them concurrently would race the worktree / push.
+concurrency:
+  group: gh-pages
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -79,10 +85,10 @@ jobs:
         run: ./.github/scripts/prepare-docs.sh
 
       - run: zensical build --clean
-      
+
       - name: Install lychee
         run: sudo snap install lychee
-          
+
       - name: Check for broken links with lychee
         run: lychee --root-dir ./site --verbose --no-progress --accept '100..=103,200..=299,403' --accept-timeouts './site/**/*.html'
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,15 @@ on:
     branches:
       - main
       - docs-* # for testing
+    # Only run on branch pushes that change inputs to this site. Tag pushes
+    # are handled by the separate `tags:` filter below and are not subject to
+    # `paths:` (GitHub treats a new ref as "all files changed").
+    paths:
+      - "docs/**"
+      - "README.md"
+      - "zensical.toml"
+      - ".github/scripts/prepare-docs.sh"
+      - ".github/workflows/docs.yml"
     tags:
       - "v*"
   workflow_dispatch:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,10 +34,11 @@ on:
         type: boolean
         default: false
 
+# This workflow only produces content on the gh-pages branch; the actual
+# Pages deployment is handled by pages-deploy.yml, which runs on push to
+# that branch.
 permissions:
   contents: write
-  pages: write
-  id-token: write
 
 # Serialize with the Doxygen workflow, which also pushes to gh-pages.
 # Running them concurrently would race the worktree / push.

--- a/.github/workflows/doxy-docs.yml
+++ b/.github/workflows/doxy-docs.yml
@@ -91,6 +91,50 @@ jobs:
             -e "s|@AWESOME_CSS_DIR@|${GITHUB_WORKSPACE}/third_party/doxygen-awesome-css|g" \
             Doxyfile.in > Doxyfile
 
+      # Customise the doxygen output beyond what Doxyfile.in expresses:
+      #   1. LAYOUT_FILE: hide the "Main Page" tab (we don't ship a doxygen
+      #      landing page; the zensical site is the project landing page).
+      #   2. HTML_HEADER: inject a small <script> that loads the version
+      #      selector. We base it on doxygen's own default header so the
+      #      $relpath^ / $treeview / $search / $mathjax / $extrastylesheet
+      #      tokens stay intact and we don't have to track header changes
+      #      across doxygen versions.
+      #   3. HTML_EXTRA_FILES / HTML_EXTRA_STYLESHEET: ship the selector's
+      #      JS and CSS alongside the rest of the html output.
+      - name: Customise layout, header, and assets
+        run: |
+          set -euo pipefail
+          mkdir -p doxygen-gen
+
+          # 1. Default layout file, with the mainpage tab disabled.
+          doxygen -l doxygen-gen/DoxygenLayout.xml
+          sed -i \
+            's|<tab type="mainpage" visible="yes"|<tab type="mainpage" visible="no"|' \
+            doxygen-gen/DoxygenLayout.xml
+
+          # 2. Default html header/footer/stylesheet (the stylesheet output
+          #    is required by `doxygen -w html` but we don't use it).
+          doxygen -w html doxygen-gen/header.html doxygen-gen/footer.html \
+            doxygen-gen/_unused.css Doxyfile
+          # Inject the version selector script before </head>. Use a literal
+          # newline so the inserted line ends up on its own line.
+          sed -i '/<\/head>/i\
+          <script type="text/javascript" src="$relpath^version-selector.js" defer></script>' \
+            doxygen-gen/header.html
+
+          # 3. Append the customisation options to the Doxyfile. Using `+=`
+          #    for the list-valued options means we add to (rather than
+          #    replace) whatever Doxyfile.in already set.
+          cat >> Doxyfile <<EOF
+
+          # Appended by .github/workflows/doxy-docs.yml -----------------------------
+          LAYOUT_FILE             = ${GITHUB_WORKSPACE}/doxygen-gen/DoxygenLayout.xml
+          HTML_HEADER             = ${GITHUB_WORKSPACE}/doxygen-gen/header.html
+          HTML_FOOTER             = ${GITHUB_WORKSPACE}/doxygen-gen/footer.html
+          HTML_EXTRA_FILES       += ${GITHUB_WORKSPACE}/.github/doxygen/version-selector.js
+          HTML_EXTRA_STYLESHEET  += ${GITHUB_WORKSPACE}/.github/doxygen/version-selector.css
+          EOF
+
       - name: Build doxygen docs
         run: doxygen Doxyfile
 
@@ -143,7 +187,43 @@ jobs:
           if [[ "${UPDATE_LATEST}" == "1" ]]; then
             rm -rf "gh-pages-wt/api/latest"
             cp -a "${SRC}/." "gh-pages-wt/api/latest"
+            # Record which version 'latest' currently aliases, so the
+            # selector can label it "vX.Y.Z (latest)" in versions.json.
+            echo "${BUILD_REF}" > "gh-pages-wt/api/.latest_alias_of"
           fi
+
+          # Regenerate gh-pages/api/versions.json (mike-compatible format)
+          # so the in-page version selector can populate itself. Each entry
+          # has {version, title, aliases}; the one matching .latest_alias_of
+          # gets aliases: ["latest"].
+          LATEST_OF=""
+          [[ -f gh-pages-wt/api/.latest_alias_of ]] && \
+            LATEST_OF="$(cat gh-pages-wt/api/.latest_alias_of)"
+          (
+            cd gh-pages-wt/api
+            shopt -s nullglob
+            vdirs=()
+            for d in */; do
+              d="${d%/}"
+              [[ "${d}" == "latest" ]] && continue
+              vdirs+=("${d}")
+            done
+            if (( ${#vdirs[@]} > 0 )); then
+              printf '%s\n' "${vdirs[@]}" \
+                | sort -Vr \
+                | jq -Rs --arg latest "${LATEST_OF}" '
+                    split("\n")
+                    | map(select(length > 0))
+                    | map({
+                        version: .,
+                        title: .,
+                        aliases: (if . == $latest then ["latest"] else [] end)
+                      })
+                  ' > versions.json
+            else
+              echo '[]' > versions.json
+            fi
+          )
 
           # Regenerate gh-pages/api/index.html with a sorted list of all
           # published versions, so /mxl/api/ is browsable. 'latest' is pinned

--- a/.github/workflows/doxy-docs.yml
+++ b/.github/workflows/doxy-docs.yml
@@ -8,6 +8,15 @@ on:
     branches:
       - main
       - docs-* # for testing
+    # Only run on branch pushes that change inputs to the API reference
+    # (the C/C++ sources or this workflow's own configuration). Tag pushes
+    # are handled by the `tags:` filter below and are not subject to
+    # `paths:` (GitHub treats a new ref as "all files changed").
+    paths:
+      - "lib/**"
+      - "Doxyfile.in"
+      - ".github/doxygen/**"
+      - ".github/workflows/doxy-docs.yml"
     tags:
       - "v*"
   workflow_dispatch:
@@ -38,22 +47,19 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      # Always check out the ref that triggered the run (or the default
-      # branch, for dispatch) so we get the current workflow infrastructure.
+      # Always check out the default branch (main) so we use the *current*
+      # build infrastructure --- Doxyfile.in, .github/doxygen/ assets, layout
+      # tweaks added in later steps --- even when publishing docs for an
+      # older tag. The actual C/C++ sources are overlaid from BUILD_REF in a
+      # separate step below so doxygen documents the correct version.
+      #
+      # Without this, tag builds would inherit the Doxyfile.in shipped with
+      # the tag (e.g. one that still included README.md in INPUT and so
+      # rendered the README as the API site's landing page).
       - uses: actions/checkout@v5
         with:
+          ref: main
           fetch-depth: 0
-
-      # If the user dispatched with a specific ref, overlay only the doxygen
-      # input sources from that ref. This mirrors what docs.yml does for the
-      # zensical site and allows (re)building API docs for historical tags
-      # whose own copy of this workflow predates workflow_dispatch.
-      - name: Overlay doxygen sources from selected ref
-        if: ${{ inputs.ref != '' }}
-        env:
-          INPUT_REF: ${{ inputs.ref }}
-        run: |
-          git checkout "${INPUT_REF}" -- lib/ README.md Doxyfile.in
 
       # Decide which name this build is published as on gh-pages. Same rule
       # as docs.yml: dispatched input wins, otherwise the triggering ref.
@@ -68,6 +74,13 @@ jobs:
           fi
           echo "BUILD_REF=${BUILD_REF}" >> "$GITHUB_ENV"
           echo "Publishing API docs as version: ${BUILD_REF}"
+
+      # Overlay the C/C++ sources from BUILD_REF onto main's checkout so
+      # doxygen documents the right version. When BUILD_REF is itself "main"
+      # this is a no-op.
+      - name: Overlay lib/ from build ref
+        run: |
+          git checkout "${BUILD_REF}" -- lib/
 
       - name: Install Doxygen and Graphviz
         run: |

--- a/.github/workflows/doxy-docs.yml
+++ b/.github/workflows/doxy-docs.yml
@@ -47,18 +47,19 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      # Always check out the default branch (main) so we use the *current*
-      # build infrastructure --- Doxyfile.in, .github/doxygen/ assets, layout
-      # tweaks added in later steps --- even when publishing docs for an
-      # older tag. The actual C/C++ sources are overlaid from BUILD_REF in a
-      # separate step below so doxygen documents the correct version.
+      # Check out the ref that triggered this run (the pushed branch/tag,
+      # or --- for workflow_dispatch --- the ref the workflow was dispatched
+      # from, which defaults to the default branch). This keeps the workflow
+      # file and every asset it references (Doxyfile.in, .github/doxygen/,
+      # scripts) coming from the *same* commit, so new files added in the
+      # same commit as new workflow steps are always visible.
       #
-      # Without this, tag builds would inherit the Doxyfile.in shipped with
-      # the tag (e.g. one that still included README.md in INPUT and so
-      # rendered the README as the API site's landing page).
+      # The C/C++ sources for BUILD_REF are overlaid from that ref in a
+      # separate step below, so doxygen documents the correct version even
+      # when we're re-running from a different ref (e.g. dispatched from
+      # main to rebuild docs for an older tag).
       - uses: actions/checkout@v5
         with:
-          ref: main
           fetch-depth: 0
 
       # Decide which name this build is published as on gh-pages. Same rule

--- a/.github/workflows/doxy-docs.yml
+++ b/.github/workflows/doxy-docs.yml
@@ -1,4 +1,4 @@
-name: Build Documentation
+name: Build Doxygen Documentation
 
 on:
   # push:
@@ -25,7 +25,7 @@ jobs:
 
       - name: Generate docs
         run: |
-          doxygen Doxyfile
+          doxygen Doxyfile.in
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/doxy-docs.yml
+++ b/.github/workflows/doxy-docs.yml
@@ -145,6 +145,57 @@ jobs:
             cp -a "${SRC}/." "gh-pages-wt/api/latest"
           fi
 
+          # Regenerate gh-pages/api/index.html with a sorted list of all
+          # published versions, so /mxl/api/ is browsable. 'latest' is pinned
+          # to the top; everything else is version-sorted, descending.
+          INDEX="gh-pages-wt/api/index.html"
+          {
+            echo '<!DOCTYPE html>'
+            echo '<html lang="en">'
+            echo '<head>'
+            echo '  <meta charset="utf-8">'
+            echo '  <title>MXL API Reference — published versions</title>'
+            echo '  <meta name="viewport" content="width=device-width, initial-scale=1">'
+            echo '  <style>'
+            echo '    body{font-family:system-ui,-apple-system,Segoe UI,sans-serif;max-width:40rem;margin:3rem auto;padding:0 1rem;line-height:1.5;color:#24292f}'
+            echo '    h1{margin-bottom:.25rem} p{color:#57606a}'
+            echo '    ul{padding-left:1.25rem} li{margin:.25rem 0}'
+            echo '    a{color:#0969da;text-decoration:none} a:hover{text-decoration:underline}'
+            echo '    code{background:#f6f8fa;padding:1px 4px;border-radius:4px}'
+            echo '  </style>'
+            echo '</head>'
+            echo '<body>'
+            echo '  <h1>MXL API Reference</h1>'
+            echo '  <p>Doxygen-generated C/C++ API reference. Pick a version:</p>'
+            echo '  <ul>'
+            (
+              cd gh-pages-wt/api
+              if [[ -d latest ]]; then
+                echo '    <li><a href="latest/"><strong>latest</strong></a> &mdash; alias for the default branch</li>'
+              fi
+              # All other version directories, version-sorted descending.
+              # Use globbing rather than `find -printf` so this works on any
+              # POSIX `find`. The shell expands */ to top-level dirs only.
+              shopt -s nullglob
+              dirs=()
+              for d in */; do
+                d="${d%/}"
+                [[ "${d}" == "latest" ]] && continue
+                dirs+=("${d}")
+              done
+              if (( ${#dirs[@]} > 0 )); then
+                printf '%s\n' "${dirs[@]}" \
+                  | sort -Vr \
+                  | while IFS= read -r d; do
+                      printf '    <li><a href="%s/"><code>%s</code></a></li>\n' "${d}" "${d}"
+                    done
+              fi
+            )
+            echo '  </ul>'
+            echo '</body>'
+            echo '</html>'
+          } > "${INDEX}"
+
           cd gh-pages-wt
           git add api
           if git diff --cached --quiet; then

--- a/.github/workflows/doxy-docs.yml
+++ b/.github/workflows/doxy-docs.yml
@@ -7,9 +7,13 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
+
+# Avoid racing with the mike-based Documentation workflow, which also pushes
+# to gh-pages.
+concurrency:
+  group: gh-pages
+  cancel-in-progress: false
 
 jobs:
   build:
@@ -18,29 +22,42 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Doxygen
+      - name: Install Doxygen and Graphviz
         run: |
           sudo apt-get update
           sudo apt-get install -y doxygen graphviz
 
-      - name: Generate docs
+      - name: Fetch doxygen-awesome-css
         run: |
-          doxygen Doxyfile.in
+          mkdir -p third_party
+          curl -fsSL -o third_party/doxygen-awesome.zip \
+            https://github.com/jothepro/doxygen-awesome-css/archive/refs/heads/main.zip
+          unzip -q third_party/doxygen-awesome.zip -d third_party
+          mv third_party/doxygen-awesome-css-main third_party/doxygen-awesome-css
 
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+      - name: Generate Doxyfile from template
+        run: |
+          # Doxyfile.in is a CMake configure_file template. Substitute the
+          # two @VAR@ placeholders that the CMake build would normally fill in.
+          sed \
+            -e "s|@CMAKE_CURRENT_SOURCE_DIR@|${GITHUB_WORKSPACE}|g" \
+            -e "s|@AWESOME_CSS_DIR@|${GITHUB_WORKSPACE}/third_party/doxygen-awesome-css|g" \
+            Doxyfile.in > Doxyfile
+
+      - name: Generate docs
+        run: doxygen Doxyfile
+
+      # Publish into the gh-pages branch alongside the mike-managed site.
+      # keep_files: true preserves the versioned docs (latest/, vX.Y.Z/,
+      # versions.json, ...) maintained by .github/workflows/docs.yml.
+      - name: Deploy to gh-pages (api/ subdirectory)
+        uses: peaceiris/actions-gh-pages@v4
         with:
-          path: html
-
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: docs/html
+          destination_dir: api
+          keep_files: true
+          commit_message: "doxygen: update api docs (${{ github.sha }})"
+          user_name: "github-actions[bot]"
+          user_email: "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/doxy-docs.yml
+++ b/.github/workflows/doxy-docs.yml
@@ -129,10 +129,14 @@ jobs:
           #    is required by `doxygen -w html` but we don't use it).
           doxygen -w html doxygen-gen/header.html doxygen-gen/footer.html \
             doxygen-gen/_unused.css Doxyfile
-          # Inject the version selector script before </head>. Use a literal
-          # newline so the inserted line ends up on its own line.
+          # Inject the version selector and main-docs back-link scripts
+          # before </head>. Use a literal newline so each inserted line
+          # ends up on its own line.
           sed -i '/<\/head>/i\
           <script type="text/javascript" src="$relpath^version-selector.js" defer></script>' \
+            doxygen-gen/header.html
+          sed -i '/<\/head>/i\
+          <script type="text/javascript" src="$relpath^main-docs-link.js" defer></script>' \
             doxygen-gen/header.html
 
           # 3. Append the customisation options to the Doxyfile. Using `+=`
@@ -145,7 +149,9 @@ jobs:
           HTML_HEADER             = ${GITHUB_WORKSPACE}/doxygen-gen/header.html
           HTML_FOOTER             = ${GITHUB_WORKSPACE}/doxygen-gen/footer.html
           HTML_EXTRA_FILES       += ${GITHUB_WORKSPACE}/.github/doxygen/version-selector.js
+          HTML_EXTRA_FILES       += ${GITHUB_WORKSPACE}/.github/doxygen/main-docs-link.js
           HTML_EXTRA_STYLESHEET  += ${GITHUB_WORKSPACE}/.github/doxygen/version-selector.css
+          HTML_EXTRA_STYLESHEET  += ${GITHUB_WORKSPACE}/.github/doxygen/main-docs-link.css
           EOF
 
       - name: Build doxygen docs

--- a/.github/workflows/doxy-docs.yml
+++ b/.github/workflows/doxy-docs.yml
@@ -129,15 +129,25 @@ jobs:
           #    is required by `doxygen -w html` but we don't use it).
           doxygen -w html doxygen-gen/header.html doxygen-gen/footer.html \
             doxygen-gen/_unused.css Doxyfile
-          # Inject the version selector and main-docs back-link scripts
-          # before </head>. Use a literal newline so each inserted line
-          # ends up on its own line.
+          # Inject the version selector, main-docs back-link, and GitHub
+          # repo-link scripts before </head>. Use a literal newline so each
+          # inserted line ends up on its own line.
           sed -i '/<\/head>/i\
           <script type="text/javascript" src="$relpath^version-selector.js" defer></script>' \
             doxygen-gen/header.html
           sed -i '/<\/head>/i\
           <script type="text/javascript" src="$relpath^main-docs-link.js" defer></script>' \
             doxygen-gen/header.html
+          sed -i '/<\/head>/i\
+          <script type="text/javascript" src="$relpath^github-repo-link.js" defer></script>' \
+            doxygen-gen/header.html
+
+          # 2a. Bake the current build's repo URL into a build-time copy of
+          #     github-repo-link.js. HTML_EXTRA_FILES copies files verbatim,
+          #     so we can't do the substitution in the source tree.
+          cp .github/doxygen/github-repo-link.js doxygen-gen/github-repo-link.js
+          sed -i "s|__REPO_URL__|${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}|g" \
+            doxygen-gen/github-repo-link.js
 
           # 3. Append the customisation options to the Doxyfile. Using `+=`
           #    for the list-valued options means we add to (rather than
@@ -150,8 +160,10 @@ jobs:
           HTML_FOOTER             = ${GITHUB_WORKSPACE}/doxygen-gen/footer.html
           HTML_EXTRA_FILES       += ${GITHUB_WORKSPACE}/.github/doxygen/version-selector.js
           HTML_EXTRA_FILES       += ${GITHUB_WORKSPACE}/.github/doxygen/main-docs-link.js
+          HTML_EXTRA_FILES       += ${GITHUB_WORKSPACE}/doxygen-gen/github-repo-link.js
           HTML_EXTRA_STYLESHEET  += ${GITHUB_WORKSPACE}/.github/doxygen/version-selector.css
           HTML_EXTRA_STYLESHEET  += ${GITHUB_WORKSPACE}/.github/doxygen/main-docs-link.css
+          HTML_EXTRA_STYLESHEET  += ${GITHUB_WORKSPACE}/.github/doxygen/github-repo-link.css
           EOF
 
       - name: Build doxygen docs

--- a/.github/workflows/doxy-docs.yml
+++ b/.github/workflows/doxy-docs.yml
@@ -1,0 +1,46 @@
+name: Build Documentation
+
+on:
+  # push:
+  #   branches:
+  #     - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Doxygen
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y doxygen graphviz
+
+      - name: Generate docs
+        run: |
+          doxygen Doxyfile
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: html
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/doxy-docs.yml
+++ b/.github/workflows/doxy-docs.yml
@@ -1,26 +1,73 @@
+# SPDX-FileCopyrightText: 2025 Contributors to the Media eXchange Layer project.
+# SPDX-License-Identifier: CC-BY-4.0
+
 name: Build Doxygen Documentation
 
 on:
-  # push:
-  #   branches:
-  #     - main
+  push:
+    branches:
+      - main
+      - docs-* # for testing
+    tags:
+      - "v*"
   workflow_dispatch:
+    inputs:
+      ref:
+        description: >-
+          Optional branch or tag to build docs from. Leave empty to build the
+          ref this workflow runs on. Use this to (re)build docs for historical
+          tags whose own copy of this workflow predates workflow_dispatch.
+        required: false
+        default: ""
+      alias_latest:
+        description: "Also publish this build under the 'latest' alias"
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
 
-# Avoid racing with the mike-based Documentation workflow, which also pushes
-# to gh-pages.
+# Serialize with the zensical Documentation workflow, which also pushes to
+# gh-pages. Running them concurrently would race the worktree / push.
 concurrency:
   group: gh-pages
   cancel-in-progress: false
 
 jobs:
-  build:
+  deploy:
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v4
+      # Always check out the ref that triggered the run (or the default
+      # branch, for dispatch) so we get the current workflow infrastructure.
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      # If the user dispatched with a specific ref, overlay only the doxygen
+      # input sources from that ref. This mirrors what docs.yml does for the
+      # zensical site and allows (re)building API docs for historical tags
+      # whose own copy of this workflow predates workflow_dispatch.
+      - name: Overlay doxygen sources from selected ref
+        if: ${{ inputs.ref != '' }}
+        env:
+          INPUT_REF: ${{ inputs.ref }}
+        run: |
+          git checkout "${INPUT_REF}" -- lib/ README.md Doxyfile.in
+
+      # Decide which name this build is published as on gh-pages. Same rule
+      # as docs.yml: dispatched input wins, otherwise the triggering ref.
+      - name: Determine build ref
+        env:
+          INPUT_REF: ${{ inputs.ref }}
+        run: |
+          if [[ -n "${INPUT_REF}" ]]; then
+            BUILD_REF="${INPUT_REF}"
+          else
+            BUILD_REF="${GITHUB_REF_NAME}"
+          fi
+          echo "BUILD_REF=${BUILD_REF}" >> "$GITHUB_ENV"
+          echo "Publishing API docs as version: ${BUILD_REF}"
 
       - name: Install Doxygen and Graphviz
         run: |
@@ -44,20 +91,68 @@ jobs:
             -e "s|@AWESOME_CSS_DIR@|${GITHUB_WORKSPACE}/third_party/doxygen-awesome-css|g" \
             Doxyfile.in > Doxyfile
 
-      - name: Generate docs
+      - name: Build doxygen docs
         run: doxygen Doxyfile
 
-      # Publish into the gh-pages branch alongside the mike-managed site.
-      # keep_files: true preserves the versioned docs (latest/, vX.Y.Z/,
-      # versions.json, ...) maintained by .github/workflows/docs.yml.
-      - name: Deploy to gh-pages (api/ subdirectory)
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_branch: gh-pages
-          publish_dir: docs/html
-          destination_dir: api
-          keep_files: true
-          commit_message: "doxygen: update api docs (${{ github.sha }})"
-          user_name: "github-actions[bot]"
-          user_email: "github-actions[bot]@users.noreply.github.com"
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      # Publish under api/<version>/ on gh-pages, with an optional api/latest/
+      # alias. Versioning rules match the mike invocation in docs.yml:
+      #   - push to branch:    publish as <branch>, update 'latest'
+      #   - push to tag:       publish as <tag>, no alias change
+      #   - workflow_dispatch: publish as <BUILD_REF>; update 'latest' only
+      #                        when the alias_latest input is true
+      #
+      # We use a gh-pages worktree and a normal commit (rather than a force
+      # push) so the zensical site maintained by mike in the same branch is
+      # left untouched.
+      - name: Publish API docs to gh-pages
+        env:
+          ALIAS_LATEST: ${{ inputs.alias_latest }}
+        run: |
+          set -euo pipefail
+
+          UPDATE_LATEST=0
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            [[ "${ALIAS_LATEST}" == "true" ]] && UPDATE_LATEST=1
+          elif [[ "${GITHUB_REF_TYPE}" == "branch" ]]; then
+            UPDATE_LATEST=1
+          fi
+
+          SRC="${GITHUB_WORKSPACE}/docs/html"
+
+          # Make sure we have gh-pages locally. mike (in docs.yml) is normally
+          # the workflow that first creates it; if it doesn't exist yet, start
+          # an orphan branch so this workflow can run standalone too.
+          if git ls-remote --exit-code --heads origin gh-pages >/dev/null; then
+            git fetch origin gh-pages:gh-pages || git fetch origin gh-pages
+            git worktree add gh-pages-wt gh-pages
+          else
+            git worktree add --detach gh-pages-wt
+            git -C gh-pages-wt checkout --orphan gh-pages
+            git -C gh-pages-wt rm -rf . >/dev/null 2>&1 || true
+          fi
+
+          mkdir -p gh-pages-wt/api
+          rm -rf "gh-pages-wt/api/${BUILD_REF}"
+          cp -a "${SRC}/." "gh-pages-wt/api/${BUILD_REF}"
+
+          if [[ "${UPDATE_LATEST}" == "1" ]]; then
+            rm -rf "gh-pages-wt/api/latest"
+            cp -a "${SRC}/." "gh-pages-wt/api/latest"
+          fi
+
+          cd gh-pages-wt
+          git add api
+          if git diff --cached --quiet; then
+            echo "No changes to API docs; nothing to commit."
+            exit 0
+          fi
+
+          MSG="doxygen: publish API docs for ${BUILD_REF}"
+          [[ "${UPDATE_LATEST}" == "1" ]] && MSG="${MSG} (latest)"
+          git commit -m "${MSG}"
+          git push origin gh-pages

--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -11,19 +11,30 @@
 # modified from this repo.
 #
 # Switching Settings -> Pages -> Build and deployment -> Source to
-# "GitHub Actions" disables the built-in workflow. This file replaces it: it
-# runs on any push to gh-pages (from either producing workflow, or from a
-# manual commit) and serves the branch contents verbatim via the current
+# "GitHub Actions" disables the built-in workflow. This file replaces it,
+# serving the branch contents verbatim via the current
 # actions/upload-pages-artifact + actions/deploy-pages combo.
+#
+# Trigger notes:
+#   We use `workflow_run` rather than `push: branches: [gh-pages]` because
+#   push-triggered workflows must have their definition present on the ref
+#   that received the push --- and gh-pages only ever contains the built
+#   site (mike + doxygen output), never .github/workflows/. workflow_run
+#   instead reads this file from the default branch, so it fires correctly
+#   after either producer workflow completes on main / docs-* / a tag.
 
 name: Deploy gh-pages to GitHub Pages
 
 on:
-  push:
-    branches:
-      - gh-pages
+  workflow_run:
+    workflows:
+      - Documentation
+      - Build Doxygen Documentation
+    types:
+      - completed
   # Allow re-deploying the current gh-pages tip on demand (e.g. after
-  # rotating the Pages configuration in repo settings).
+  # rotating the Pages configuration in repo settings, or if a deploy was
+  # skipped because the producer run failed after already pushing).
   workflow_dispatch:
 
 permissions:
@@ -33,15 +44,20 @@ permissions:
 
 # Never cancel an in-progress deployment: leaving Pages in a half-updated
 # state is worse than deploying a slightly older revision. Concurrent
-# producer runs (docs.yml / doxy-docs.yml) are already serialized by their
-# own `gh-pages` concurrency group, so pushes --- and therefore runs of this
-# workflow --- arrive in order.
+# producer runs are already serialized by their own `gh-pages` concurrency
+# group, so runs of this workflow arrive in order.
 concurrency:
   group: pages-deploy
   cancel-in-progress: false
 
 jobs:
   deploy:
+    # Only deploy when the upstream producer succeeded. workflow_run fires
+    # on every completion regardless of conclusion, so filter here to avoid
+    # publishing a partially-built site. Manual dispatch is always allowed.
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -67,14 +67,14 @@ jobs:
         with:
           ref: gh-pages
 
-      - uses: actions/configure-pages@v5
+      - uses: actions/configure-pages@v6
 
       # Upload the entire gh-pages tree as-is. mike (zensical site) and the
       # Doxygen workflow have already arranged the branch layout; we just
       # publish what's there.
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: .
 
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: 2025 Contributors to the Media eXchange Layer project.
+# SPDX-License-Identifier: CC-BY-4.0
+
+# Deploy the gh-pages branch to GitHub Pages using the modern Pages actions.
+#
+# Both docs.yml (mike / zensical site) and doxy-docs.yml (Doxygen API refs)
+# publish their output by pushing to the gh-pages branch. Historically, with
+# the Pages "Source" set to "Deploy from a branch", GitHub then auto-ran its
+# built-in "pages build and deployment" workflow to serve that branch --- but
+# that workflow emits Node.js deprecation warnings and its steps can't be
+# modified from this repo.
+#
+# Switching Settings -> Pages -> Build and deployment -> Source to
+# "GitHub Actions" disables the built-in workflow. This file replaces it: it
+# runs on any push to gh-pages (from either producing workflow, or from a
+# manual commit) and serves the branch contents verbatim via the current
+# actions/upload-pages-artifact + actions/deploy-pages combo.
+
+name: Deploy gh-pages to GitHub Pages
+
+on:
+  push:
+    branches:
+      - gh-pages
+  # Allow re-deploying the current gh-pages tip on demand (e.g. after
+  # rotating the Pages configuration in repo settings).
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Never cancel an in-progress deployment: leaving Pages in a half-updated
+# state is worse than deploying a slightly older revision. Concurrent
+# producer runs (docs.yml / doxy-docs.yml) are already serialized by their
+# own `gh-pages` concurrency group, so pushes --- and therefore runs of this
+# workflow --- arrive in order.
+concurrency:
+  group: pages-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: gh-pages
+
+      - uses: actions/configure-pages@v5
+
+      # Upload the entire gh-pages tree as-is. mike (zensical site) and the
+      # Doxygen workflow have already arranged the branch layout; we just
+      # publish what's there.
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: .
+
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -11,10 +11,12 @@ OUTPUT_DIRECTORY       = docs
 OUTPUT_LANGUAGE        = English
 
 # Input settings
-INPUT                  = @CMAKE_CURRENT_SOURCE_DIR@/README.md @CMAKE_CURRENT_SOURCE_DIR@/lib
+# The project README is intentionally excluded: the zensical site already
+# renders it as its landing page, so including it here would just duplicate
+# that content on the API reference site.
+INPUT                  = @CMAKE_CURRENT_SOURCE_DIR@/lib
 FILE_PATTERNS          = *.c *.cpp *.h *.hpp *.md
 RECURSIVE              = YES
-USE_MDFILE_AS_MAINPAGE = README.md
 
 # Build settings
 EXTRACT_ALL            = YES
@@ -49,9 +51,9 @@ SORT_MEMBER_DOCS       = YES
 SORT_BRIEF_DOCS        = YES
 SORT_BY_SCOPE_NAME     = YES
 
-GENERATE_TREEVIEW      = YES 
+GENERATE_TREEVIEW      = YES
 DISABLE_INDEX          = NO
 FULL_SIDEBAR           = NO
 HTML_EXTRA_STYLESHEET  = @AWESOME_CSS_DIR@/doxygen-awesome.css
-HTML_COLORSTYLE        = LIGHT 
+HTML_COLORSTYLE        = LIGHT
 GENERATE_TODOLIST      = YES

--- a/docs/API Reference.md
+++ b/docs/API Reference.md
@@ -8,18 +8,18 @@ SPDX-License-Identifier: CC-BY-4.0
 The C/C++ API reference is generated separately with [Doxygen] and published
 alongside this site.
 
-- **[Latest API reference](https://dmf-mxl.github.io/mxl/api/latest/)** —
+- **[Latest API reference](https://peterbrightwell.github.io/mxl/api/latest/)** —
   tracks the tip of the default branch.
-- **[Browse all published versions](https://dmf-mxl.github.io/mxl/api/)** —
+- **[Browse all published versions](https://peterbrightwell.github.io/mxl/api/)** —
   one directory per released tag (e.g. `v1.1.0/`) plus branch builds.
 
 To view the API docs for a specific release, navigate to
-`https://dmf-mxl.github.io/mxl/api/<version>/` (for example,
-[`api/v1.1.0/`](https://dmf-mxl.github.io/mxl/api/v1.1.0/)).
+`https://peterbrightwell.github.io/mxl/api/<version>/` (for example,
+[`api/v1.1.0/`](https://peterbrightwell.github.io/mxl/api/v1.1.0/)).
 
-The Doxygen build is driven by [`Doxyfile.in`](https://github.com/dmf-mxl/mxl/blob/main/Doxyfile.in)
+The Doxygen build is driven by [`Doxyfile.in`](https://github.com/peterbrightwell/mxl/blob/main/Doxyfile.in)
 and published by the
-[`Build Doxygen Documentation`](https://github.com/dmf-mxl/mxl/blob/main/.github/workflows/doxy-docs.yml)
+[`Build Doxygen Documentation`](https://github.com/peterbrightwell/mxl/blob/main/.github/workflows/doxy-docs.yml)
 workflow.
 
 [Doxygen]: https://www.doxygen.nl/

--- a/docs/API Reference.md
+++ b/docs/API Reference.md
@@ -8,18 +8,16 @@ SPDX-License-Identifier: CC-BY-4.0
 The C/C++ API reference is generated separately with [Doxygen] and published
 alongside this site.
 
-- **[Latest API reference](https://peterbrightwell.github.io/mxl/api/latest/)** —
-  tracks the tip of the default branch.
-- **[Browse all published versions](https://peterbrightwell.github.io/mxl/api/)** —
-  one directory per released tag (e.g. `v1.1.0/`) plus branch builds.
+- **[API reference for this version (`__BUILD_REF__`)](__SITE_BASE__/api/__BUILD_REF__/)**
+  — matches the version of the docs you are currently reading.
+- **[Latest API reference](__SITE_BASE__/api/latest/)** — tracks the tip of the
+  default branch.
+- **[Browse all published versions](__SITE_BASE__/api/)** — index of every
+  published tag and branch build.
 
-To view the API docs for a specific release, navigate to
-`https://peterbrightwell.github.io/mxl/api/<version>/` (for example,
-[`api/v1.1.0/`](https://peterbrightwell.github.io/mxl/api/v1.1.0/)).
-
-The Doxygen build is driven by [`Doxyfile.in`](https://github.com/peterbrightwell/mxl/blob/main/Doxyfile.in)
+The Doxygen build is driven by [`Doxyfile.in`](https://github.com/__REPO_SLUG__/blob/main/Doxyfile.in)
 and published by the
-[`Build Doxygen Documentation`](https://github.com/peterbrightwell/mxl/blob/main/.github/workflows/doxy-docs.yml)
+[`Build Doxygen Documentation`](https://github.com/__REPO_SLUG__/blob/main/.github/workflows/doxy-docs.yml)
 workflow.
 
 [Doxygen]: https://www.doxygen.nl/

--- a/docs/API Reference.md
+++ b/docs/API Reference.md
@@ -1,0 +1,25 @@
+<!--
+SPDX-FileCopyrightText: 2025 Contributors to the Media eXchange Layer project.
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
+# API Reference
+
+The C/C++ API reference is generated separately with [Doxygen] and published
+alongside this site.
+
+- **[Latest API reference](https://dmf-mxl.github.io/mxl/api/latest/)** —
+  tracks the tip of the default branch.
+- **[Browse all published versions](https://dmf-mxl.github.io/mxl/api/)** —
+  one directory per released tag (e.g. `v1.1.0/`) plus branch builds.
+
+To view the API docs for a specific release, navigate to
+`https://dmf-mxl.github.io/mxl/api/<version>/` (for example,
+[`api/v1.1.0/`](https://dmf-mxl.github.io/mxl/api/v1.1.0/)).
+
+The Doxygen build is driven by [`Doxyfile.in`](https://github.com/dmf-mxl/mxl/blob/main/Doxyfile.in)
+and published by the
+[`Build Doxygen Documentation`](https://github.com/dmf-mxl/mxl/blob/main/.github/workflows/doxy-docs.yml)
+workflow.
+
+[Doxygen]: https://www.doxygen.nl/

--- a/zensical.toml
+++ b/zensical.toml
@@ -33,6 +33,17 @@ site_author = "The MXL Project"
 # Read more: https://zensical.org/docs/setup/basics/#site_url
 #site_url = "https://www.example.com/"
 
+# The repository this project lives in. Zensical renders a link (with the
+# host's icon --- GitHub octocat here) in the top-right of the page header
+# and enables optional "edit this page" / "view source" actions via the
+# content.action.* features below. Templated by .github/scripts/prepare-docs.sh
+# so both fork builds (e.g. peterbrightwell/mxl) and the upstream
+# (dmf-mxl/mxl) point at the correct repo without config drift.
+#
+# Read more: https://zensical.org/docs/setup/repository/
+repo_name = "__REPO_SLUG__"
+repo_url = "https://github.com/__REPO_SLUG__"
+
 # The copyright notice appears in the page footer and can contain an HTML
 # fragment.
 #


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2026 Contributors to the Media eXchange Layer project. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- Before submitting a pull request, please check that:
- it has a suitably descriptive title
- it mentions any issue(s) that it addresses
- you have considered whether it should be backported (specify how far back below)
- any required regression tests have run successfully
- all commits are signed-off: see [here](https://github.com/dmf-mxl/mxl/blob/main/CONTRIBUTING.md#commit-sign-off) for more information
-->

# Details
Adds a doxy-docs.yml action to build Doxygen pages. Separate to the Zensical build but both happen via gh-pages and are consistent. There are links between.  Requires settings change for Pages to build from a new pages-depoly.yml action rather than GitHub's legacy builder, which uses deprecated node version.

Tested ok at https://peterbrightwell.github.io/mxl/api/latest/ etc

Uses some GitHub Copilot code.

Addresses #563

# Backport requirements
Maybe not because it runs from main by default.
