### PR TITLE
CI: update cache and registry login actions for Node 24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
         run: git submodule update --init --recursive
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -130,7 +130,7 @@ jobs:
             "
 
       - name: Restore vcpkg cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ${{ github.workspace }}/vcpkg_cache
           key: vcpkg-${{ steps.docker-hash.outputs.image-tag }}-${{ hashFiles('vcpkg.json') }}
@@ -150,7 +150,7 @@ jobs:
             "
 
       - name: Save vcpkg cache
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ${{ github.workspace }}/vcpkg_cache
           key: vcpkg-${{ steps.docker-hash.outputs.image-tag }}-${{ hashFiles('vcpkg.json') }}
@@ -205,7 +205,7 @@ jobs:
         run: git submodule update --init --recursive
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -282,7 +282,7 @@ jobs:
           docker tag ${{ steps.docker-hash.outputs.image-tag }} mxl_build_container_with_source
 
       - name: Cache Cargo registry
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin/


### PR DESCRIPTION
# Details

Update `docker/login-action` from v3 to v4 and the cache actions from v3/v4 to v5. These releases use the Node 24 runtime and avoid the Node 20 deprecation warnings on GitHub-hosted runners.

# Backport requirements

None.