### PR TITLE
Fix devcontainer's dockerfile for use in multiarch environments

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -118,8 +118,11 @@ RUN git clone --depth 1 --branch 0.14.5 \
       https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs.git \
       /tmp/gst-plugins-rs \
  && cd /tmp/gst-plugins-rs \
- && cargo build --release -p gst-plugin-closedcaption \
- && sudo install -m 0644 target/release/libgstrsclosedcaption.so \
-      "/usr/lib/$(gcc -dumpmachine)/gstreamer-1.0/" \
- && cd / \
- && rm -rf /tmp/gst-plugins-rs
+ && cargo build --release -p gst-plugin-closedcaption
+
+USER root
+RUN install -m 0644 /tmp/gst-plugins-rs/target/release/libgstrsclosedcaption.so \
+    "/usr/lib/$(gcc -dumpmachine)/gstreamer-1.0/"
+
+USER "${USERNAME}"
+RUN rm -rf /tmp/gst-plugins-rs


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2026 Contributors to the Media eXchange Layer project. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- Before submitting a pull request, please check that:
- it has a suitably descriptive title
- it mentions any issue(s) that it addresses
- you have considered whether it should be backported (specify how far back below)
- any required regression tests have run successfully
- all commits are signed-off: see [here](https://github.com/dmf-mxl/mxl/blob/main/CONTRIBUTING.md#commit-sign-off) for more information
-->

# Details
As we package MXL in our builds, we use the devcontainer in a multiarch environment to produce builds for x64 as well as ARM (aarch64). Unfortunately, the sudo command doesn't work within the multiarch environment for ARM. This fixes that workflow for us.

# Backport requirements
Yes: release/1.1