### PR TITLE
Add Rust Bindings for Fabrics API

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -317,7 +317,7 @@ jobs:
             -i mxl_build_container_with_source \
             bash -c "
               cd /workspace/mxl/rust && \
-              cargo build --release --all-targets --locked
+              cargo build --release --features mxl-fabrics-ofi --all-targets --locked
             "
 
       - name: Test the Rust bindings
@@ -336,7 +336,7 @@ jobs:
             -i mxl_build_container_with_source \
             bash -c "
               cd /workspace/mxl/rust && \
-              cargo test --release --all-targets --locked -- --test-threads=1 --show-output
+              cargo test --release --all-targets --features mxl-fabrics-ofi --locked -- --test-threads=1 --show-output
             " 2>&1 | tee test.log
           status=${PIPESTATUS[0]}
           set -e
@@ -354,3 +354,4 @@ jobs:
             } >> "$GITHUB_STEP_SUMMARY"
           fi
           exit "${status}"
+

--- a/rust/.gitignore
+++ b/rust/.gitignore
@@ -4,4 +4,4 @@
 .DS_Store
 .idea
 .vscode
-target
+/target

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -32,27 +32,21 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.14"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
-
-[[package]]
-name = "anyhow"
-version = "1.0.102"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "atomic_refcell"
-version = "0.1.14"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e4227379beff4205943696e6c3e0cd809bacdf3f0edd6e3dd153e2269571a4"
+checksum = "41e67cd8309bbd06cd603a9e693a784ac2e5d1e955f11286e355089fcab3047c"
 
 [[package]]
 name = "autocfg"
-version = "1.5.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base64"
@@ -77,15 +71,15 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash",
- "shlex 1.3.0",
+ "shlex",
  "syn",
 ]
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "bitstream-io"
@@ -107,18 +101,18 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.3"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "cc"
-version = "1.2.63"
+version = "1.2.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+checksum = "90583009037521a116abf44494efecd645ba48b6622457080f080b85544e2215"
 dependencies = [
  "find-msvc-tools",
- "shlex 2.0.1",
+ "shlex",
 ]
 
 [[package]]
@@ -154,9 +148,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-expr"
-version = "0.20.8"
+version = "0.20.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb693542bcafa528e198be0ebd9d3632ca5b7c93dbe7237460e199910835997c"
+checksum = "21be0e1ce6cdb2ee7fff840f922fb04ead349e5cfb1e750b769132d44ce04720"
 dependencies = [
  "smallvec",
  "target-lexicon",
@@ -170,15 +164,15 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
 dependencies = [
  "iana-time-zone",
  "num-traits",
@@ -198,9 +192,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.5.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -208,9 +202,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.5.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -218,9 +212,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -230,15 +224,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.1.0"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "cmake"
-version = "0.1.58"
+version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+checksum = "b042e5d8a74ae91bb0961acd039822472ec99f8ab0948cbf6d1369588f8be586"
 dependencies = [
  "cc",
 ]
@@ -250,6 +244,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+<<<<<<< HEAD
+=======
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
+>>>>>>> 2f115003 (Remove dependency to anyhow.)
 name = "ctrlc"
 version = "3.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -274,9 +327,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "equivalent"
@@ -286,36 +339,30 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
-name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -324,9 +371,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -341,34 +388,34 @@ checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
  "futures-macro",
  "futures-task",
  "pin-project-lite",
+ "pin-utils",
  "slab",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
  "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -485,9 +532,9 @@ dependencies = [
 
 [[package]]
 name = "gst-plugin-version-helper"
-version = "0.8.4"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94668bc2592732b8c2b653668ae41211d45988fb61264888b9c2d545d4bd826d"
+checksum = "a68a894ef2d738054b950e1dbef5d9012b63fd968d4d32dbccd31bd8d8d4b219"
 dependencies = [
  "chrono",
  "toml_edit",
@@ -495,9 +542,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer"
-version = "0.24.5"
+version = "0.24.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e8251db223ca38d9aefaf3d19f6f11581a9123cd12dacebd8b9e182da965023"
+checksum = "0bed73742c5d54cb48533be608b67d89f96e1ebbba280be7823f1ef995e3a9d7"
 dependencies = [
  "cfg-if",
  "futures-channel",
@@ -604,9 +651,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-sys"
-version = "0.24.5"
+version = "0.24.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5d37c1a599ae57b8186948bd5699f2dbfc044baea9d400228b489a85bcf2759"
+checksum = "5d88630697e757c319e7bcec7b13919ba80492532dd3238481c1c4eee05d4904"
 dependencies = [
  "cfg-if",
  "glib-sys",
@@ -647,18 +694,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "heck"
@@ -668,9 +706,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.65"
+version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -691,21 +729,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.1",
- "serde",
- "serde_core",
+ "hashbrown",
 ]
 
 [[package]]
@@ -728,18 +758,16 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.18"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.99"
+version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
 dependencies = [
- "cfg-if",
- "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -760,16 +788,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libloading"
@@ -783,9 +805,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.30"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "matchers"
@@ -798,9 +820,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "minimal-lexical"
@@ -818,7 +840,6 @@ checksum = "956787520e75e9bd233246045d19f42fb73242759cc57fba9611d940ae96d4b0"
 name = "mxl"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "base64",
  "clap",
  "ctrlc",
@@ -855,9 +876,9 @@ dependencies = [
 
 [[package]]
 name = "no_std_io2"
-version = "0.9.4"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003"
+checksum = "b51ed7824b6e07d354605f4abb3d9d300350701299da96642ee084f5ce631550"
 dependencies = [
  "memchr",
 ]
@@ -926,9 +947,9 @@ checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "once_cell"
-version = "1.21.4"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "option-operations"
@@ -941,21 +962,27 @@ dependencies = [
 
 [[package]]
 name = "pastey"
-version = "0.2.3"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.17"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.33"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "prettyplease"
@@ -969,42 +996,42 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.5.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
  "toml_edit",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "r-efi"
-version = "6.0.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1014,9 +1041,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1025,15 +1052,15 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustversion"
@@ -1042,10 +1069,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
-name = "semver"
-version = "1.0.28"
+name = "ryu"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "serde"
@@ -1079,22 +1106,22 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
  "itoa",
  "memchr",
+ "ryu",
  "serde",
  "serde_core",
- "zmij",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "1.1.1"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
 dependencies = [
  "serde_core",
 ]
@@ -1115,16 +1142,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "shlex"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
-
-[[package]]
 name = "slab"
-version = "0.4.12"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"
@@ -1151,9 +1172,9 @@ dependencies = [
 
 [[package]]
 name = "system-deps"
-version = "7.0.8"
+version = "7.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "396a35feb67335377e0251fcbc1092fc85c484bd4e3a7a54319399da127796e7"
+checksum = "48c8f33736f986f16d69b6cb8b03f55ddcad5c41acc4ccc39dd88e84aa805e7f"
 dependencies = [
  "cfg-expr",
  "heck",
@@ -1164,24 +1185,24 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.13.5"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
+checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1199,9 +1220,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.2+spec-1.1.0"
+version = "0.9.9+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+checksum = "eb5238e643fc34a1d5d7e753e1532a91912d74b63b92b3ea51fde8d1b7bc79dd"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -1214,18 +1235,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.1.1+spec-1.1.0"
+version = "0.7.4+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+checksum = "fe3cea6b2aa3b910092f6abd4053ea464fab5f9c170ba5e9a6aead16ec4af2b6"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.25.12+spec-1.1.0"
+version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -1235,24 +1256,24 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.0.5+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "4c03bee5ce3696f31250db0bbaff18bc43301ce0e8db2ed1f07cbb2acf89984c"
 dependencies = [
  "winnow",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
+version = "1.0.5+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+checksum = "a9cd6190959dce0994aa8970cd32ab116d1851ead27e866039acaf2524ce44fa"
 
 [[package]]
 name = "tracing"
-version = "0.1.44"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+checksum = "2d15d90a0b5c19378952d479dc858407149d7bb45a14de0142f6c534b16fc647"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -1273,9 +1294,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.36"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+checksum = "7a04e24fab5c89c6a36eb8558c9656f30d81de51dfa4d3b45f26b21d61fa0a6c"
 dependencies = [
  "once_cell",
  "valuable",
@@ -1294,9 +1315,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.23"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -1312,9 +1333,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-test"
-version = "0.2.6"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19a4c448db514d4f24c5ddb9f73f2ee71bfb24c526cf0c570ba142d1119e0051"
+checksum = "557b891436fe0d5e0e363427fc7f217abf9ccd510d5136549847bdcbcd011d68"
 dependencies = [
  "tracing-core",
  "tracing-subscriber",
@@ -1323,9 +1344,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-test-macro"
-version = "0.2.6"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad06847b7afb65c7866a36664b75c40b895e318cea4f71299f013fb22965329d"
+checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
 dependencies = [
  "quote",
  "syn",
@@ -1333,9 +1354,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.24"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "unicode-width"
@@ -1344,16 +1365,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "uuid"
-version = "1.23.2"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
+checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
 dependencies = [
  "getrandom",
  "js-sys",
@@ -1375,27 +1390,18 @@ checksum = "03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.122"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1406,9 +1412,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.122"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1416,9 +1422,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.122"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1429,45 +1435,11 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.122"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
 ]
 
 [[package]]
@@ -1540,109 +1512,15 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.3"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
-
-[[package]]
-name = "zmij"
-version = "1.0.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -818,6 +818,7 @@ checksum = "956787520e75e9bd233246045d19f42fb73242759cc57fba9611d940ae96d4b0"
 name = "mxl"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "base64",
  "clap",
  "ctrlc",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7,28 +7,21 @@ name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
-dependencies = [
- "memchr",
-]
+dependencies = ["memchr"]
 
 [[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
+dependencies = ["libc"]
 
 [[package]]
 name = "annotate-snippets"
 version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "710e8eae58854cdc1790fcb56cca04d712a17be849eeb81da2a724bf4bae2bc4"
-dependencies = [
- "anstyle",
- "unicode-width",
-]
+dependencies = ["anstyle", "unicode-width"]
 
 [[package]]
 name = "anstyle"
@@ -60,19 +53,19 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "annotate-snippets",
- "bitflags",
- "cexpr",
- "clang-sys",
- "itertools 0.13.0",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "syn",
+  "annotate-snippets",
+  "bitflags",
+  "cexpr",
+  "clang-sys",
+  "itertools 0.13.0",
+  "log",
+  "prettyplease",
+  "proc-macro2",
+  "quote",
+  "regex",
+  "rustc-hash",
+  "shlex",
+  "syn",
 ]
 
 [[package]]
@@ -86,18 +79,14 @@ name = "bitstream-io"
 version = "4.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7eff00be299a18769011411c9def0d827e8f2d7bf0c3dbf53633147a8867fd1f"
-dependencies = [
- "no_std_io2",
-]
+dependencies = ["no_std_io2"]
 
 [[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
-dependencies = [
- "objc2",
-]
+dependencies = ["objc2"]
 
 [[package]]
 name = "bumpalo"
@@ -110,51 +99,35 @@ name = "cc"
 version = "1.2.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90583009037521a116abf44494efecd645ba48b6622457080f080b85544e2215"
-dependencies = [
- "find-msvc-tools",
- "shlex",
-]
+dependencies = ["find-msvc-tools", "shlex"]
 
 [[package]]
 name = "cdp-types"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "332ca05a88e143d80a245f9aa6c65b6e6383ee3e332017005647c27c6a62f902"
-dependencies = [
- "cea708-types",
- "log",
- "thiserror",
-]
+dependencies = ["cea708-types", "log", "thiserror"]
 
 [[package]]
 name = "cea708-types"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de28b1d549e7f8f53a746fb36ae4c10c776a8e004950b527be1669a58667ae0b"
-dependencies = [
- "log",
- "muldiv",
- "thiserror",
-]
+dependencies = ["log", "muldiv", "thiserror"]
 
 [[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
-]
+dependencies = ["nom"]
 
 [[package]]
 name = "cfg-expr"
 version = "0.20.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21be0e1ce6cdb2ee7fff840f922fb04ead349e5cfb1e750b769132d44ce04720"
-dependencies = [
- "smallvec",
- "target-lexicon",
-]
+dependencies = ["smallvec", "target-lexicon"]
 
 [[package]]
 name = "cfg-if"
@@ -173,54 +146,35 @@ name = "chrono"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
-dependencies = [
- "iana-time-zone",
- "num-traits",
- "windows-link",
-]
+dependencies = ["iana-time-zone", "num-traits", "windows-link"]
 
 [[package]]
 name = "clang-sys"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading",
-]
+dependencies = ["glob", "libc", "libloading"]
 
 [[package]]
 name = "clap"
 version = "4.5.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
-dependencies = [
- "clap_builder",
- "clap_derive",
-]
+dependencies = ["clap_builder", "clap_derive"]
 
 [[package]]
 name = "clap_builder"
 version = "4.5.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
-dependencies = [
- "anstyle",
- "clap_lex",
-]
+dependencies = ["anstyle", "clap_lex"]
 
 [[package]]
 name = "clap_derive"
 version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
-]
+dependencies = ["heck", "proc-macro2", "quote", "syn"]
 
 [[package]]
 name = "clap_lex"
@@ -233,9 +187,7 @@ name = "cmake"
 version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b042e5d8a74ae91bb0961acd039822472ec99f8ab0948cbf6d1369588f8be586"
-dependencies = [
- "cc",
-]
+dependencies = ["cc"]
 
 [[package]]
 name = "core-foundation-sys"
@@ -244,86 +196,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-<<<<<<< HEAD
-=======
-name = "crossbeam"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
-
-[[package]]
->>>>>>> 2f115003 (Remove dependency to anyhow.)
 name = "ctrlc"
 version = "3.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
-dependencies = [
- "dispatch2",
- "nix",
- "windows-sys",
-]
+dependencies = ["dispatch2", "nix", "windows-sys"]
 
 [[package]]
 name = "dispatch2"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
-dependencies = [
- "bitflags",
- "block2",
- "libc",
- "objc2",
-]
+dependencies = ["bitflags", "block2", "libc", "objc2"]
 
 [[package]]
 name = "either"
@@ -348,9 +232,7 @@ name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
-dependencies = [
- "futures-core",
-]
+dependencies = ["futures-core"]
 
 [[package]]
 name = "futures-core"
@@ -363,22 +245,14 @@ name = "futures-executor"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
+dependencies = ["futures-core", "futures-task", "futures-util"]
 
 [[package]]
 name = "futures-macro"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
+dependencies = ["proc-macro2", "quote", "syn"]
 
 [[package]]
 name = "futures-sink"
@@ -398,12 +272,12 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
- "futures-core",
- "futures-macro",
- "futures-task",
- "pin-project-lite",
- "pin-utils",
- "slab",
+  "futures-core",
+  "futures-macro",
+  "futures-task",
+  "pin-project-lite",
+  "pin-utils",
+  "slab",
 ]
 
 [[package]]
@@ -411,25 +285,14 @@ name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi",
- "wasip2",
-]
+dependencies = ["cfg-if", "libc", "r-efi", "wasip2"]
 
 [[package]]
 name = "gio-sys"
 version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0071fe88dba8e40086c8ff9bbb62622999f49628344b1d1bf490a48a29d80f22"
-dependencies = [
- "glib-sys",
- "gobject-sys",
- "libc",
- "system-deps",
- "windows-sys",
-]
+dependencies = ["glib-sys", "gobject-sys", "libc", "system-deps", "windows-sys"]
 
 [[package]]
 name = "glib"
@@ -437,19 +300,19 @@ version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16de123c2e6c90ce3b573b7330de19be649080ec612033d397d72da265f1bd8b"
 dependencies = [
- "bitflags",
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-task",
- "futures-util",
- "gio-sys",
- "glib-macros",
- "glib-sys",
- "gobject-sys",
- "libc",
- "memchr",
- "smallvec",
+  "bitflags",
+  "futures-channel",
+  "futures-core",
+  "futures-executor",
+  "futures-task",
+  "futures-util",
+  "gio-sys",
+  "glib-macros",
+  "glib-sys",
+  "gobject-sys",
+  "libc",
+  "memchr",
+  "smallvec",
 ]
 
 [[package]]
@@ -457,23 +320,14 @@ name = "glib-macros"
 version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf59b675301228a696fe01c3073974643365080a76cc3ed5bc2cbc466ad87f17"
-dependencies = [
- "heck",
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn",
-]
+dependencies = ["heck", "proc-macro-crate", "proc-macro2", "quote", "syn"]
 
 [[package]]
 name = "glib-sys"
 version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d95e1a3a19ae464a7286e14af9a90683c64d70c02532d88d87ce95056af3e6c"
-dependencies = [
- "libc",
- "system-deps",
-]
+dependencies = ["libc", "system-deps"]
 
 [[package]]
 name = "glob"
@@ -486,48 +340,44 @@ name = "gobject-sys"
 version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dca35da0d19a18f4575f3cb99fe1c9e029a2941af5662f326f738a21edaf294"
-dependencies = [
- "glib-sys",
- "libc",
- "system-deps",
-]
+dependencies = ["glib-sys", "libc", "system-deps"]
 
 [[package]]
 name = "gst-avsynctest-rs"
 version = "0.1.0"
 dependencies = [
- "cdp-types",
- "cea708-types",
- "glib",
- "gst-plugin-version-helper",
- "gstreamer",
- "gstreamer-app",
- "gstreamer-audio",
- "gstreamer-base",
- "gstreamer-video",
+  "cdp-types",
+  "cea708-types",
+  "glib",
+  "gst-plugin-version-helper",
+  "gstreamer",
+  "gstreamer-app",
+  "gstreamer-audio",
+  "gstreamer-base",
+  "gstreamer-video",
 ]
 
 [[package]]
 name = "gst-mxl-rs"
 version = "0.1.0"
 dependencies = [
- "bitstream-io",
- "glib",
- "gst-avsynctest-rs",
- "gst-plugin-version-helper",
- "gstreamer",
- "gstreamer-app",
- "gstreamer-audio",
- "gstreamer-base",
- "gstreamer-video",
- "mxl",
- "regex",
- "serde_json",
- "thiserror",
- "tracing",
- "tracing-subscriber",
- "tracing-test",
- "uuid",
+  "bitstream-io",
+  "glib",
+  "gst-avsynctest-rs",
+  "gst-plugin-version-helper",
+  "gstreamer",
+  "gstreamer-app",
+  "gstreamer-audio",
+  "gstreamer-base",
+  "gstreamer-video",
+  "mxl",
+  "regex",
+  "serde_json",
+  "thiserror",
+  "tracing",
+  "tracing-subscriber",
+  "tracing-test",
+  "uuid",
 ]
 
 [[package]]
@@ -535,10 +385,7 @@ name = "gst-plugin-version-helper"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a68a894ef2d738054b950e1dbef5d9012b63fd968d4d32dbccd31bd8d8d4b219"
-dependencies = [
- "chrono",
- "toml_edit",
-]
+dependencies = ["chrono", "toml_edit"]
 
 [[package]]
 name = "gstreamer"
@@ -546,23 +393,23 @@ version = "0.24.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bed73742c5d54cb48533be608b67d89f96e1ebbba280be7823f1ef995e3a9d7"
 dependencies = [
- "cfg-if",
- "futures-channel",
- "futures-core",
- "futures-util",
- "glib",
- "gstreamer-sys",
- "itertools 0.14.0",
- "kstring",
- "libc",
- "muldiv",
- "num-integer",
- "num-rational",
- "option-operations",
- "pastey",
- "pin-project-lite",
- "smallvec",
- "thiserror",
+  "cfg-if",
+  "futures-channel",
+  "futures-core",
+  "futures-util",
+  "glib",
+  "gstreamer-sys",
+  "itertools 0.14.0",
+  "kstring",
+  "libc",
+  "muldiv",
+  "num-integer",
+  "num-rational",
+  "option-operations",
+  "pastey",
+  "pin-project-lite",
+  "smallvec",
+  "thiserror",
 ]
 
 [[package]]
@@ -571,13 +418,13 @@ version = "0.24.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3da7017b2a2fa5cdf9123b1603947ea24174f6d8cea0ea673411df824c811921"
 dependencies = [
- "futures-core",
- "futures-sink",
- "glib",
- "gstreamer",
- "gstreamer-app-sys",
- "gstreamer-base",
- "libc",
+  "futures-core",
+  "futures-sink",
+  "glib",
+  "gstreamer",
+  "gstreamer-app-sys",
+  "gstreamer-base",
+  "libc",
 ]
 
 [[package]]
@@ -586,11 +433,11 @@ version = "0.24.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fa9f1b12b546aea543c15a0fdbc5a53617902a74f6d357a32b6a9fb4bc4725c"
 dependencies = [
- "glib-sys",
- "gstreamer-base-sys",
- "gstreamer-sys",
- "libc",
- "system-deps",
+  "glib-sys",
+  "gstreamer-base-sys",
+  "gstreamer-sys",
+  "libc",
+  "system-deps",
 ]
 
 [[package]]
@@ -599,13 +446,13 @@ version = "0.24.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76c058cce8d32bfb6dd578a3d6d1d874b855a638b738d8bb34cd7aedd65aeddd"
 dependencies = [
- "cfg-if",
- "glib",
- "gstreamer",
- "gstreamer-audio-sys",
- "gstreamer-base",
- "libc",
- "smallvec",
+  "cfg-if",
+  "glib",
+  "gstreamer",
+  "gstreamer-audio-sys",
+  "gstreamer-base",
+  "libc",
+  "smallvec",
 ]
 
 [[package]]
@@ -614,12 +461,12 @@ version = "0.24.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "807e476f555c4e7409d8c8fe4fd10fa9989b8e8f2898762d9551e1adfde98a2d"
 dependencies = [
- "glib-sys",
- "gobject-sys",
- "gstreamer-base-sys",
- "gstreamer-sys",
- "libc",
- "system-deps",
+  "glib-sys",
+  "gobject-sys",
+  "gstreamer-base-sys",
+  "gstreamer-sys",
+  "libc",
+  "system-deps",
 ]
 
 [[package]]
@@ -628,12 +475,12 @@ version = "0.24.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9375f9a12120a8ee17b765c816c9b23861ce258def77b0ee40a05acb00c74972"
 dependencies = [
- "atomic_refcell",
- "cfg-if",
- "glib",
- "gstreamer",
- "gstreamer-base-sys",
- "libc",
+  "atomic_refcell",
+  "cfg-if",
+  "glib",
+  "gstreamer",
+  "gstreamer-base-sys",
+  "libc",
 ]
 
 [[package]]
@@ -642,11 +489,11 @@ version = "0.24.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b844f3559b6ab0379b4b771261643783ae4e0ffa71d5f5f46e33b7acf66b752"
 dependencies = [
- "glib-sys",
- "gobject-sys",
- "gstreamer-sys",
- "libc",
- "system-deps",
+  "glib-sys",
+  "gobject-sys",
+  "gstreamer-sys",
+  "libc",
+  "system-deps",
 ]
 
 [[package]]
@@ -654,13 +501,7 @@ name = "gstreamer-sys"
 version = "0.24.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d88630697e757c319e7bcec7b13919ba80492532dd3238481c1c4eee05d4904"
-dependencies = [
- "cfg-if",
- "glib-sys",
- "gobject-sys",
- "libc",
- "system-deps",
-]
+dependencies = ["cfg-if", "glib-sys", "gobject-sys", "libc", "system-deps"]
 
 [[package]]
 name = "gstreamer-video"
@@ -668,14 +509,14 @@ version = "0.24.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72d9ba5295b206563a990a087c6541d57f650dcd4be4ca8a5a149a758e8df8a0"
 dependencies = [
- "cfg-if",
- "futures-channel",
- "glib",
- "gstreamer",
- "gstreamer-base",
- "gstreamer-video-sys",
- "libc",
- "thiserror",
+  "cfg-if",
+  "futures-channel",
+  "glib",
+  "gstreamer",
+  "gstreamer-base",
+  "gstreamer-video-sys",
+  "libc",
+  "thiserror",
 ]
 
 [[package]]
@@ -684,12 +525,12 @@ version = "0.24.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20236fa412d7a50e59aa234b46828a99e3e5f06c4f80d271a49ecd2a1d3bfcbe"
 dependencies = [
- "glib-sys",
- "gobject-sys",
- "gstreamer-base-sys",
- "gstreamer-sys",
- "libc",
- "system-deps",
+  "glib-sys",
+  "gobject-sys",
+  "gstreamer-base-sys",
+  "gstreamer-sys",
+  "libc",
+  "system-deps",
 ]
 
 [[package]]
@@ -710,13 +551,13 @@ version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
 dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "log",
- "wasm-bindgen",
- "windows-core",
+  "android_system_properties",
+  "core-foundation-sys",
+  "iana-time-zone-haiku",
+  "js-sys",
+  "log",
+  "wasm-bindgen",
+  "windows-core",
 ]
 
 [[package]]
@@ -724,37 +565,28 @@ name = "iana-time-zone-haiku"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
-]
+dependencies = ["cc"]
 
 [[package]]
 name = "indexmap"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
-dependencies = [
- "equivalent",
- "hashbrown",
-]
+dependencies = ["equivalent", "hashbrown"]
 
 [[package]]
 name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
+dependencies = ["either"]
 
 [[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
-dependencies = [
- "either",
-]
+dependencies = ["either"]
 
 [[package]]
 name = "itoa"
@@ -767,19 +599,14 @@ name = "js-sys"
 version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
-dependencies = [
- "once_cell",
- "wasm-bindgen",
-]
+dependencies = ["once_cell", "wasm-bindgen"]
 
 [[package]]
 name = "kstring"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "558bf9508a558512042d3095138b1f7b8fe90c5467d94f9f1da28b3731c5dbd1"
-dependencies = [
- "static_assertions",
-]
+dependencies = ["static_assertions"]
 
 [[package]]
 name = "lazy_static"
@@ -798,10 +625,7 @@ name = "libloading"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
-dependencies = [
- "cfg-if",
- "windows-link",
-]
+dependencies = ["cfg-if", "windows-link"]
 
 [[package]]
 name = "log"
@@ -814,9 +638,7 @@ name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
-dependencies = [
- "regex-automata",
-]
+dependencies = ["regex-automata"]
 
 [[package]]
 name = "memchr"
@@ -840,104 +662,79 @@ checksum = "956787520e75e9bd233246045d19f42fb73242759cc57fba9611d940ae96d4b0"
 name = "mxl"
 version = "0.1.0"
 dependencies = [
- "base64",
- "clap",
- "ctrlc",
- "libloading",
- "mxl-sys",
- "serde",
- "serde_json",
- "thiserror",
- "tracing",
- "tracing-subscriber",
- "uuid",
+  "base64",
+  "clap",
+  "ctrlc",
+  "libloading",
+  "mxl-sys",
+  "serde",
+  "serde_json",
+  "thiserror",
+  "tracing",
+  "tracing-subscriber",
+  "uuid",
 ]
 
 [[package]]
 name = "mxl-sys"
 version = "0.1.0"
-dependencies = [
- "bindgen",
- "cmake",
- "libloading",
-]
+dependencies = ["bindgen", "cmake", "libloading"]
 
 [[package]]
 name = "nix"
 version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
-dependencies = [
- "bitflags",
- "cfg-if",
- "cfg_aliases",
- "libc",
-]
+dependencies = ["bitflags", "cfg-if", "cfg_aliases", "libc"]
 
 [[package]]
 name = "no_std_io2"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b51ed7824b6e07d354605f4abb3d9d300350701299da96642ee084f5ce631550"
-dependencies = [
- "memchr",
-]
+dependencies = ["memchr"]
 
 [[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
-]
+dependencies = ["memchr", "minimal-lexical"]
 
 [[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
-dependencies = [
- "windows-sys",
-]
+dependencies = ["windows-sys"]
 
 [[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
+dependencies = ["num-traits"]
 
 [[package]]
 name = "num-rational"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
-dependencies = [
- "num-integer",
- "num-traits",
-]
+dependencies = ["num-integer", "num-traits"]
 
 [[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
-dependencies = [
- "autocfg",
-]
+dependencies = ["autocfg"]
 
 [[package]]
 name = "objc2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
-dependencies = [
- "objc2-encode",
-]
+dependencies = ["objc2-encode"]
 
 [[package]]
 name = "objc2-encode"
@@ -956,9 +753,7 @@ name = "option-operations"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aca39cf52b03268400c16eeb9b56382ea3c3353409309b63f5c8f0b1faf42754"
-dependencies = [
- "pastey",
-]
+dependencies = ["pastey"]
 
 [[package]]
 name = "pastey"
@@ -989,37 +784,28 @@ name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
-]
+dependencies = ["proc-macro2", "syn"]
 
 [[package]]
 name = "proc-macro-crate"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
-dependencies = [
- "toml_edit",
-]
+dependencies = ["toml_edit"]
 
 [[package]]
 name = "proc-macro2"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
-dependencies = [
- "unicode-ident",
-]
+dependencies = ["unicode-ident"]
 
 [[package]]
 name = "quote"
 version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
-dependencies = [
- "proc-macro2",
-]
+dependencies = ["proc-macro2"]
 
 [[package]]
 name = "r-efi"
@@ -1032,23 +818,14 @@ name = "regex"
 version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
+dependencies = ["aho-corasick", "memchr", "regex-automata", "regex-syntax"]
 
 [[package]]
 name = "regex-automata"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
+dependencies = ["aho-corasick", "memchr", "regex-syntax"]
 
 [[package]]
 name = "regex-syntax"
@@ -1079,61 +856,42 @@ name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
-dependencies = [
- "serde_core",
- "serde_derive",
-]
+dependencies = ["serde_core", "serde_derive"]
 
 [[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
-dependencies = [
- "serde_derive",
-]
+dependencies = ["serde_derive"]
 
 [[package]]
 name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
+dependencies = ["proc-macro2", "quote", "syn"]
 
 [[package]]
 name = "serde_json"
 version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
-dependencies = [
- "itoa",
- "memchr",
- "ryu",
- "serde",
- "serde_core",
-]
+dependencies = ["itoa", "memchr", "ryu", "serde", "serde_core"]
 
 [[package]]
 name = "serde_spanned"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
-dependencies = [
- "serde_core",
-]
+dependencies = ["serde_core"]
 
 [[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
-dependencies = [
- "lazy_static",
-]
+dependencies = ["lazy_static"]
 
 [[package]]
 name = "shlex"
@@ -1164,24 +922,14 @@ name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
+dependencies = ["proc-macro2", "quote", "unicode-ident"]
 
 [[package]]
 name = "system-deps"
 version = "7.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c8f33736f986f16d69b6cb8b03f55ddcad5c41acc4ccc39dd88e84aa805e7f"
-dependencies = [
- "cfg-expr",
- "heck",
- "pkg-config",
- "toml",
- "version-compare",
-]
+dependencies = ["cfg-expr", "heck", "pkg-config", "toml", "version-compare"]
 
 [[package]]
 name = "target-lexicon"
@@ -1194,29 +942,21 @@ name = "thiserror"
 version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
-dependencies = [
- "thiserror-impl",
-]
+dependencies = ["thiserror-impl"]
 
 [[package]]
 name = "thiserror-impl"
 version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
+dependencies = ["proc-macro2", "quote", "syn"]
 
 [[package]]
 name = "thread_local"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
-dependencies = [
- "cfg-if",
-]
+dependencies = ["cfg-if"]
 
 [[package]]
 name = "toml"
@@ -1224,13 +964,13 @@ version = "0.9.9+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb5238e643fc34a1d5d7e753e1532a91912d74b63b92b3ea51fde8d1b7bc79dd"
 dependencies = [
- "indexmap",
- "serde_core",
- "serde_spanned",
- "toml_datetime",
- "toml_parser",
- "toml_writer",
- "winnow",
+  "indexmap",
+  "serde_core",
+  "serde_spanned",
+  "toml_datetime",
+  "toml_parser",
+  "toml_writer",
+  "winnow",
 ]
 
 [[package]]
@@ -1238,30 +978,21 @@ name = "toml_datetime"
 version = "0.7.4+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe3cea6b2aa3b910092f6abd4053ea464fab5f9c170ba5e9a6aead16ec4af2b6"
-dependencies = [
- "serde_core",
-]
+dependencies = ["serde_core"]
 
 [[package]]
 name = "toml_edit"
 version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
-dependencies = [
- "indexmap",
- "toml_datetime",
- "toml_parser",
- "winnow",
-]
+dependencies = ["indexmap", "toml_datetime", "toml_parser", "winnow"]
 
 [[package]]
 name = "toml_parser"
 version = "1.0.5+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c03bee5ce3696f31250db0bbaff18bc43301ce0e8db2ed1f07cbb2acf89984c"
-dependencies = [
- "winnow",
-]
+dependencies = ["winnow"]
 
 [[package]]
 name = "toml_writer"
@@ -1274,44 +1005,28 @@ name = "tracing"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d15d90a0b5c19378952d479dc858407149d7bb45a14de0142f6c534b16fc647"
-dependencies = [
- "log",
- "pin-project-lite",
- "tracing-attributes",
- "tracing-core",
-]
+dependencies = ["log", "pin-project-lite", "tracing-attributes", "tracing-core"]
 
 [[package]]
 name = "tracing-attributes"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
+dependencies = ["proc-macro2", "quote", "syn"]
 
 [[package]]
 name = "tracing-core"
 version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a04e24fab5c89c6a36eb8558c9656f30d81de51dfa4d3b45f26b21d61fa0a6c"
-dependencies = [
- "once_cell",
- "valuable",
-]
+dependencies = ["once_cell", "valuable"]
 
 [[package]]
 name = "tracing-log"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
-]
+dependencies = ["log", "once_cell", "tracing-core"]
 
 [[package]]
 name = "tracing-subscriber"
@@ -1319,16 +1034,16 @@ version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
 dependencies = [
- "matchers",
- "nu-ansi-term",
- "once_cell",
- "regex-automata",
- "sharded-slab",
- "smallvec",
- "thread_local",
- "tracing",
- "tracing-core",
- "tracing-log",
+  "matchers",
+  "nu-ansi-term",
+  "once_cell",
+  "regex-automata",
+  "sharded-slab",
+  "smallvec",
+  "thread_local",
+  "tracing",
+  "tracing-core",
+  "tracing-log",
 ]
 
 [[package]]
@@ -1336,21 +1051,14 @@ name = "tracing-test"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "557b891436fe0d5e0e363427fc7f217abf9ccd510d5136549847bdcbcd011d68"
-dependencies = [
- "tracing-core",
- "tracing-subscriber",
- "tracing-test-macro",
-]
+dependencies = ["tracing-core", "tracing-subscriber", "tracing-test-macro"]
 
 [[package]]
 name = "tracing-test-macro"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
-dependencies = [
- "quote",
- "syn",
-]
+dependencies = ["quote", "syn"]
 
 [[package]]
 name = "unicode-ident"
@@ -1369,12 +1077,7 @@ name = "uuid"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
-dependencies = [
- "getrandom",
- "js-sys",
- "serde_core",
- "wasm-bindgen",
-]
+dependencies = ["getrandom", "js-sys", "serde_core", "wasm-bindgen"]
 
 [[package]]
 name = "valuable"
@@ -1393,9 +1096,7 @@ name = "wasip2"
 version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
-dependencies = [
- "wit-bindgen",
-]
+dependencies = ["wit-bindgen"]
 
 [[package]]
 name = "wasm-bindgen"
@@ -1403,11 +1104,11 @@ version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
 dependencies = [
- "cfg-if",
- "once_cell",
- "rustversion",
- "wasm-bindgen-macro",
- "wasm-bindgen-shared",
+  "cfg-if",
+  "once_cell",
+  "rustversion",
+  "wasm-bindgen-macro",
+  "wasm-bindgen-shared",
 ]
 
 [[package]]
@@ -1415,32 +1116,21 @@ name = "wasm-bindgen-macro"
 version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
+dependencies = ["quote", "wasm-bindgen-macro-support"]
 
 [[package]]
 name = "wasm-bindgen-macro-support"
 version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
-dependencies = [
- "bumpalo",
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-shared",
-]
+dependencies = ["bumpalo", "proc-macro2", "quote", "syn", "wasm-bindgen-shared"]
 
 [[package]]
 name = "wasm-bindgen-shared"
 version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
-dependencies = [
- "unicode-ident",
-]
+dependencies = ["unicode-ident"]
 
 [[package]]
 name = "windows-core"
@@ -1448,11 +1138,11 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
+  "windows-implement",
+  "windows-interface",
+  "windows-link",
+  "windows-result",
+  "windows-strings",
 ]
 
 [[package]]
@@ -1460,22 +1150,14 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
+dependencies = ["proc-macro2", "quote", "syn"]
 
 [[package]]
 name = "windows-interface"
 version = "0.59.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
+dependencies = ["proc-macro2", "quote", "syn"]
 
 [[package]]
 name = "windows-link"
@@ -1488,36 +1170,28 @@ name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link",
-]
+dependencies = ["windows-link"]
 
 [[package]]
 name = "windows-strings"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link",
-]
+dependencies = ["windows-link"]
 
 [[package]]
 name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
-dependencies = [
- "windows-link",
-]
+dependencies = ["windows-link"]
 
 [[package]]
 name = "winnow"
 version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
-dependencies = [
- "memchr",
-]
+dependencies = ["memchr"]
 
 [[package]]
 name = "wit-bindgen"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7,21 +7,28 @@ name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
-dependencies = ["memchr"]
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = ["libc"]
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "annotate-snippets"
 version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "710e8eae58854cdc1790fcb56cca04d712a17be849eeb81da2a724bf4bae2bc4"
-dependencies = ["anstyle", "unicode-width"]
+dependencies = [
+ "anstyle",
+ "unicode-width",
+]
 
 [[package]]
 name = "anstyle"
@@ -53,19 +60,19 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
-  "annotate-snippets",
-  "bitflags",
-  "cexpr",
-  "clang-sys",
-  "itertools 0.13.0",
-  "log",
-  "prettyplease",
-  "proc-macro2",
-  "quote",
-  "regex",
-  "rustc-hash",
-  "shlex",
-  "syn",
+ "annotate-snippets",
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn",
 ]
 
 [[package]]
@@ -79,14 +86,18 @@ name = "bitstream-io"
 version = "4.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7eff00be299a18769011411c9def0d827e8f2d7bf0c3dbf53633147a8867fd1f"
-dependencies = ["no_std_io2"]
+dependencies = [
+ "no_std_io2",
+]
 
 [[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
-dependencies = ["objc2"]
+dependencies = [
+ "objc2",
+]
 
 [[package]]
 name = "bumpalo"
@@ -99,35 +110,51 @@ name = "cc"
 version = "1.2.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90583009037521a116abf44494efecd645ba48b6622457080f080b85544e2215"
-dependencies = ["find-msvc-tools", "shlex"]
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
 
 [[package]]
 name = "cdp-types"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "332ca05a88e143d80a245f9aa6c65b6e6383ee3e332017005647c27c6a62f902"
-dependencies = ["cea708-types", "log", "thiserror"]
+dependencies = [
+ "cea708-types",
+ "log",
+ "thiserror",
+]
 
 [[package]]
 name = "cea708-types"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de28b1d549e7f8f53a746fb36ae4c10c776a8e004950b527be1669a58667ae0b"
-dependencies = ["log", "muldiv", "thiserror"]
+dependencies = [
+ "log",
+ "muldiv",
+ "thiserror",
+]
 
 [[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = ["nom"]
+dependencies = [
+ "nom",
+]
 
 [[package]]
 name = "cfg-expr"
 version = "0.20.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21be0e1ce6cdb2ee7fff840f922fb04ead349e5cfb1e750b769132d44ce04720"
-dependencies = ["smallvec", "target-lexicon"]
+dependencies = [
+ "smallvec",
+ "target-lexicon",
+]
 
 [[package]]
 name = "cfg-if"
@@ -146,35 +173,54 @@ name = "chrono"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
-dependencies = ["iana-time-zone", "num-traits", "windows-link"]
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
+]
 
 [[package]]
 name = "clang-sys"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = ["glob", "libc", "libloading"]
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
 
 [[package]]
 name = "clap"
 version = "4.5.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
-dependencies = ["clap_builder", "clap_derive"]
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
 
 [[package]]
 name = "clap_builder"
 version = "4.5.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
-dependencies = ["anstyle", "clap_lex"]
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
 
 [[package]]
 name = "clap_derive"
 version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
-dependencies = ["heck", "proc-macro2", "quote", "syn"]
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "clap_lex"
@@ -187,7 +233,9 @@ name = "cmake"
 version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b042e5d8a74ae91bb0961acd039822472ec99f8ab0948cbf6d1369588f8be586"
-dependencies = ["cc"]
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "core-foundation-sys"
@@ -200,14 +248,23 @@ name = "ctrlc"
 version = "3.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
-dependencies = ["dispatch2", "nix", "windows-sys"]
+dependencies = [
+ "dispatch2",
+ "nix",
+ "windows-sys",
+]
 
 [[package]]
 name = "dispatch2"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
-dependencies = ["bitflags", "block2", "libc", "objc2"]
+dependencies = [
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
+]
 
 [[package]]
 name = "either"
@@ -232,7 +289,9 @@ name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
-dependencies = ["futures-core"]
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "futures-core"
@@ -245,14 +304,22 @@ name = "futures-executor"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
-dependencies = ["futures-core", "futures-task", "futures-util"]
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-macro"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
-dependencies = ["proc-macro2", "quote", "syn"]
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -272,12 +339,12 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
-  "futures-core",
-  "futures-macro",
-  "futures-task",
-  "pin-project-lite",
-  "pin-utils",
-  "slab",
+ "futures-core",
+ "futures-macro",
+ "futures-task",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -285,14 +352,25 @@ name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
-dependencies = ["cfg-if", "libc", "r-efi", "wasip2"]
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+]
 
 [[package]]
 name = "gio-sys"
 version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0071fe88dba8e40086c8ff9bbb62622999f49628344b1d1bf490a48a29d80f22"
-dependencies = ["glib-sys", "gobject-sys", "libc", "system-deps", "windows-sys"]
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+ "windows-sys",
+]
 
 [[package]]
 name = "glib"
@@ -300,19 +378,19 @@ version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16de123c2e6c90ce3b573b7330de19be649080ec612033d397d72da265f1bd8b"
 dependencies = [
-  "bitflags",
-  "futures-channel",
-  "futures-core",
-  "futures-executor",
-  "futures-task",
-  "futures-util",
-  "gio-sys",
-  "glib-macros",
-  "glib-sys",
-  "gobject-sys",
-  "libc",
-  "memchr",
-  "smallvec",
+ "bitflags",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-task",
+ "futures-util",
+ "gio-sys",
+ "glib-macros",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "memchr",
+ "smallvec",
 ]
 
 [[package]]
@@ -320,14 +398,23 @@ name = "glib-macros"
 version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf59b675301228a696fe01c3073974643365080a76cc3ed5bc2cbc466ad87f17"
-dependencies = ["heck", "proc-macro-crate", "proc-macro2", "quote", "syn"]
+dependencies = [
+ "heck",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "glib-sys"
 version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d95e1a3a19ae464a7286e14af9a90683c64d70c02532d88d87ce95056af3e6c"
-dependencies = ["libc", "system-deps"]
+dependencies = [
+ "libc",
+ "system-deps",
+]
 
 [[package]]
 name = "glob"
@@ -340,44 +427,48 @@ name = "gobject-sys"
 version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dca35da0d19a18f4575f3cb99fe1c9e029a2941af5662f326f738a21edaf294"
-dependencies = ["glib-sys", "libc", "system-deps"]
+dependencies = [
+ "glib-sys",
+ "libc",
+ "system-deps",
+]
 
 [[package]]
 name = "gst-avsynctest-rs"
 version = "0.1.0"
 dependencies = [
-  "cdp-types",
-  "cea708-types",
-  "glib",
-  "gst-plugin-version-helper",
-  "gstreamer",
-  "gstreamer-app",
-  "gstreamer-audio",
-  "gstreamer-base",
-  "gstreamer-video",
+ "cdp-types",
+ "cea708-types",
+ "glib",
+ "gst-plugin-version-helper",
+ "gstreamer",
+ "gstreamer-app",
+ "gstreamer-audio",
+ "gstreamer-base",
+ "gstreamer-video",
 ]
 
 [[package]]
 name = "gst-mxl-rs"
 version = "0.1.0"
 dependencies = [
-  "bitstream-io",
-  "glib",
-  "gst-avsynctest-rs",
-  "gst-plugin-version-helper",
-  "gstreamer",
-  "gstreamer-app",
-  "gstreamer-audio",
-  "gstreamer-base",
-  "gstreamer-video",
-  "mxl",
-  "regex",
-  "serde_json",
-  "thiserror",
-  "tracing",
-  "tracing-subscriber",
-  "tracing-test",
-  "uuid",
+ "bitstream-io",
+ "glib",
+ "gst-avsynctest-rs",
+ "gst-plugin-version-helper",
+ "gstreamer",
+ "gstreamer-app",
+ "gstreamer-audio",
+ "gstreamer-base",
+ "gstreamer-video",
+ "mxl",
+ "regex",
+ "serde_json",
+ "thiserror",
+ "tracing",
+ "tracing-subscriber",
+ "tracing-test",
+ "uuid",
 ]
 
 [[package]]
@@ -385,7 +476,10 @@ name = "gst-plugin-version-helper"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a68a894ef2d738054b950e1dbef5d9012b63fd968d4d32dbccd31bd8d8d4b219"
-dependencies = ["chrono", "toml_edit"]
+dependencies = [
+ "chrono",
+ "toml_edit",
+]
 
 [[package]]
 name = "gstreamer"
@@ -393,23 +487,23 @@ version = "0.24.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bed73742c5d54cb48533be608b67d89f96e1ebbba280be7823f1ef995e3a9d7"
 dependencies = [
-  "cfg-if",
-  "futures-channel",
-  "futures-core",
-  "futures-util",
-  "glib",
-  "gstreamer-sys",
-  "itertools 0.14.0",
-  "kstring",
-  "libc",
-  "muldiv",
-  "num-integer",
-  "num-rational",
-  "option-operations",
-  "pastey",
-  "pin-project-lite",
-  "smallvec",
-  "thiserror",
+ "cfg-if",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "glib",
+ "gstreamer-sys",
+ "itertools 0.14.0",
+ "kstring",
+ "libc",
+ "muldiv",
+ "num-integer",
+ "num-rational",
+ "option-operations",
+ "pastey",
+ "pin-project-lite",
+ "smallvec",
+ "thiserror",
 ]
 
 [[package]]
@@ -418,13 +512,13 @@ version = "0.24.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3da7017b2a2fa5cdf9123b1603947ea24174f6d8cea0ea673411df824c811921"
 dependencies = [
-  "futures-core",
-  "futures-sink",
-  "glib",
-  "gstreamer",
-  "gstreamer-app-sys",
-  "gstreamer-base",
-  "libc",
+ "futures-core",
+ "futures-sink",
+ "glib",
+ "gstreamer",
+ "gstreamer-app-sys",
+ "gstreamer-base",
+ "libc",
 ]
 
 [[package]]
@@ -433,11 +527,11 @@ version = "0.24.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fa9f1b12b546aea543c15a0fdbc5a53617902a74f6d357a32b6a9fb4bc4725c"
 dependencies = [
-  "glib-sys",
-  "gstreamer-base-sys",
-  "gstreamer-sys",
-  "libc",
-  "system-deps",
+ "glib-sys",
+ "gstreamer-base-sys",
+ "gstreamer-sys",
+ "libc",
+ "system-deps",
 ]
 
 [[package]]
@@ -446,13 +540,13 @@ version = "0.24.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76c058cce8d32bfb6dd578a3d6d1d874b855a638b738d8bb34cd7aedd65aeddd"
 dependencies = [
-  "cfg-if",
-  "glib",
-  "gstreamer",
-  "gstreamer-audio-sys",
-  "gstreamer-base",
-  "libc",
-  "smallvec",
+ "cfg-if",
+ "glib",
+ "gstreamer",
+ "gstreamer-audio-sys",
+ "gstreamer-base",
+ "libc",
+ "smallvec",
 ]
 
 [[package]]
@@ -461,12 +555,12 @@ version = "0.24.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "807e476f555c4e7409d8c8fe4fd10fa9989b8e8f2898762d9551e1adfde98a2d"
 dependencies = [
-  "glib-sys",
-  "gobject-sys",
-  "gstreamer-base-sys",
-  "gstreamer-sys",
-  "libc",
-  "system-deps",
+ "glib-sys",
+ "gobject-sys",
+ "gstreamer-base-sys",
+ "gstreamer-sys",
+ "libc",
+ "system-deps",
 ]
 
 [[package]]
@@ -475,12 +569,12 @@ version = "0.24.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9375f9a12120a8ee17b765c816c9b23861ce258def77b0ee40a05acb00c74972"
 dependencies = [
-  "atomic_refcell",
-  "cfg-if",
-  "glib",
-  "gstreamer",
-  "gstreamer-base-sys",
-  "libc",
+ "atomic_refcell",
+ "cfg-if",
+ "glib",
+ "gstreamer",
+ "gstreamer-base-sys",
+ "libc",
 ]
 
 [[package]]
@@ -489,11 +583,11 @@ version = "0.24.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b844f3559b6ab0379b4b771261643783ae4e0ffa71d5f5f46e33b7acf66b752"
 dependencies = [
-  "glib-sys",
-  "gobject-sys",
-  "gstreamer-sys",
-  "libc",
-  "system-deps",
+ "glib-sys",
+ "gobject-sys",
+ "gstreamer-sys",
+ "libc",
+ "system-deps",
 ]
 
 [[package]]
@@ -501,7 +595,13 @@ name = "gstreamer-sys"
 version = "0.24.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d88630697e757c319e7bcec7b13919ba80492532dd3238481c1c4eee05d4904"
-dependencies = ["cfg-if", "glib-sys", "gobject-sys", "libc", "system-deps"]
+dependencies = [
+ "cfg-if",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+]
 
 [[package]]
 name = "gstreamer-video"
@@ -509,14 +609,14 @@ version = "0.24.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72d9ba5295b206563a990a087c6541d57f650dcd4be4ca8a5a149a758e8df8a0"
 dependencies = [
-  "cfg-if",
-  "futures-channel",
-  "glib",
-  "gstreamer",
-  "gstreamer-base",
-  "gstreamer-video-sys",
-  "libc",
-  "thiserror",
+ "cfg-if",
+ "futures-channel",
+ "glib",
+ "gstreamer",
+ "gstreamer-base",
+ "gstreamer-video-sys",
+ "libc",
+ "thiserror",
 ]
 
 [[package]]
@@ -525,12 +625,12 @@ version = "0.24.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20236fa412d7a50e59aa234b46828a99e3e5f06c4f80d271a49ecd2a1d3bfcbe"
 dependencies = [
-  "glib-sys",
-  "gobject-sys",
-  "gstreamer-base-sys",
-  "gstreamer-sys",
-  "libc",
-  "system-deps",
+ "glib-sys",
+ "gobject-sys",
+ "gstreamer-base-sys",
+ "gstreamer-sys",
+ "libc",
+ "system-deps",
 ]
 
 [[package]]
@@ -551,13 +651,13 @@ version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
 dependencies = [
-  "android_system_properties",
-  "core-foundation-sys",
-  "iana-time-zone-haiku",
-  "js-sys",
-  "log",
-  "wasm-bindgen",
-  "windows-core",
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
 ]
 
 [[package]]
@@ -565,28 +665,37 @@ name = "iana-time-zone-haiku"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = ["cc"]
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "indexmap"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
-dependencies = ["equivalent", "hashbrown"]
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
 
 [[package]]
 name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = ["either"]
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
-dependencies = ["either"]
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -599,14 +708,19 @@ name = "js-sys"
 version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
-dependencies = ["once_cell", "wasm-bindgen"]
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "kstring"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "558bf9508a558512042d3095138b1f7b8fe90c5467d94f9f1da28b3731c5dbd1"
-dependencies = ["static_assertions"]
+dependencies = [
+ "static_assertions",
+]
 
 [[package]]
 name = "lazy_static"
@@ -625,7 +739,10 @@ name = "libloading"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
-dependencies = ["cfg-if", "windows-link"]
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
 
 [[package]]
 name = "log"
@@ -638,7 +755,9 @@ name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
-dependencies = ["regex-automata"]
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "memchr"
@@ -662,79 +781,104 @@ checksum = "956787520e75e9bd233246045d19f42fb73242759cc57fba9611d940ae96d4b0"
 name = "mxl"
 version = "0.1.0"
 dependencies = [
-  "base64",
-  "clap",
-  "ctrlc",
-  "libloading",
-  "mxl-sys",
-  "serde",
-  "serde_json",
-  "thiserror",
-  "tracing",
-  "tracing-subscriber",
-  "uuid",
+ "base64",
+ "clap",
+ "ctrlc",
+ "libloading",
+ "mxl-sys",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]
 name = "mxl-sys"
 version = "0.1.0"
-dependencies = ["bindgen", "cmake", "libloading"]
+dependencies = [
+ "bindgen",
+ "cmake",
+ "libloading",
+]
 
 [[package]]
 name = "nix"
 version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
-dependencies = ["bitflags", "cfg-if", "cfg_aliases", "libc"]
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
 
 [[package]]
 name = "no_std_io2"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b51ed7824b6e07d354605f4abb3d9d300350701299da96642ee084f5ce631550"
-dependencies = ["memchr"]
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = ["memchr", "minimal-lexical"]
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
 
 [[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
-dependencies = ["windows-sys"]
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = ["num-traits"]
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-rational"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
-dependencies = ["num-integer", "num-traits"]
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
-dependencies = ["autocfg"]
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "objc2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
-dependencies = ["objc2-encode"]
+dependencies = [
+ "objc2-encode",
+]
 
 [[package]]
 name = "objc2-encode"
@@ -753,7 +897,9 @@ name = "option-operations"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aca39cf52b03268400c16eeb9b56382ea3c3353409309b63f5c8f0b1faf42754"
-dependencies = ["pastey"]
+dependencies = [
+ "pastey",
+]
 
 [[package]]
 name = "pastey"
@@ -784,28 +930,37 @@ name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = ["proc-macro2", "syn"]
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
 
 [[package]]
 name = "proc-macro-crate"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
-dependencies = ["toml_edit"]
+dependencies = [
+ "toml_edit",
+]
 
 [[package]]
 name = "proc-macro2"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
-dependencies = ["unicode-ident"]
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "quote"
 version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
-dependencies = ["proc-macro2"]
+dependencies = [
+ "proc-macro2",
+]
 
 [[package]]
 name = "r-efi"
@@ -818,14 +973,23 @@ name = "regex"
 version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
-dependencies = ["aho-corasick", "memchr", "regex-automata", "regex-syntax"]
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
 
 [[package]]
 name = "regex-automata"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
-dependencies = ["aho-corasick", "memchr", "regex-syntax"]
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
 
 [[package]]
 name = "regex-syntax"
@@ -856,42 +1020,61 @@ name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
-dependencies = ["serde_core", "serde_derive"]
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
 
 [[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
-dependencies = ["serde_derive"]
+dependencies = [
+ "serde_derive",
+]
 
 [[package]]
 name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
-dependencies = ["proc-macro2", "quote", "syn"]
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "serde_json"
 version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
-dependencies = ["itoa", "memchr", "ryu", "serde", "serde_core"]
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "serde_spanned"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
-dependencies = ["serde_core"]
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
-dependencies = ["lazy_static"]
+dependencies = [
+ "lazy_static",
+]
 
 [[package]]
 name = "shlex"
@@ -922,14 +1105,24 @@ name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
-dependencies = ["proc-macro2", "quote", "unicode-ident"]
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "system-deps"
 version = "7.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c8f33736f986f16d69b6cb8b03f55ddcad5c41acc4ccc39dd88e84aa805e7f"
-dependencies = ["cfg-expr", "heck", "pkg-config", "toml", "version-compare"]
+dependencies = [
+ "cfg-expr",
+ "heck",
+ "pkg-config",
+ "toml",
+ "version-compare",
+]
 
 [[package]]
 name = "target-lexicon"
@@ -942,21 +1135,29 @@ name = "thiserror"
 version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
-dependencies = ["thiserror-impl"]
+dependencies = [
+ "thiserror-impl",
+]
 
 [[package]]
 name = "thiserror-impl"
 version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
-dependencies = ["proc-macro2", "quote", "syn"]
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "thread_local"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
-dependencies = ["cfg-if"]
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "toml"
@@ -964,13 +1165,13 @@ version = "0.9.9+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb5238e643fc34a1d5d7e753e1532a91912d74b63b92b3ea51fde8d1b7bc79dd"
 dependencies = [
-  "indexmap",
-  "serde_core",
-  "serde_spanned",
-  "toml_datetime",
-  "toml_parser",
-  "toml_writer",
-  "winnow",
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
 ]
 
 [[package]]
@@ -978,21 +1179,30 @@ name = "toml_datetime"
 version = "0.7.4+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe3cea6b2aa3b910092f6abd4053ea464fab5f9c170ba5e9a6aead16ec4af2b6"
-dependencies = ["serde_core"]
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "toml_edit"
 version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
-dependencies = ["indexmap", "toml_datetime", "toml_parser", "winnow"]
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
 
 [[package]]
 name = "toml_parser"
 version = "1.0.5+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c03bee5ce3696f31250db0bbaff18bc43301ce0e8db2ed1f07cbb2acf89984c"
-dependencies = ["winnow"]
+dependencies = [
+ "winnow",
+]
 
 [[package]]
 name = "toml_writer"
@@ -1005,28 +1215,44 @@ name = "tracing"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d15d90a0b5c19378952d479dc858407149d7bb45a14de0142f6c534b16fc647"
-dependencies = ["log", "pin-project-lite", "tracing-attributes", "tracing-core"]
+dependencies = [
+ "log",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
 
 [[package]]
 name = "tracing-attributes"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
-dependencies = ["proc-macro2", "quote", "syn"]
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "tracing-core"
 version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a04e24fab5c89c6a36eb8558c9656f30d81de51dfa4d3b45f26b21d61fa0a6c"
-dependencies = ["once_cell", "valuable"]
+dependencies = [
+ "once_cell",
+ "valuable",
+]
 
 [[package]]
 name = "tracing-log"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
-dependencies = ["log", "once_cell", "tracing-core"]
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
 
 [[package]]
 name = "tracing-subscriber"
@@ -1034,16 +1260,16 @@ version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
 dependencies = [
-  "matchers",
-  "nu-ansi-term",
-  "once_cell",
-  "regex-automata",
-  "sharded-slab",
-  "smallvec",
-  "thread_local",
-  "tracing",
-  "tracing-core",
-  "tracing-log",
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1051,14 +1277,21 @@ name = "tracing-test"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "557b891436fe0d5e0e363427fc7f217abf9ccd510d5136549847bdcbcd011d68"
-dependencies = ["tracing-core", "tracing-subscriber", "tracing-test-macro"]
+dependencies = [
+ "tracing-core",
+ "tracing-subscriber",
+ "tracing-test-macro",
+]
 
 [[package]]
 name = "tracing-test-macro"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
-dependencies = ["quote", "syn"]
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "unicode-ident"
@@ -1077,7 +1310,12 @@ name = "uuid"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
-dependencies = ["getrandom", "js-sys", "serde_core", "wasm-bindgen"]
+dependencies = [
+ "getrandom",
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "valuable"
@@ -1096,7 +1334,9 @@ name = "wasip2"
 version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
-dependencies = ["wit-bindgen"]
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -1104,11 +1344,11 @@ version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
 dependencies = [
-  "cfg-if",
-  "once_cell",
-  "rustversion",
-  "wasm-bindgen-macro",
-  "wasm-bindgen-shared",
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
 ]
 
 [[package]]
@@ -1116,21 +1356,32 @@ name = "wasm-bindgen-macro"
 version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
-dependencies = ["quote", "wasm-bindgen-macro-support"]
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
 
 [[package]]
 name = "wasm-bindgen-macro-support"
 version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
-dependencies = ["bumpalo", "proc-macro2", "quote", "syn", "wasm-bindgen-shared"]
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
 
 [[package]]
 name = "wasm-bindgen-shared"
 version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
-dependencies = ["unicode-ident"]
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "windows-core"
@@ -1138,11 +1389,11 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
-  "windows-implement",
-  "windows-interface",
-  "windows-link",
-  "windows-result",
-  "windows-strings",
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -1150,14 +1401,22 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = ["proc-macro2", "quote", "syn"]
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "windows-interface"
 version = "0.59.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
-dependencies = ["proc-macro2", "quote", "syn"]
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "windows-link"
@@ -1170,28 +1429,36 @@ name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = ["windows-link"]
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-strings"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = ["windows-link"]
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
-dependencies = ["windows-link"]
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "winnow"
 version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
-dependencies = ["memchr"]
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -32,21 +32,33 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "atomic_refcell"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41e67cd8309bbd06cd603a9e693a784ac2e5d1e955f11286e355089fcab3047c"
+checksum = "21e4227379beff4205943696e6c3e0cd809bacdf3f0edd6e3dd153e2269571a4"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bindgen"
@@ -65,15 +77,15 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash",
- "shlex",
+ "shlex 1.3.0",
  "syn",
 ]
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bitstream-io"
@@ -85,19 +97,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "bumpalo"
-version = "3.19.1"
+name = "block2"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "cc"
-version = "1.2.49"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90583009037521a116abf44494efecd645ba48b6622457080f080b85544e2215"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
- "shlex",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -133,9 +154,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-expr"
-version = "0.20.5"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21be0e1ce6cdb2ee7fff840f922fb04ead349e5cfb1e750b769132d44ce04720"
+checksum = "fb693542bcafa528e198be0ebd9d3632ca5b7c93dbe7237460e199910835997c"
 dependencies = [
  "smallvec",
  "target-lexicon",
@@ -148,10 +169,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "chrono"
-version = "0.4.42"
+name = "cfg_aliases"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "num-traits",
@@ -171,9 +198,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.53"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -181,9 +208,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.53"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -191,9 +218,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.49"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -203,15 +230,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.6"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
-version = "0.1.56"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b042e5d8a74ae91bb0961acd039822472ec99f8ab0948cbf6d1369588f8be586"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
@@ -223,10 +250,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "either"
-version = "1.15.0"
+name = "ctrlc"
+version = "3.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+dependencies = [
+ "dispatch2",
+ "nix",
+ "windows-sys",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
+]
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "equivalent"
@@ -236,30 +286,36 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -268,9 +324,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -285,34 +341,34 @@ checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
  "futures-macro",
  "futures-task",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.4"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
  "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -429,9 +485,9 @@ dependencies = [
 
 [[package]]
 name = "gst-plugin-version-helper"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68a894ef2d738054b950e1dbef5d9012b63fd968d4d32dbccd31bd8d8d4b219"
+checksum = "94668bc2592732b8c2b653668ae41211d45988fb61264888b9c2d545d4bd826d"
 dependencies = [
  "chrono",
  "toml_edit",
@@ -439,9 +495,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer"
-version = "0.24.4"
+version = "0.24.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bed73742c5d54cb48533be608b67d89f96e1ebbba280be7823f1ef995e3a9d7"
+checksum = "1e8251db223ca38d9aefaf3d19f6f11581a9123cd12dacebd8b9e182da965023"
 dependencies = [
  "cfg-if",
  "futures-channel",
@@ -548,9 +604,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-sys"
-version = "0.24.4"
+version = "0.24.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d88630697e757c319e7bcec7b13919ba80492532dd3238481c1c4eee05d4904"
+checksum = "b5d37c1a599ae57b8186948bd5699f2dbfc044baea9d400228b489a85bcf2759"
 dependencies = [
  "cfg-if",
  "glib-sys",
@@ -591,9 +647,18 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -603,9 +668,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.64"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -626,13 +691,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "indexmap"
-version = "2.12.1"
+name = "id-arena"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -655,16 +728,18 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.83"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -685,10 +760,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "libc"
-version = "0.2.178"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
@@ -702,9 +783,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "matchers"
@@ -717,9 +798,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "minimal-lexical"
@@ -737,7 +818,9 @@ checksum = "956787520e75e9bd233246045d19f42fb73242759cc57fba9611d940ae96d4b0"
 name = "mxl"
 version = "0.1.0"
 dependencies = [
+ "base64",
  "clap",
+ "ctrlc",
  "libloading",
  "mxl-sys",
  "serde",
@@ -758,10 +841,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "no_std_io2"
-version = "0.9.3"
+name = "nix"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b51ed7824b6e07d354605f4abb3d9d300350701299da96642ee084f5ce631550"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "no_std_io2"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003"
 dependencies = [
  "memchr",
 ]
@@ -814,10 +909,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.21.3"
+name = "objc2"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "option-operations"
@@ -830,27 +940,21 @@ dependencies = [
 
 [[package]]
 name = "pastey"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "prettyplease"
@@ -864,42 +968,42 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.103"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.42"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "r-efi"
-version = "5.3.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -909,9 +1013,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -920,15 +1024,15 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustversion"
@@ -937,10 +1041,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
-name = "ryu"
-version = "1.0.20"
+name = "semver"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -974,22 +1078,22 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -1010,10 +1114,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "slab"
-version = "0.4.11"
+name = "shlex"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -1040,9 +1150,9 @@ dependencies = [
 
 [[package]]
 name = "system-deps"
-version = "7.0.7"
+version = "7.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c8f33736f986f16d69b6cb8b03f55ddcad5c41acc4ccc39dd88e84aa805e7f"
+checksum = "396a35feb67335377e0251fcbc1092fc85c484bd4e3a7a54319399da127796e7"
 dependencies = [
  "cfg-expr",
  "heck",
@@ -1053,24 +1163,24 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.13.3"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1088,9 +1198,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.9+spec-1.0.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb5238e643fc34a1d5d7e753e1532a91912d74b63b92b3ea51fde8d1b7bc79dd"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -1103,18 +1213,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.4+spec-1.0.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe3cea6b2aa3b910092f6abd4053ea464fab5f9c170ba5e9a6aead16ec4af2b6"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.23.10+spec-1.0.0"
+version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -1124,24 +1234,24 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.5+spec-1.0.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c03bee5ce3696f31250db0bbaff18bc43301ce0e8db2ed1f07cbb2acf89984c"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.5+spec-1.0.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9cd6190959dce0994aa8970cd32ab116d1851ead27e866039acaf2524ce44fa"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tracing"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d15d90a0b5c19378952d479dc858407149d7bb45a14de0142f6c534b16fc647"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -1162,9 +1272,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.35"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a04e24fab5c89c6a36eb8558c9656f30d81de51dfa4d3b45f26b21d61fa0a6c"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -1183,9 +1293,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -1201,9 +1311,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-test"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "557b891436fe0d5e0e363427fc7f217abf9ccd510d5136549847bdcbcd011d68"
+checksum = "19a4c448db514d4f24c5ddb9f73f2ee71bfb24c526cf0c570ba142d1119e0051"
 dependencies = [
  "tracing-core",
  "tracing-subscriber",
@@ -1212,9 +1322,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-test-macro"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
+checksum = "ad06847b7afb65c7866a36664b75c40b895e318cea4f71299f013fb22965329d"
 dependencies = [
  "quote",
  "syn",
@@ -1222,9 +1332,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-width"
@@ -1233,10 +1343,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
-name = "uuid"
-version = "1.19.0"
+name = "unicode-xid"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "uuid"
+version = "1.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
 dependencies = [
  "getrandom",
  "js-sys",
@@ -1258,18 +1374,27 @@ checksum = "03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e"
 
 [[package]]
 name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.106"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1280,9 +1405,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.106"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1290,9 +1415,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.106"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1303,11 +1428,45 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.106"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -1380,15 +1539,109 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "wit-bindgen"
-version = "0.46.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -435,7 +435,7 @@ dependencies = [
 
 [[package]]
 name = "gst-avsynctest-rs"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cdp-types",
  "cea708-types",
@@ -450,7 +450,7 @@ dependencies = [
 
 [[package]]
 name = "gst-mxl-rs"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bitstream-io",
  "glib",
@@ -779,7 +779,7 @@ checksum = "956787520e75e9bd233246045d19f42fb73242759cc57fba9611d940ae96d4b0"
 
 [[package]]
 name = "mxl"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "base64",
  "clap",
@@ -796,7 +796,7 @@ dependencies = [
 
 [[package]]
 name = "mxl-sys"
-version = "0.1.0"
+version = "1.1.0"
 dependencies = [
  "bindgen",
  "cmake",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 publish = false
-version = "0.1.0"
+version = "0.2.0"
 rust-version = "1.87"
 license = "Apache-2.0"
 license-file = "../LICENSE.txt"

--- a/rust/mxl-sys/Cargo.toml
+++ b/rust/mxl-sys/Cargo.toml
@@ -18,3 +18,4 @@ cmake = "0.1.54"
 
 [features]
 mxl-not-built = []
+mxl-fabrics-ofi = []

--- a/rust/mxl-sys/Cargo.toml
+++ b/rust/mxl-sys/Cargo.toml
@@ -3,9 +3,9 @@
 
 [package]
 name = "mxl-sys"
+version = "1.1.0"
 edition.workspace = true
 publish.workspace = true
-version.workspace = true
 license.workspace = true
 rust-version.workspace = true
 

--- a/rust/mxl-sys/build.rs
+++ b/rust/mxl-sys/build.rs
@@ -124,8 +124,6 @@ fn main() {
         println!("cargo:include={include_dir}");
     }
 
-    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
-
     let bindings = bindgen::builder()
         .clang_args(
             bindgen_specs
@@ -143,6 +141,7 @@ fn main() {
         .generate()
         .unwrap();
 
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
     bindings
         .write_to_file(out_path.join("bindings.rs"))
         .expect("Could not write bindings");

--- a/rust/mxl-sys/build.rs
+++ b/rust/mxl-sys/build.rs
@@ -63,11 +63,68 @@ fn get_bindgen_specs() -> BindgenSpecs {
     }
 }
 
+fn get_bindgen_specs_fabrics() -> BindgenSpecs {
+    let header = "wrapper-fabrics.h".to_string();
+
+    let manifest_dir =
+        PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect("failed to get current directory"));
+    let repo_root = manifest_dir.parent().unwrap().parent().unwrap();
+    let mut includes_dirs = vec![
+        repo_root
+            .join("lib")
+            .join("include")
+            .to_string_lossy()
+            .to_string(),
+        repo_root
+            .join("lib")
+            .join("fabrics")
+            .join("include")
+            .to_string_lossy()
+            .to_string(),
+    ];
+    if cfg!(not(feature = "mxl-not-built")) {
+        let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
+        let build_version_dir = out_dir.join("include").to_string_lossy().to_string();
+
+        includes_dirs.push(build_version_dir);
+
+        // Rebuild if any file in lib/ changes
+        let lib_root = repo_root.join("lib");
+        println!("cargo:rerun-if-changed={}", lib_root.display());
+
+        let dst = cmake::Config::new(repo_root)
+            .generator("Ninja")
+            .configure_arg("--preset")
+            .configure_arg(BUILD_VARIANT)
+            .configure_arg("-B")
+            .configure_arg(out_dir.join("build"))
+            .define("MXL_ENABLE_FABRICS_OFI", "ON")
+            .define("BUILD_DOCS", "OFF")
+            .define("BUILD_TESTS", "OFF")
+            .define("BUILD_TOOLS", "OFF")
+            .build();
+
+        println!(
+            "cargo:rustc-link-search={}",
+            dst.join("lib/fabrics/ofi").display()
+        );
+        println!("cargo:rustc-link-lib=mxl");
+        println!("cargo:rustc-link-lib=mxl-fabrics");
+    }
+
+    BindgenSpecs {
+        header,
+        includes_dirs,
+    }
+}
+
 fn main() {
     let bindgen_specs = get_bindgen_specs();
     for include_dir in &bindgen_specs.includes_dirs {
         println!("cargo:include={include_dir}");
     }
+
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
 
     let bindings = bindgen::builder()
         .clang_args(
@@ -86,10 +143,31 @@ fn main() {
         .generate()
         .unwrap();
 
-    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
     bindings
         .write_to_file(out_path.join("bindings.rs"))
         .expect("Could not write bindings");
+
+    if cfg!(feature = "mxl-fabrics-ofi") {
+        let fabrics_bindings = bindgen::builder()
+            .clang_args(
+                get_bindgen_specs_fabrics()
+                    .includes_dirs
+                    .iter()
+                    .map(|dir| format!("-I{dir}")),
+            )
+            .header("wrapper-fabrics.h")
+            .derive_default(true)
+            .derive_debug(true)
+            .prepend_enum_name(false)
+            .dynamic_library_name("libmxlfabrics")
+            .dynamic_link_require_all(false)
+            .parse_callbacks(Box::new(CB))
+            .generate()
+            .unwrap();
+        fabrics_bindings
+            .write_to_file(out_path.join("fabrics_bindings.rs"))
+            .expect("Could not write fabrics bindings");
+    }
 }
 
 #[derive(Debug)]

--- a/rust/mxl-sys/build.rs
+++ b/rust/mxl-sys/build.rs
@@ -151,7 +151,7 @@ fn main() {
             .blocklist_var(".*")
             .raw_line("use crate::types::*;")
             .dynamic_library_name("libmxlfabrics")
-            .dynamic_link_require_all(false)
+            .dynamic_link_require_all(true)
             .parse_callbacks(Box::new(CB))
             .generate()
             .unwrap();

--- a/rust/mxl-sys/build.rs
+++ b/rust/mxl-sys/build.rs
@@ -31,6 +31,16 @@ fn get_bindgen_specs() -> BindgenSpecs {
             .to_string_lossy()
             .to_string(),
     ];
+    if cfg!(feature = "mxl-fabrics-ofi") {
+        includes_dirs.push(
+            repo_root
+                .join("lib")
+                .join("fabrics")
+                .join("include")
+                .to_string_lossy()
+                .to_string(),
+        );
+    }
     if cfg!(not(feature = "mxl-not-built")) {
         let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
         let build_version_dir = out_dir.join("include").to_string_lossy().to_string();
@@ -41,7 +51,8 @@ fn get_bindgen_specs() -> BindgenSpecs {
         let lib_root = repo_root.join("lib");
         println!("cargo:rerun-if-changed={}", lib_root.display());
 
-        let dst = cmake::Config::new(repo_root)
+        let mut config = cmake::Config::new(repo_root);
+        config
             .generator("Ninja")
             .configure_arg("--preset")
             .configure_arg(BUILD_VARIANT)
@@ -50,66 +61,21 @@ fn get_bindgen_specs() -> BindgenSpecs {
             .define("BUILD_DOCS", "OFF")
             .define("BUILD_TESTS", "OFF")
             .define("BUILD_TOOLS", "OFF")
-            .define("CMAKE_INSTALL_LIBDIR", "lib")
-            .build();
+            .define("CMAKE_INSTALL_LIBDIR", "lib");
+        if cfg!(feature = "mxl-fabrics-ofi") {
+            config.define("MXL_ENABLE_FABRICS_OFI", "ON");
+        }
+        let dst = config.build();
 
         println!("cargo:rustc-link-search={}", dst.join("lib").display());
         println!("cargo:rustc-link-lib=mxl");
-    }
-
-    BindgenSpecs {
-        header,
-        includes_dirs,
-    }
-}
-
-fn get_bindgen_specs_fabrics() -> BindgenSpecs {
-    let header = "wrapper-fabrics.h".to_string();
-
-    let manifest_dir =
-        PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect("failed to get current directory"));
-    let repo_root = manifest_dir.parent().unwrap().parent().unwrap();
-    let mut includes_dirs = vec![
-        repo_root
-            .join("lib")
-            .join("include")
-            .to_string_lossy()
-            .to_string(),
-        repo_root
-            .join("lib")
-            .join("fabrics")
-            .join("include")
-            .to_string_lossy()
-            .to_string(),
-    ];
-    if cfg!(not(feature = "mxl-not-built")) {
-        let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
-        let build_version_dir = out_dir.join("include").to_string_lossy().to_string();
-
-        includes_dirs.push(build_version_dir);
-
-        // Rebuild if any file in lib/ changes
-        let lib_root = repo_root.join("lib");
-        println!("cargo:rerun-if-changed={}", lib_root.display());
-
-        let dst = cmake::Config::new(repo_root)
-            .generator("Ninja")
-            .configure_arg("--preset")
-            .configure_arg(BUILD_VARIANT)
-            .configure_arg("-B")
-            .configure_arg(out_dir.join("build"))
-            .define("MXL_ENABLE_FABRICS_OFI", "ON")
-            .define("BUILD_DOCS", "OFF")
-            .define("BUILD_TESTS", "OFF")
-            .define("BUILD_TOOLS", "OFF")
-            .build();
-
-        println!(
-            "cargo:rustc-link-search={}",
-            dst.join("lib/fabrics/ofi").display()
-        );
-        println!("cargo:rustc-link-lib=mxl");
-        println!("cargo:rustc-link-lib=mxl-fabrics");
+        if cfg!(feature = "mxl-fabrics-ofi") {
+            println!(
+                "cargo:rustc-link-search={}",
+                dst.join("lib/fabrics/ofi").display()
+            );
+            println!("cargo:rustc-link-lib=mxl-fabrics");
+        }
     }
 
     BindgenSpecs {
@@ -124,7 +90,32 @@ fn main() {
         println!("cargo:include={include_dir}");
     }
 
-    let bindings = bindgen::builder()
+    let mut types_builder = bindgen::builder()
+        .clang_args(
+            bindgen_specs
+                .includes_dirs
+                .iter()
+                .map(|dir| format!("-I{dir}")),
+        )
+        .header(bindgen_specs.header.clone())
+        .derive_default(true)
+        .derive_debug(true)
+        .prepend_enum_name(false)
+        .blocklist_function(".*")
+        .parse_callbacks(Box::new(CB));
+    if cfg!(feature = "mxl-fabrics-ofi") {
+        types_builder = types_builder.header("wrapper-fabrics.h");
+    }
+    let types_bindings = types_builder
+        .generate()
+        .expect("Could not generate shared type bindings");
+
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    types_bindings
+        .write_to_file(out_path.join("types_bindings.rs"))
+        .expect("Could not write shared type bindings");
+
+    let mxl_bindings = bindgen::builder()
         .clang_args(
             bindgen_specs
                 .includes_dirs
@@ -132,32 +123,33 @@ fn main() {
                 .map(|dir| format!("-I{dir}")),
         )
         .header(bindgen_specs.header)
-        .derive_default(true)
-        .derive_debug(true)
-        .prepend_enum_name(false)
+        .allowlist_function("mxl.*")
+        .blocklist_type(".*")
+        .blocklist_var(".*")
+        .raw_line("use crate::types::*;")
         .dynamic_library_name("libmxl")
         .dynamic_link_require_all(true)
         .parse_callbacks(Box::new(CB))
         .generate()
-        .unwrap();
+        .expect("Could not generate libmxl function bindings");
 
-    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
-    bindings
-        .write_to_file(out_path.join("bindings.rs"))
-        .expect("Could not write bindings");
+    mxl_bindings
+        .write_to_file(out_path.join("mxl_bindings.rs"))
+        .expect("Could not write libmxl function bindings");
 
     if cfg!(feature = "mxl-fabrics-ofi") {
         let fabrics_bindings = bindgen::builder()
             .clang_args(
-                get_bindgen_specs_fabrics()
+                bindgen_specs
                     .includes_dirs
                     .iter()
                     .map(|dir| format!("-I{dir}")),
             )
             .header("wrapper-fabrics.h")
-            .derive_default(true)
-            .derive_debug(true)
-            .prepend_enum_name(false)
+            .allowlist_function("mxlFabrics.*")
+            .blocklist_type(".*")
+            .blocklist_var(".*")
+            .raw_line("use crate::types::*;")
             .dynamic_library_name("libmxlfabrics")
             .dynamic_link_require_all(false)
             .parse_callbacks(Box::new(CB))

--- a/rust/mxl-sys/src/lib.rs
+++ b/rust/mxl-sys/src/lib.rs
@@ -17,3 +17,8 @@
 extern crate libloading;
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+
+#[cfg(feature = "mxl-fabrics-ofi")]
+pub mod fabrics {
+    include!(concat!(env!("OUT_DIR"), "/fabrics_bindings.rs"));
+}

--- a/rust/mxl-sys/src/lib.rs
+++ b/rust/mxl-sys/src/lib.rs
@@ -16,9 +16,18 @@
 
 extern crate libloading;
 
-include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+pub mod types {
+    include!(concat!(env!("OUT_DIR"), "/types_bindings.rs"));
+}
+
+pub mod mxl {
+    include!(concat!(env!("OUT_DIR"), "/mxl_bindings.rs"));
+}
 
 #[cfg(feature = "mxl-fabrics-ofi")]
 pub mod fabrics {
     include!(concat!(env!("OUT_DIR"), "/fabrics_bindings.rs"));
 }
+
+pub use mxl::libmxl;
+pub use types::*;

--- a/rust/mxl-sys/tests/simple_test.rs
+++ b/rust/mxl-sys/tests/simple_test.rs
@@ -12,3 +12,24 @@ fn there_is_bindgen_generated_code() {
 
     println!("mxl_version: {:?}", mxl_version);
 }
+
+#[cfg(feature = "mxl-fabrics-ofi")]
+#[test]
+fn core_and_fabrics_bindings_share_handle_types() {
+    let instance: mxl_sys::Instance = std::ptr::null_mut();
+    let writer: mxl_sys::FlowWriter = std::ptr::null_mut();
+    let reader: mxl_sys::FlowReader = std::ptr::null_mut();
+
+    let _: mxl_sys::types::Instance = instance;
+    let target_config = mxl_sys::types::FabricsTargetConfig {
+        writer,
+        ..Default::default()
+    };
+    let initiator_config = mxl_sys::types::FabricsInitiatorConfig {
+        reader,
+        ..Default::default()
+    };
+
+    assert!(target_config.writer.is_null());
+    assert!(initiator_config.reader.is_null());
+}

--- a/rust/mxl-sys/wrapper-fabrics.h
+++ b/rust/mxl-sys/wrapper-fabrics.h
@@ -1,0 +1,1 @@
+#include "mxl/fabrics.h"

--- a/rust/mxl-sys/wrapper-fabrics.h
+++ b/rust/mxl-sys/wrapper-fabrics.h
@@ -1,1 +1,4 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: Apache-2.0
+
 #include "mxl/fabrics.h"

--- a/rust/mxl/Cargo.toml
+++ b/rust/mxl/Cargo.toml
@@ -22,6 +22,13 @@ serde.workspace = true
 clap.workspace = true
 serde_json.workspace = true
 tracing-subscriber.workspace = true
+ctrlc = "3"
+base64 = "0.22"
 
 [features]
 mxl-not-built = ["mxl-sys/mxl-not-built"]
+mxl-fabrics-ofi = ["mxl-sys/mxl-fabrics-ofi"]
+
+[[example]]
+name = "fabrics-demo"
+required-features = ["mxl-fabrics-ofi"]

--- a/rust/mxl/Cargo.toml
+++ b/rust/mxl/Cargo.toml
@@ -24,7 +24,6 @@ serde_json.workspace = true
 tracing-subscriber.workspace = true
 ctrlc = "3"
 base64 = "0.22"
-anyhow = "1.0"
 
 [features]
 mxl-not-built = ["mxl-sys/mxl-not-built"]

--- a/rust/mxl/Cargo.toml
+++ b/rust/mxl/Cargo.toml
@@ -24,6 +24,7 @@ serde_json.workspace = true
 tracing-subscriber.workspace = true
 ctrlc = "3"
 base64 = "0.22"
+anyhow = "1.0"
 
 [features]
 mxl-not-built = ["mxl-sys/mxl-not-built"]

--- a/rust/mxl/examples/fabrics-demo.rs
+++ b/rust/mxl/examples/fabrics-demo.rs
@@ -469,8 +469,8 @@ fn main() -> Result<(), anyhow::Error> {
 
     let interface_config = mxl::fabrics::InterfaceConfig::builder(endpoint_address)
         .provider(provider.prov_type().clone())
-        .caps(Capabilities::builder().supports_remote_write().build())
-        .build()?;
+        .caps(Capabilities::default())
+        .build();
 
     let interfaces = fabrics_instance
         .get_interfaces(Some(interface_config))

--- a/rust/mxl/examples/fabrics-demo.rs
+++ b/rust/mxl/examples/fabrics-demo.rs
@@ -16,11 +16,11 @@ use clap::{Parser, Subcommand};
 use base64::{Engine as _, prelude::BASE64_STANDARD};
 
 use mxl::{
-    Error, FlowConfigInfo, FlowInfo, FlowReader, FlowWriter, GrainReader, GrainWriter,
-    MxlFabricsApi, MxlInstance, SamplesReader, SamplesWriter,
+    Error, FlowConfigInfo, FlowInfo, FlowReader, FlowWriter, GrainReader, GrainWriter, MxlInstance,
+    SamplesReader, SamplesWriter,
     config::{get_mxl_fabrics_ofi_so_path, get_mxl_so_path},
     fabrics::{
-        EndpointAddress, FabricsInstance, TargetInfo,
+        Capabilities, EndpointAddress, FabricsInstance, InterfaceConfig, ProviderType, TargetInfo,
         initiator::{self, Initiator},
         target::{self, Target},
     },
@@ -40,24 +40,23 @@ pub struct Cli {
     #[arg(
         short,
         long,
-        default_value = "tcp",
-        help = "The fabrics provider. One of (tcp, verbs or efa)."
+        help = "Force a specific provider (tcp, verbs, efa or shm). Auto-selected if not specified."
     )]
-    pub provider: String,
+    pub provider: Option<String>,
 
     #[arg(
         short,
         long,
-        help = "This corresponds to the interface identifier of the fabrics endpoint, it can also be a logical address. This can be seen as the bind address when using sockets."
+        help = "Filter interface selection by node address. If not set, the best available interface is chosen automatically."
     )]
-    pub node: String,
+    pub node: Option<String>,
 
     #[arg(
         short,
         long,
-        help = "This corresponds to a service identifier for the fabrics endpoint. This can be seen as the bind port when using sockets."
+        help = "Service identifier for the fabrics endpoint (e.g. a port number)."
     )]
-    pub service: String,
+    pub service: Option<String>,
 
     #[command(subcommand)]
     pub command: Command,
@@ -72,6 +71,12 @@ pub enum Command {
             help = "The JSON file which contains the NMOS Flow configuration."
         )]
         flow_file: String,
+        #[arg(
+            long,
+            help = "Output file path for raw target info (optional, always logged as base64)."
+        )]
+        target_info_path: Option<String>,
+        //TODO: flow options?
     },
     /// Run as an initiator (flow reader + fabrics initiator).
     Initiator {
@@ -79,7 +84,7 @@ pub enum Command {
         flow_id: String,
         #[arg(
             long,
-            help = "The target information to send to. Start the target first and paste the printed target info here."
+            help = "Base64-encoded target info, or a path prefixed with '@' to read raw target info from a file."
         )]
         target_info: String,
     },
@@ -95,26 +100,15 @@ struct TargetEndpoint<'a> {
 impl<'a> TargetEndpoint<'a> {
     pub fn new(
         instance: &'a MxlInstance,
-        fabrics_api: &Arc<MxlFabricsApi>,
+        fabrics_instance: &FabricsInstance,
+        interface: InterfaceConfig,
         flow_file: &str,
-        cli: &Cli,
     ) -> Result<(Self, TargetInfo), mxl::Error> {
         let flow_config_str = std::fs::read_to_string(flow_file).expect("Failed to read flow file");
 
         let (flow_writer, flow_config, _) = instance.create_flow_writer(&flow_config_str, None)?;
 
-        let fabrics_instance = instance.create_fabrics_instance(fabrics_api)?;
-
-        let provider = fabrics_instance.provider_from_str(&cli.provider)?;
-
-        let target_config = target::Config::new(
-            EndpointAddress {
-                node: Some(&cli.node),
-                service: Some(&cli.service),
-            },
-            provider,
-            &flow_writer,
-        );
+        let target_config = target::Config::new(interface, &flow_writer);
 
         let target = fabrics_instance.create_target()?;
         let (target, target_info) = target.setup(&target_config)?;
@@ -218,26 +212,15 @@ struct InitiatorEndpoint<'a> {
 impl<'a> InitiatorEndpoint<'a> {
     pub fn new(
         instance: &'a MxlInstance,
-        fabrics_api: &Arc<MxlFabricsApi>,
+        fabrics_instance: FabricsInstance,
+        interface: InterfaceConfig,
         flow_id: &str,
-        cli: &Cli,
     ) -> Result<Self, mxl::Error> {
         let flow_reader = instance.create_flow_reader(flow_id)?;
 
-        let fabrics_instance = instance.create_fabrics_instance(fabrics_api)?;
-
         let initiator = fabrics_instance.create_initiator()?;
 
-        let provider = fabrics_instance.provider_from_str(&cli.provider)?;
-
-        let initiator_config = initiator::Config::new(
-            EndpointAddress {
-                node: Some(&cli.node),
-                service: Some(&cli.service),
-            },
-            provider,
-            &flow_reader,
-        );
+        let initiator_config = initiator::Config::new(interface, &flow_reader);
 
         let initiator = initiator.setup(&initiator_config)?;
 
@@ -430,10 +413,36 @@ impl<'a> InitiatorEndpoint<'a> {
     }
 }
 
-fn main() -> Result<(), mxl::Error> {
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ProviderPrio(ProviderType);
+impl ProviderPrio {
+    fn priority(&self) -> u32 {
+        match self {
+            ProviderPrio(ProviderType::Efa) => 4,
+            ProviderPrio(ProviderType::Verbs) => 3,
+            ProviderPrio(ProviderType::Tcp) => 2,
+            ProviderPrio(ProviderType::Shm) => 1,
+            _ => 0,
+        }
+    }
+}
+impl Ord for ProviderPrio {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.priority().cmp(&other.priority())
+    }
+}
+impl PartialOrd for ProviderPrio {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+fn main() -> Result<(), anyhow::Error> {
     common::setup_logging();
 
     let cli = Cli::parse();
+
+    tracing::info!(domain = %cli.domain, provider = ?cli.provider, node = ?cli.node, service = ?cli.service, command = ?cli.command, "Starting fabrics demo");
 
     let running = Arc::new(AtomicBool::new(true));
     let running2 = running.clone();
@@ -448,17 +457,69 @@ fn main() -> Result<(), mxl::Error> {
 
     let instance = mxl::MxlInstance::new(api, &cli.domain, "")?;
 
+    let fabrics_instance = instance.create_fabrics_instance(&fabrics_api)?;
+
+    let endpoint_address = EndpointAddress {
+        node: cli.node.as_deref(),
+        service: cli.service.as_deref(),
+    };
+
+    let provider =
+        fabrics_instance.provider_from_str(&cli.provider.unwrap_or("any".to_string()))?;
+
+    let interface_config = mxl::fabrics::InterfaceConfig::builder(endpoint_address)
+        .provider(provider.prov_type().clone())
+        .caps(Capabilities::builder().supports_remote_write().build())
+        .build()?;
+
+    let interfaces = fabrics_instance
+        .get_interfaces(Some(interface_config))
+        .expect("Failed to get interfaces");
+
+    let mut interface = interfaces
+        .iter()
+        .max_by_key(|k| ProviderPrio(k.provider.clone()))
+        .ok_or(Error::Other("No suitable interface found".to_string()))?;
+    interface.set_endpoint_address(EndpointAddress {
+        node: cli.node.as_deref(),
+        service: cli.service.as_deref(),
+    });
+
+    tracing::info!(
+        provider = ?interface.provider,
+        node = ?interface.endpoint_address.node,
+        service = ?interface.endpoint_address.service,
+        caps = ?interface.caps,
+        "Selected interface");
+
     match &cli.command {
         Command::Initiator {
             flow_id,
             target_info,
         } => {
-            let initiator = InitiatorEndpoint::new(&instance, &fabrics_api, flow_id, &cli)?;
+            let initiator =
+                InitiatorEndpoint::new(&instance, fabrics_instance, interface, flow_id)?;
             initiator.run(target_info, running)?;
         }
-        Command::Target { flow_file } => {
+        Command::Target {
+            flow_file,
+            target_info_path,
+        } => {
             let (target, target_info) =
-                TargetEndpoint::new(&instance, &fabrics_api, flow_file, &cli)?;
+                TargetEndpoint::new(&instance, &fabrics_instance, interface, flow_file)?;
+
+            if let Some(target_info_file) = target_info_path
+                && target_info_file.starts_with('@')
+            {
+                let file = if target_info_file.starts_with("@") {
+                    target_info_file
+                        .strip_prefix('@')
+                        .expect("impossible to fail.") //SAFETY: we already checked that the string starts with '@';
+                } else {
+                    target_info_file.as_str()
+                };
+                std::fs::write(file, target_info.to_string()?.as_bytes())?;
+            }
             tracing::info!(
                 "Target Info: {}",
                 BASE64_STANDARD.encode(target_info.to_string()?)

--- a/rust/mxl/examples/fabrics-demo.rs
+++ b/rust/mxl/examples/fabrics-demo.rs
@@ -1,0 +1,468 @@
+mod common;
+
+use std::{
+    sync::{
+        Arc,
+        atomic::{self, AtomicBool},
+    },
+    time::Duration,
+};
+
+use clap::{Parser, Subcommand};
+
+use base64::{Engine as _, prelude::BASE64_STANDARD};
+
+use mxl::{
+    Error, FlowConfigInfo, FlowInfo, FlowReader, FlowWriter, GrainReader, GrainWriter,
+    MxlFabricsApi, MxlInstance, SamplesReader, SamplesWriter,
+    config::{get_mxl_fabrics_ofi_so_path, get_mxl_so_path},
+    fabrics::{
+        EndpointAddress, FabricsInstance, TargetInfo,
+        initiator::{self, Initiator},
+        target::{self, Target},
+    },
+};
+
+#[derive(Debug, Parser)]
+#[command(
+    version = clap::crate_version!(),
+    author = clap::crate_authors!(),
+    subcommand_required = true,
+    arg_required_else_help = true
+)]
+pub struct Cli {
+    #[arg(short, long, help = "The MXL domain directory")]
+    pub domain: String,
+
+    #[arg(
+        short,
+        long,
+        default_value = "tcp",
+        help = "The fabrics provider. One of (tcp, verbs or efa)."
+    )]
+    pub provider: String,
+
+    #[arg(
+        short,
+        long,
+        help = "This corresponds to the interface identifier of the fabrics endpoint, it can also be a logical address. This can be seen as the bind address when using sockets."
+    )]
+    pub node: String,
+
+    #[arg(
+        short,
+        long,
+        help = "This corresponds to a service identifier for the fabrics endpoint. This can be seen as the bind port when using sockets."
+    )]
+    pub service: String,
+
+    #[command(subcommand)]
+    pub command: Command,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum Command {
+    /// Run as a receiver (fabrics target + flow writer).
+    Target {
+        #[arg(
+            long,
+            help = "The JSON file which contains the NMOS Flow configuration."
+        )]
+        flow_file: String,
+    },
+    /// Run as an initiator (flow reader + fabrics initiator).
+    Initiator {
+        #[arg(long, help = "The flow ID to read from.")]
+        flow_id: String,
+        #[arg(
+            long,
+            help = "The target information to send to. Start the target first and paste the printed target info here."
+        )]
+        target_info: String,
+    },
+}
+
+struct TargetEndpoint<'a> {
+    _instance: &'a MxlInstance,
+    flow_config: FlowConfigInfo,
+    flow_writer: FlowWriter,
+    target: Target<target::states::Specializing>,
+}
+
+impl<'a> TargetEndpoint<'a> {
+    pub fn new(
+        instance: &'a MxlInstance,
+        fabrics_api: &Arc<MxlFabricsApi>,
+        flow_file: &str,
+        cli: &Cli,
+    ) -> Result<(Self, TargetInfo), mxl::Error> {
+        let flow_config_str = std::fs::read_to_string(flow_file).expect("Failed to read flow file");
+
+        let (flow_writer, flow_config, _) = instance.create_flow_writer(&flow_config_str, None)?;
+
+        let fabrics_instance = instance.create_fabrics_instance(fabrics_api)?;
+
+        let provider = fabrics_instance.provider_from_str(&cli.provider)?;
+
+        let target_config = target::Config::new(
+            EndpointAddress {
+                node: Some(&cli.node),
+                service: Some(&cli.service),
+            },
+            provider,
+            &flow_writer,
+        );
+
+        let target = fabrics_instance.create_target()?;
+        let (target, target_info) = target.setup(&target_config)?;
+
+        Ok((
+            Self {
+                _instance: instance,
+                flow_config,
+                flow_writer,
+                target,
+            },
+            target_info,
+        ))
+    }
+
+    pub fn run(self, running: Arc<AtomicBool>) -> Result<(), mxl::Error> {
+        match self.target.specialize(&self.flow_config) {
+            target::Either::Grain(target) => {
+                Self::run_discrete(target, self.flow_writer.to_grain_writer()?, running)?;
+            }
+            target::Either::Sample(target) => {
+                Self::run_continuous(target, self.flow_writer.to_samples_writer()?, running)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn run_discrete(
+        target: Target<target::states::Grain>,
+        writer: GrainWriter,
+        running: Arc<AtomicBool>,
+    ) -> Result<(), mxl::Error> {
+        while running.load(atomic::Ordering::SeqCst) {
+            match target.read(Duration::from_millis(200)) {
+                Ok(read_result) => {
+                    let grain = writer.open_grain(read_result.grain_index)?;
+                    let valid_slices = grain.valid_slices();
+                    grain.commit(valid_slices)?;
+
+                    tracing::debug!(
+                        "Commited grain index {}, slice index {}.",
+                        read_result.grain_index,
+                        valid_slices
+                    );
+                }
+                Err(mxl::Error::NotReady) => {
+                    continue;
+                }
+                Err(mxl::Error::Interrupted) => {
+                    tracing::info!("Interrupted, exiting.");
+                    break;
+                }
+                Err(e) => {
+                    return Err(e);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn run_continuous(
+        target: Target<target::states::Sample>,
+        writer: SamplesWriter,
+        running: Arc<AtomicBool>,
+    ) -> Result<(), mxl::Error> {
+        while running.load(atomic::Ordering::SeqCst) {
+            match target.read(Duration::from_millis(200)) {
+                Ok(read_result) => {
+                    let samples = writer.open_samples(read_result.head_index, read_result.count)?;
+                    samples.commit()?;
+
+                    tracing::debug!(
+                        "Commited samples, head index {}, count {}.",
+                        read_result.head_index,
+                        read_result.count
+                    );
+                }
+                Err(mxl::Error::NotReady) => {
+                    continue;
+                }
+                Err(mxl::Error::Interrupted) => {
+                    tracing::info!("Interrupted, exiting.");
+                    break;
+                }
+                Err(e) => {
+                    return Err(e);
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+struct InitiatorEndpoint<'a> {
+    instance: &'a MxlInstance,
+    fabrics_instance: FabricsInstance,
+    flow_reader: FlowReader,
+    initiator: Initiator<initiator::states::Specializing>,
+}
+
+impl<'a> InitiatorEndpoint<'a> {
+    pub fn new(
+        instance: &'a MxlInstance,
+        fabrics_api: &Arc<MxlFabricsApi>,
+        flow_id: &str,
+        cli: &Cli,
+    ) -> Result<Self, mxl::Error> {
+        let flow_reader = instance.create_flow_reader(flow_id)?;
+
+        let fabrics_instance = instance.create_fabrics_instance(fabrics_api)?;
+
+        let initiator = fabrics_instance.create_initiator()?;
+
+        let provider = fabrics_instance.provider_from_str(&cli.provider)?;
+
+        let initiator_config = initiator::Config::new(
+            EndpointAddress {
+                node: Some(&cli.node),
+                service: Some(&cli.service),
+            },
+            provider,
+            &flow_reader,
+        );
+
+        let initiator = initiator.setup(&initiator_config)?;
+
+        Ok(Self {
+            instance,
+            fabrics_instance,
+            initiator,
+            flow_reader,
+        })
+    }
+
+    pub fn run(self, target_info_str: &str, running: Arc<AtomicBool>) -> Result<(), mxl::Error> {
+        let flow_info = self.flow_reader.get_info()?;
+
+        let target_info_str =
+            String::from_utf8(BASE64_STANDARD.decode(target_info_str).map_err(|e| {
+                Error::Other(format!("Failed to decode target_info from base64: {e}"))
+            })?)
+            .map_err(|e| Error::Other(format!("Decoded target_info is not valid UTF-8: {e}")))?;
+
+        let target_info = self
+            .fabrics_instance
+            .target_info_from_str(&target_info_str)?;
+
+        match self.initiator.specialize(&flow_info.config) {
+            initiator::Either::Grain(initiator) => {
+                initiator.add_target(&target_info)?;
+                // Wait to be connected
+                loop {
+                    if !running.load(atomic::Ordering::SeqCst) {
+                        return Ok(());
+                    }
+
+                    if initiator.make_progress(Duration::from_millis(250)).is_ok() {
+                        break;
+                    }
+                }
+                Self::run_discrete(
+                    self.instance,
+                    initiator,
+                    self.flow_reader.to_grain_reader()?,
+                    &flow_info,
+                    running,
+                )?;
+            }
+            initiator::Either::Samples(initiator) => {
+                initiator.add_target(&target_info)?;
+                // Wait to be connected
+                loop {
+                    if !running.load(atomic::Ordering::SeqCst) {
+                        return Ok(());
+                    }
+
+                    if initiator.make_progress(Duration::from_millis(250)).is_ok() {
+                        break;
+                    }
+                }
+                Self::run_continuous(
+                    self.instance,
+                    initiator,
+                    self.flow_reader.to_samples_reader()?,
+                    &flow_info,
+                    running,
+                )?;
+            }
+        }
+
+        tracing::info!("Stopping as requested.");
+
+        Ok(())
+    }
+
+    fn run_discrete(
+        instance: &MxlInstance,
+        initiator: Initiator<initiator::states::Grain>,
+        reader: GrainReader,
+        flow_info: &FlowInfo,
+        running: Arc<AtomicBool>,
+    ) -> Result<(), mxl::Error> {
+        let rate = flow_info.config.common().grain_rate()?;
+        let mut index = instance.get_current_index(&rate);
+        while running.load(atomic::Ordering::SeqCst) {
+            match reader.get_complete_grain(index, Duration::from_millis(200)) {
+                Ok(grain) => {
+                    match initiator.transfer(index, 0, grain.total_slices) {
+                        Err(Error::NotReady) => {
+                            // Retry the same grain
+                            continue;
+                        }
+                        Err(e) => {
+                            return Err(e);
+                        }
+                        Ok(_) => {}
+                    };
+
+                    // Transfer was posted, now wait for completion
+                    loop {
+                        match initiator.make_progress(Duration::from_millis(10)) {
+                            Ok(_) => {
+                                // we're done exiting the loop
+                                break;
+                            }
+                            Err(Error::Interrupted) => {
+                                return Ok(());
+                            }
+                            Err(Error::NotReady) => {
+                                // Retry
+                                continue;
+                            }
+                            Err(e) => {
+                                return Err(e);
+                            }
+                        }
+                    }
+                    index += 1;
+                }
+                Err(Error::OutOfRangeTooLate) => {
+                    // We are too late, move to the next grain
+                    index = instance.get_current_index(&rate);
+                }
+                Err(Error::OutOfRangeTooEarly) => {
+                    // We are too early, retry the same grain
+                }
+                Err(e) => {
+                    tracing::error!("Error reading from flow: {}.", e);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn run_continuous(
+        instance: &MxlInstance,
+        initiator: Initiator<initiator::states::Samples>,
+        reader: SamplesReader,
+        flow_info: &FlowInfo,
+        running: Arc<AtomicBool>,
+    ) -> Result<(), mxl::Error> {
+        let rate = flow_info.config.common().grain_rate()?;
+        let count = flow_info.config.common().max_sync_batch_size_hint() as usize;
+        let mut index = instance.get_current_index(&rate);
+        while running.load(atomic::Ordering::SeqCst) {
+            match reader.get_samples_non_blocking(index, count) {
+                Ok(_sample) => {
+                    match initiator.transfer(index, count) {
+                        Err(Error::NotReady) => {
+                            // Retry the same grain
+                            continue;
+                        }
+                        Err(e) => {
+                            return Err(e);
+                        }
+                        Ok(_) => {}
+                    };
+
+                    // Transfer was posted, now wait for completion
+                    loop {
+                        match initiator.make_progress(Duration::from_millis(10)) {
+                            Ok(_) => {
+                                // we're done exiting the loop
+                                break;
+                            }
+                            Err(Error::Interrupted) => {
+                                return Ok(());
+                            }
+                            Err(Error::NotReady) => {
+                                // Retry
+                                continue;
+                            }
+                            Err(e) => {
+                                return Err(e);
+                            }
+                        }
+                    }
+                    index += 1;
+                }
+                Err(Error::OutOfRangeTooLate) => {
+                    // We are too late, move to the next grain
+                    index = instance.get_current_index(&rate);
+                }
+                Err(Error::OutOfRangeTooEarly) => {
+                    // We are too early, retry the same grain
+                }
+                Err(e) => {
+                    tracing::error!("Error reading from flow: {}.", e);
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+fn main() -> Result<(), mxl::Error> {
+    common::setup_logging();
+
+    let cli = Cli::parse();
+
+    let running = Arc::new(AtomicBool::new(true));
+    let running2 = running.clone();
+    ctrlc::set_handler(move || {
+        running2.store(false, atomic::Ordering::SeqCst);
+    })
+    .expect("Error setting Ctrl-C handler");
+
+    let api = mxl::load_api(get_mxl_so_path())?;
+
+    let fabrics_api = mxl::load_fabrics_api(get_mxl_fabrics_ofi_so_path())?;
+
+    let instance = mxl::MxlInstance::new(api, &cli.domain, "")?;
+
+    match &cli.command {
+        Command::Initiator {
+            flow_id,
+            target_info,
+        } => {
+            let initiator = InitiatorEndpoint::new(&instance, &fabrics_api, flow_id, &cli)?;
+            initiator.run(target_info, running)?;
+        }
+        Command::Target { flow_file } => {
+            let (target, target_info) =
+                TargetEndpoint::new(&instance, &fabrics_api, flow_file, &cli)?;
+            tracing::info!(
+                "Target Info: {}",
+                BASE64_STANDARD.encode(target_info.to_string()?)
+            );
+            target.run(running)?;
+        }
+    }
+
+    Ok(())
+}

--- a/rust/mxl/examples/fabrics-demo.rs
+++ b/rust/mxl/examples/fabrics-demo.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: Apache-2.0
+
 mod common;
 
 use std::{

--- a/rust/mxl/examples/fabrics-demo.rs
+++ b/rust/mxl/examples/fabrics-demo.rs
@@ -217,11 +217,8 @@ impl<'a> InitiatorEndpoint<'a> {
         flow_id: &str,
     ) -> Result<Self, mxl::Error> {
         let flow_reader = instance.create_flow_reader(flow_id)?;
-
         let initiator = fabrics_instance.create_initiator()?;
-
         let initiator_config = initiator::Config::new(interface, &flow_reader);
-
         let initiator = initiator.setup(&initiator_config)?;
 
         Ok(Self {

--- a/rust/mxl/examples/fabrics-demo.rs
+++ b/rust/mxl/examples/fabrics-demo.rs
@@ -437,7 +437,7 @@ impl PartialOrd for ProviderPrio {
     }
 }
 
-fn main() -> Result<(), anyhow::Error> {
+fn main() -> Result<(), mxl::Error> {
     common::setup_logging();
 
     let cli = Cli::parse();
@@ -518,7 +518,8 @@ fn main() -> Result<(), anyhow::Error> {
                 } else {
                     target_info_file.as_str()
                 };
-                std::fs::write(file, target_info.to_string()?.as_bytes())?;
+                std::fs::write(file, target_info.to_string()?.as_bytes())
+                    .map_err(|e| mxl::Error::Other(format!("fail to write to file: {}", e)))?;
             }
             tracing::info!(
                 "Target Info: {}",

--- a/rust/mxl/examples/fabrics-demo.rs
+++ b/rust/mxl/examples/fabrics-demo.rs
@@ -127,7 +127,7 @@ impl<'a> TargetEndpoint<'a> {
             TargetFlavor::Grain(target) => {
                 Self::run_discrete(target, self.flow_writer.to_grain_writer()?, running)?;
             }
-            TargetFlavor::Sample(target) => {
+            TargetFlavor::Samples(target) => {
                 Self::run_continuous(target, self.flow_writer.to_samples_writer()?, running)?;
             }
         }

--- a/rust/mxl/examples/fabrics-demo.rs
+++ b/rust/mxl/examples/fabrics-demo.rs
@@ -16,13 +16,13 @@ use clap::{Parser, Subcommand};
 use base64::{Engine as _, prelude::BASE64_STANDARD};
 
 use mxl::{
-    Error, FlowConfigInfo, FlowInfo, FlowReader, FlowWriter, GrainReader, GrainWriter, MxlInstance,
-    SamplesReader, SamplesWriter,
+    Error, FlowInfo, FlowReader, FlowWriter, GrainReader, GrainWriter, MxlInstance, SamplesReader,
+    SamplesWriter,
     config::{get_mxl_fabrics_ofi_so_path, get_mxl_so_path},
     fabrics::{
         Capabilities, EndpointAddress, FabricsInstance, InterfaceConfig, ProviderType, TargetInfo,
-        initiator::{self, Initiator},
-        target::{self, Target},
+        initiator::{self, Initiator, InitiatorFlavor},
+        target::{self, Target, TargetFlavor},
     },
 };
 
@@ -92,9 +92,8 @@ pub enum Command {
 
 struct TargetEndpoint<'a> {
     _instance: &'a MxlInstance,
-    flow_config: FlowConfigInfo,
     flow_writer: FlowWriter,
-    target: Target<target::states::Specializing>,
+    target: TargetFlavor,
 }
 
 impl<'a> TargetEndpoint<'a> {
@@ -111,12 +110,11 @@ impl<'a> TargetEndpoint<'a> {
         let target_config = target::Config::new(interface, &flow_writer);
 
         let target = fabrics_instance.create_target()?;
-        let (target, target_info) = target.setup(&target_config)?;
+        let (target, target_info) = target.setup(&target_config, &flow_config)?;
 
         Ok((
             Self {
                 _instance: instance,
-                flow_config,
                 flow_writer,
                 target,
             },
@@ -125,11 +123,11 @@ impl<'a> TargetEndpoint<'a> {
     }
 
     pub fn run(self, running: Arc<AtomicBool>) -> Result<(), mxl::Error> {
-        match self.target.specialize(&self.flow_config) {
-            target::Either::Grain(target) => {
+        match self.target {
+            TargetFlavor::Grain(target) => {
                 Self::run_discrete(target, self.flow_writer.to_grain_writer()?, running)?;
             }
-            target::Either::Sample(target) => {
+            TargetFlavor::Sample(target) => {
                 Self::run_continuous(target, self.flow_writer.to_samples_writer()?, running)?;
             }
         }
@@ -170,7 +168,7 @@ impl<'a> TargetEndpoint<'a> {
     }
 
     fn run_continuous(
-        target: Target<target::states::Sample>,
+        target: Target<target::states::Samples>,
         writer: SamplesWriter,
         running: Arc<AtomicBool>,
     ) -> Result<(), mxl::Error> {
@@ -206,7 +204,7 @@ struct InitiatorEndpoint<'a> {
     instance: &'a MxlInstance,
     fabrics_instance: FabricsInstance,
     flow_reader: FlowReader,
-    initiator: Initiator<initiator::states::Specializing>,
+    initiator: InitiatorFlavor,
 }
 
 impl<'a> InitiatorEndpoint<'a> {
@@ -232,18 +230,25 @@ impl<'a> InitiatorEndpoint<'a> {
     pub fn run(self, target_info_str: &str, running: Arc<AtomicBool>) -> Result<(), mxl::Error> {
         let flow_info = self.flow_reader.get_info()?;
 
-        let target_info_str =
+        let target_info_str = if let Some(file_path) = target_info_str.strip_prefix('@') {
+            std::fs::read_to_string(file_path).map_err(|e| {
+                Error::Other(format!(
+                    "Failed to read target info file '{file_path}': {e}"
+                ))
+            })?
+        } else {
             String::from_utf8(BASE64_STANDARD.decode(target_info_str).map_err(|e| {
                 Error::Other(format!("Failed to decode target_info from base64: {e}"))
             })?)
-            .map_err(|e| Error::Other(format!("Decoded target_info is not valid UTF-8: {e}")))?;
+            .map_err(|e| Error::Other(format!("Decoded target_info is not valid UTF-8: {e}")))?
+        };
 
         let target_info = self
             .fabrics_instance
             .target_info_from_str(&target_info_str)?;
 
-        match self.initiator.specialize(&flow_info.config) {
-            initiator::Either::Grain(initiator) => {
+        match self.initiator {
+            InitiatorFlavor::Grain(initiator) => {
                 initiator.add_target(&target_info)?;
                 // Wait to be connected
                 loop {
@@ -263,7 +268,7 @@ impl<'a> InitiatorEndpoint<'a> {
                     running,
                 )?;
             }
-            initiator::Either::Samples(initiator) => {
+            InitiatorFlavor::Samples(initiator) => {
                 initiator.add_target(&target_info)?;
                 // Wait to be connected
                 loop {
@@ -356,7 +361,7 @@ impl<'a> InitiatorEndpoint<'a> {
         flow_info: &FlowInfo,
         running: Arc<AtomicBool>,
     ) -> Result<(), mxl::Error> {
-        let rate = flow_info.config.common().grain_rate()?;
+        let rate = flow_info.config.common().sample_rate()?;
         let count = flow_info.config.common().max_sync_batch_size_hint() as usize;
         let mut index = instance.get_current_index(&rate);
         while running.load(atomic::Ordering::SeqCst) {
@@ -392,7 +397,8 @@ impl<'a> InitiatorEndpoint<'a> {
                             }
                         }
                     }
-                    index += 1;
+
+                    index += count as u64;
                 }
                 Err(Error::OutOfRangeTooLate) => {
                     // We are too late, move to the next grain
@@ -456,18 +462,15 @@ fn main() -> Result<(), mxl::Error> {
 
     let fabrics_instance = instance.create_fabrics_instance(&fabrics_api)?;
 
-    let endpoint_address = EndpointAddress {
-        node: cli.node.as_deref(),
-        service: cli.service.as_deref(),
-    };
+    let interface_query_address = EndpointAddress::new(cli.node.as_deref(), None)?;
 
     let provider =
         fabrics_instance.provider_from_str(&cli.provider.unwrap_or("any".to_string()))?;
 
-    let interface_config = mxl::fabrics::InterfaceConfig::builder(endpoint_address)
+    let interface_config = mxl::fabrics::InterfaceConfig::builder(interface_query_address)
         .provider(provider.prov_type().clone())
         .caps(Capabilities::default())
-        .build();
+        .build()?;
 
     let interfaces = fabrics_instance
         .get_interfaces(Some(interface_config))
@@ -477,11 +480,11 @@ fn main() -> Result<(), mxl::Error> {
         .iter()
         .max_by_key(|k| ProviderPrio(k.provider.clone()))
         .ok_or(Error::Other("No suitable interface found".to_string()))?;
-    interface.set_endpoint_address(EndpointAddress {
-        node: cli.node.as_deref(),
-        service: cli.service.as_deref(),
-    });
-
+    let selected_node = match cli.node.as_deref() {
+        Some(node) => Some(node),
+        None => interface.endpoint_address.node()?,
+    };
+    interface.set_endpoint_address(EndpointAddress::new(selected_node, cli.service.as_deref())?);
     tracing::info!(
         provider = ?interface.provider,
         node = ?interface.endpoint_address.node,
@@ -505,16 +508,22 @@ fn main() -> Result<(), mxl::Error> {
             let (target, target_info) =
                 TargetEndpoint::new(&instance, &fabrics_instance, interface, flow_file)?;
 
-            if let Some(target_info_file) = target_info_path
-                && target_info_file.starts_with('@')
-            {
-                let file = if target_info_file.starts_with("@") {
-                    target_info_file
-                        .strip_prefix('@')
-                        .expect("impossible to fail.") //SAFETY: we already checked that the string starts with '@';
-                } else {
-                    target_info_file.as_str()
-                };
+            if let Some(target_info_file) = target_info_path {
+                let file = target_info_file
+                    .strip_prefix('@')
+                    .unwrap_or(target_info_file);
+                let path = std::path::Path::new(file);
+                if let Some(parent) = path.parent()
+                    && !parent.as_os_str().is_empty()
+                {
+                    std::fs::create_dir_all(parent).map_err(|e| {
+                        mxl::Error::Other(format!(
+                            "fail to create parent directory '{}': {}",
+                            parent.display(),
+                            e
+                        ))
+                    })?;
+                }
                 std::fs::write(file, target_info.to_string()?.as_bytes())
                     .map_err(|e| mxl::Error::Other(format!("fail to write to file: {}", e)))?;
             }

--- a/rust/mxl/examples/fabrics-demo.rs
+++ b/rust/mxl/examples/fabrics-demo.rs
@@ -157,7 +157,7 @@ impl<'a> TargetEndpoint<'a> {
                 }
                 Err(mxl::Error::Interrupted) => {
                     tracing::info!("Interrupted, exiting.");
-                    break;
+                    return Ok(());
                 }
                 Err(e) => {
                     return Err(e);
@@ -189,7 +189,7 @@ impl<'a> TargetEndpoint<'a> {
                 }
                 Err(mxl::Error::Interrupted) => {
                     tracing::info!("Interrupted, exiting.");
-                    break;
+                    return Ok(());
                 }
                 Err(e) => {
                     return Err(e);
@@ -251,15 +251,11 @@ impl<'a> InitiatorEndpoint<'a> {
             InitiatorFlavor::Grain(initiator) => {
                 initiator.add_target(&target_info)?;
                 // Wait to be connected
-                loop {
-                    if !running.load(atomic::Ordering::SeqCst) {
-                        return Ok(());
-                    }
-
-                    if initiator.make_progress(Duration::from_millis(250)).is_ok() {
-                        break;
-                    }
+                if !Self::wait_for_completion(&initiator, Duration::from_millis(250), &running)? {
+                    // Interrupted while waiting for connection, exit gracefully
+                    return Ok(());
                 }
+
                 Self::run_discrete(
                     self.instance,
                     initiator,
@@ -271,15 +267,11 @@ impl<'a> InitiatorEndpoint<'a> {
             InitiatorFlavor::Samples(initiator) => {
                 initiator.add_target(&target_info)?;
                 // Wait to be connected
-                loop {
-                    if !running.load(atomic::Ordering::SeqCst) {
-                        return Ok(());
-                    }
-
-                    if initiator.make_progress(Duration::from_millis(250)).is_ok() {
-                        break;
-                    }
+                if !Self::wait_for_completion(&initiator, Duration::from_millis(250), &running)? {
+                    // Interrupted while waiting for connection, exit gracefully
+                    return Ok(());
                 }
+
                 Self::run_continuous(
                     self.instance,
                     initiator,
@@ -319,24 +311,12 @@ impl<'a> InitiatorEndpoint<'a> {
                     };
 
                     // Transfer was posted, now wait for completion
-                    loop {
-                        match initiator.make_progress(Duration::from_millis(10)) {
-                            Ok(_) => {
-                                // we're done exiting the loop
-                                break;
-                            }
-                            Err(Error::Interrupted) => {
-                                return Ok(());
-                            }
-                            Err(Error::NotReady) => {
-                                // Retry
-                                continue;
-                            }
-                            Err(e) => {
-                                return Err(e);
-                            }
-                        }
+                    if !Self::wait_for_completion(&initiator, Duration::from_millis(10), &running)?
+                    {
+                        // Interrupted while waiting for completion, exit gracefully
+                        return Ok(());
                     }
+
                     index += 1;
                 }
                 Err(Error::OutOfRangeTooLate) => {
@@ -379,23 +359,10 @@ impl<'a> InitiatorEndpoint<'a> {
                     };
 
                     // Transfer was posted, now wait for completion
-                    loop {
-                        match initiator.make_progress(Duration::from_millis(10)) {
-                            Ok(_) => {
-                                // we're done exiting the loop
-                                break;
-                            }
-                            Err(Error::Interrupted) => {
-                                return Ok(());
-                            }
-                            Err(Error::NotReady) => {
-                                // Retry
-                                continue;
-                            }
-                            Err(e) => {
-                                return Err(e);
-                            }
-                        }
+                    if !Self::wait_for_completion(&initiator, Duration::from_millis(10), &running)?
+                    {
+                        // Interrupted while waiting for completion, exit gracefully
+                        return Ok(());
                     }
 
                     index += count as u64;
@@ -413,6 +380,33 @@ impl<'a> InitiatorEndpoint<'a> {
             }
         }
         Ok(())
+    }
+
+    fn wait_for_completion<S: initiator::states::InitiatorOperational>(
+        initiator: &Initiator<S>,
+        duration: Duration,
+        running: &AtomicBool,
+    ) -> Result<bool, mxl::Error> {
+        loop {
+            if !running.load(atomic::Ordering::SeqCst) {
+                return Ok(false);
+            }
+            match initiator.make_progress(duration) {
+                Ok(_) => {
+                    return Ok(true);
+                }
+                Err(Error::Interrupted) => {
+                    return Ok(false);
+                }
+                Err(Error::NotReady) => {
+                    // Retry
+                    continue;
+                }
+                Err(e) => {
+                    return Err(e);
+                }
+            }
+        }
     }
 }
 

--- a/rust/mxl/examples/flow-writer.rs
+++ b/rust/mxl/examples/flow-writer.rs
@@ -38,7 +38,7 @@ fn main() -> Result<(), mxl::Error> {
     let flow_def = std::fs::read_to_string(opts.flow_config_file.as_str()).map_err(|error| {
         mxl::Error::Other(format!(
             "Error while reading flow definition from \"{}\": {}",
-            &opts.flow_config_file, error
+            opts.flow_config_file, error
         ))
     })?;
 

--- a/rust/mxl/src/api.rs
+++ b/rust/mxl/src/api.rs
@@ -15,3 +15,15 @@ pub fn load_api(path_to_so_file: impl AsRef<Path>) -> Result<MxlApiHandle> {
         libmxl::new(path_to_so_file.as_ref().as_os_str())?
     }))
 }
+
+#[cfg(feature = "mxl-fabrics-ofi")]
+pub type MxlFabricsApi = mxl_sys::fabrics::libmxlfabrics;
+#[cfg(feature = "mxl-fabrics-ofi")]
+pub type MxlFabricsAPiHandle = Arc<MxlFabricsApi>;
+
+#[cfg(feature = "mxl-fabrics-ofi")]
+pub fn load_fabrics_api(path_to_so_file: impl AsRef<Path>) -> Result<MxlFabricsAPiHandle> {
+    Ok(Arc::new(unsafe {
+        mxl_sys::fabrics::libmxlfabrics::new(path_to_so_file.as_ref().as_os_str())?
+    }))
+}

--- a/rust/mxl/src/api.rs
+++ b/rust/mxl/src/api.rs
@@ -19,10 +19,10 @@ pub fn load_api(path_to_so_file: impl AsRef<Path>) -> Result<MxlApiHandle> {
 #[cfg(feature = "mxl-fabrics-ofi")]
 pub type MxlFabricsApi = mxl_sys::fabrics::libmxlfabrics;
 #[cfg(feature = "mxl-fabrics-ofi")]
-pub type MxlFabricsAPiHandle = Arc<MxlFabricsApi>;
+pub type MxlFabricsApiHandle = Arc<MxlFabricsApi>;
 
 #[cfg(feature = "mxl-fabrics-ofi")]
-pub fn load_fabrics_api(path_to_so_file: impl AsRef<Path>) -> Result<MxlFabricsAPiHandle> {
+pub fn load_fabrics_api(path_to_so_file: impl AsRef<Path>) -> Result<MxlFabricsApiHandle> {
     Ok(Arc::new(unsafe {
         mxl_sys::fabrics::libmxlfabrics::new(path_to_so_file.as_ref().as_os_str())?
     }))

--- a/rust/mxl/src/config.rs
+++ b/rust/mxl/src/config.rs
@@ -20,6 +20,23 @@ pub fn get_mxl_so_path() -> std::path::PathBuf {
         .join("libmxl.so")
 }
 
+#[cfg(not(feature = "mxl-not-built"))]
+pub fn get_mxl_fabrics_ofi_so_path() -> std::path::PathBuf {
+    // The mxl-sys build script ensures that the build directory is in the library path
+    // so we can just return the library name here.
+    "libmxl-fabrics.so".into()
+}
+
+#[cfg(feature = "mxl-not-built")]
+pub fn get_mxl_fabrics_ofi_so_path() -> std::path::PathBuf {
+    std::path::PathBuf::from_str(MXL_BUILD_DIR)
+        .expect("build error: 'MXL_FABRICS_SO_PATH' is invalid")
+        .join("lib")
+        .join("fabrics")
+        .join("ofi")
+        .join("libmxl-fabrics.so")
+}
+
 pub fn get_mxl_repo_root() -> std::path::PathBuf {
     std::path::PathBuf::from_str(MXL_REPO_ROOT).expect("build error: 'MXL_REPO_ROOT' is invalid")
 }

--- a/rust/mxl/src/config.rs
+++ b/rust/mxl/src/config.rs
@@ -30,7 +30,7 @@ pub fn get_mxl_fabrics_ofi_so_path() -> std::path::PathBuf {
 #[cfg(feature = "mxl-not-built")]
 pub fn get_mxl_fabrics_ofi_so_path() -> std::path::PathBuf {
     std::path::PathBuf::from_str(MXL_BUILD_DIR)
-        .expect("build error: 'MXL_FABRICS_SO_PATH' is invalid")
+        .expect("build error: 'MXL_BUILD_DIR' is invalid")
         .join("lib")
         .join("fabrics")
         .join("ofi")

--- a/rust/mxl/src/error.rs
+++ b/rust/mxl/src/error.rs
@@ -23,6 +23,12 @@ pub enum Error {
     InvalidArg,
     #[error("Conflict")]
     Conflict,
+    #[error("Not ready")]
+    NotReady,
+    #[error("Not found")]
+    NotFound,
+    #[error("Interrupted")]
+    Interrupted,
     /// The error is not defined in the MXL API, but it is used to wrap other errors.
     #[error("Other error: {0}")]
     Other(String),
@@ -47,6 +53,9 @@ impl Error {
             mxl_sys::MXL_ERR_TIMEOUT => Err(Error::Timeout),
             mxl_sys::MXL_ERR_INVALID_ARG => Err(Error::InvalidArg),
             mxl_sys::MXL_ERR_CONFLICT => Err(Error::Conflict),
+            mxl_sys::MXL_ERR_NOT_READY => Err(Error::NotReady),
+            mxl_sys::MXL_ERR_NOT_FOUND => Err(Error::NotFound),
+            mxl_sys::MXL_ERR_INTERRUPTED => Err(Error::Interrupted),
             other => Err(Error::Unknown(other)),
         }
     }

--- a/rust/mxl/src/error.rs
+++ b/rust/mxl/src/error.rs
@@ -23,12 +23,27 @@ pub enum Error {
     InvalidArg,
     #[error("Conflict")]
     Conflict,
+
+    // Fabrics errors
+    #[error("String length exceeds buffer size")]
+    Strlen,
+    #[error("Interrupted")]
+    Interrupted,
+    #[error("No fabric available")]
+    NoFabric,
+    #[error("Invalid state")]
+    InvalidState,
+    #[error("Internal error")]
+    Internal,
     #[error("Not ready")]
     NotReady,
     #[error("Not found")]
     NotFound,
-    #[error("Interrupted")]
-    Interrupted,
+    #[error("Already exists")]
+    Exists,
+    #[error("Unsupported operation")]
+    UnsupportedOperation,
+
     /// The error is not defined in the MXL API, but it is used to wrap other errors.
     #[error("Other error: {0}")]
     Other(String),
@@ -53,9 +68,18 @@ impl Error {
             mxl_sys::MXL_ERR_TIMEOUT => Err(Error::Timeout),
             mxl_sys::MXL_ERR_INVALID_ARG => Err(Error::InvalidArg),
             mxl_sys::MXL_ERR_CONFLICT => Err(Error::Conflict),
+
+            // fabrics errors
+            mxl_sys::MXL_ERR_STRLEN => Err(Error::Strlen),
+            mxl_sys::MXL_ERR_INTERRUPTED => Err(Error::Interrupted),
+            mxl_sys::MXL_ERR_NO_FABRIC => Err(Error::NoFabric),
+            mxl_sys::MXL_ERR_INVALID_STATE => Err(Error::InvalidState),
+            mxl_sys::MXL_ERR_INTERNAL => Err(Error::Internal),
             mxl_sys::MXL_ERR_NOT_READY => Err(Error::NotReady),
             mxl_sys::MXL_ERR_NOT_FOUND => Err(Error::NotFound),
-            mxl_sys::MXL_ERR_INTERRUPTED => Err(Error::Interrupted),
+            mxl_sys::MXL_ERR_EXISTS => Err(Error::Exists),
+            mxl_sys::MXL_ERR_UNSUPPORTED_OPERATION => Err(Error::UnsupportedOperation),
+
             other => Err(Error::Unknown(other)),
         }
     }

--- a/rust/mxl/src/error.rs
+++ b/rust/mxl/src/error.rs
@@ -23,6 +23,12 @@ pub enum Error {
     InvalidArg,
     #[error("Conflict")]
     Conflict,
+    #[error("Permission Denied")]
+    PermissionDenied,
+    /// A flow is invalid from a reader point of view if its data file has been replaced
+    /// (for example, if a writer restarted and recreated the flow)
+    #[error("Flow invalid")]
+    FlowInvalid,
 
     // Fabrics errors
     #[error("String length exceeds buffer size")]
@@ -68,6 +74,8 @@ impl Error {
             mxl_sys::MXL_ERR_TIMEOUT => Err(Error::Timeout),
             mxl_sys::MXL_ERR_INVALID_ARG => Err(Error::InvalidArg),
             mxl_sys::MXL_ERR_CONFLICT => Err(Error::Conflict),
+            mxl_sys::MXL_ERR_PERMISSION_DENIED => Err(Error::PermissionDenied),
+            mxl_sys::MXL_ERR_FLOW_INVALID => Err(Error::FlowInvalid),
 
             // fabrics errors
             mxl_sys::MXL_ERR_STRLEN => Err(Error::Strlen),

--- a/rust/mxl/src/fabrics/capabilities.rs
+++ b/rust/mxl/src/fabrics/capabilities.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: Apache-2.0
+
 /// Capabilities of the fabric interface
 #[derive(Debug)]
 pub struct Capabilities {

--- a/rust/mxl/src/fabrics/capabilities.rs
+++ b/rust/mxl/src/fabrics/capabilities.rs
@@ -1,0 +1,115 @@
+#[derive(Debug)]
+pub struct Capabilities {
+    blocking_operations: bool,
+    remote_write: bool,
+    send_recv: bool,
+
+    max_message_size: u64,
+}
+impl Capabilities {
+    pub fn builder() -> CapabilitiesBuilder {
+        CapabilitiesBuilder::default()
+    }
+}
+impl Default for Capabilities {
+    fn default() -> Self {
+        Self {
+            blocking_operations: true,
+            remote_write: true,
+            send_recv: false,
+            max_message_size: u64::MAX,
+        }
+    }
+}
+
+impl From<&Capabilities> for mxl_sys::fabrics::FabricsInterfaceCaps {
+    fn from(value: &Capabilities) -> Self {
+        let flags = (if value.blocking_operations {
+            mxl_sys::fabrics::MXL_FABRICS_IFACE_CAP_BLOCKING_OPERATIONS as u64
+        } else {
+            0
+        }) | (if value.remote_write {
+            mxl_sys::fabrics::MXL_FABRICS_IFACE_CAP_REMOTE_WRITE as u64
+        } else {
+            0
+        }) | (if value.send_recv {
+            mxl_sys::fabrics::MXL_FABRICS_IFACE_CAP_SEND_RECEIVE as u64
+        } else {
+            0
+        });
+
+        Self {
+            version: mxl_sys::fabrics::MXL_FABRICS_API_VERSION as i32,
+            flags,
+            maxMessageSize: value.max_message_size,
+        }
+    }
+}
+impl From<Capabilities> for mxl_sys::fabrics::FabricsInterfaceCaps {
+    fn from(value: Capabilities) -> Self {
+        (&value).into()
+    }
+}
+impl From<mxl_sys::fabrics::FabricsInterfaceCaps> for Capabilities {
+    fn from(value: mxl_sys::fabrics::FabricsInterfaceCaps) -> Self {
+        let flags = value.flags;
+        Self {
+            blocking_operations: (flags
+                & mxl_sys::fabrics::MXL_FABRICS_IFACE_CAP_BLOCKING_OPERATIONS as u64)
+                != 0,
+            remote_write: (flags & mxl_sys::fabrics::MXL_FABRICS_IFACE_CAP_REMOTE_WRITE as u64)
+                != 0,
+            send_recv: (flags & mxl_sys::fabrics::MXL_FABRICS_IFACE_CAP_SEND_RECEIVE as u64) != 0,
+            max_message_size: value.maxMessageSize,
+        }
+    }
+}
+
+pub struct CapabilitiesBuilder {
+    // flags for the capabilities of the fabric
+    blocking_operations: bool,
+    remote_write: bool,
+    send_recv: bool,
+
+    max_message_size: u64,
+}
+impl CapabilitiesBuilder {
+    pub fn supports_blocking_operations(mut self) -> Self {
+        self.blocking_operations = true;
+        self
+    }
+
+    pub fn supports_remote_write(mut self) -> Self {
+        self.remote_write = true;
+        self
+    }
+
+    pub fn supports_send_recv(mut self) -> Self {
+        self.send_recv = true;
+        self
+    }
+
+    pub fn max_message_size(mut self, value: u64) -> Self {
+        self.max_message_size = value;
+        self
+    }
+
+    pub fn build(self) -> Capabilities {
+        Capabilities {
+            blocking_operations: self.blocking_operations,
+            remote_write: self.remote_write,
+            send_recv: self.send_recv,
+            max_message_size: self.max_message_size,
+        }
+    }
+}
+impl Default for CapabilitiesBuilder {
+    fn default() -> Self {
+        Self {
+            blocking_operations: false,
+            remote_write: false,
+            send_recv: false,
+            max_message_size: u64::MAX,
+        }
+    }
+}

--- a/rust/mxl/src/fabrics/capabilities.rs
+++ b/rust/mxl/src/fabrics/capabilities.rs
@@ -1,3 +1,4 @@
+/// Capabilities of the fabric interface
 #[derive(Debug)]
 pub struct Capabilities {
     blocking_operations: bool,
@@ -10,6 +11,26 @@ impl Capabilities {
     pub fn builder() -> CapabilitiesBuilder {
         CapabilitiesBuilder::default()
     }
+
+    /// The interface supports blocking operations.
+    pub fn supports_blocking_operations(&self) -> bool {
+        self.blocking_operations
+    }
+
+    /// The interface supports remote-write (RDMA) operations.
+    pub fn supports_remote_write(&self) -> bool {
+        self.remote_write
+    }
+
+    /// The interface supports send/receive message operations.
+    pub fn supports_send_recv(&self) -> bool {
+        self.send_recv
+    }
+
+    /// Maximum message size supported on this interface.
+    pub fn max_message_size(&self) -> u64 {
+        self.max_message_size
+    }
 }
 impl Default for Capabilities {
     fn default() -> Self {
@@ -21,7 +42,6 @@ impl Default for Capabilities {
         }
     }
 }
-
 impl From<&Capabilities> for mxl_sys::fabrics::FabricsInterfaceCaps {
     fn from(value: &Capabilities) -> Self {
         let flags = (if value.blocking_operations {
@@ -74,18 +94,18 @@ pub struct CapabilitiesBuilder {
     max_message_size: u64,
 }
 impl CapabilitiesBuilder {
-    pub fn supports_blocking_operations(mut self) -> Self {
-        self.blocking_operations = true;
+    pub fn with_blocking_operations(mut self, value: bool) -> Self {
+        self.blocking_operations = value;
         self
     }
 
-    pub fn supports_remote_write(mut self) -> Self {
-        self.remote_write = true;
+    pub fn with_remote_write(mut self, value: bool) -> Self {
+        self.remote_write = value;
         self
     }
 
-    pub fn supports_send_recv(mut self) -> Self {
-        self.send_recv = true;
+    pub fn with_send_recv(mut self, value: bool) -> Self {
+        self.send_recv = value;
         self
     }
 
@@ -106,8 +126,8 @@ impl CapabilitiesBuilder {
 impl Default for CapabilitiesBuilder {
     fn default() -> Self {
         Self {
-            blocking_operations: false,
-            remote_write: false,
+            blocking_operations: true,
+            remote_write: true,
             send_recv: false,
             max_message_size: u64::MAX,
         }

--- a/rust/mxl/src/fabrics/capabilities.rs
+++ b/rust/mxl/src/fabrics/capabilities.rs
@@ -1,6 +1,11 @@
 // SPDX-FileCopyrightText: 2026 Contributors to the Media eXchange Layer project.
 // SPDX-License-Identifier: Apache-2.0
 
+use mxl_sys::types::{
+    FabricsInterfaceCaps, MXL_FABRICS_API_VERSION, MXL_FABRICS_IFACE_CAP_BLOCKING_OPERATIONS,
+    MXL_FABRICS_IFACE_CAP_REMOTE_WRITE, MXL_FABRICS_IFACE_CAP_SEND_RECEIVE,
+};
+
 /// Capabilities of the fabric interface
 #[derive(Debug)]
 pub struct Capabilities {
@@ -45,44 +50,41 @@ impl Default for Capabilities {
         }
     }
 }
-impl From<&Capabilities> for mxl_sys::fabrics::FabricsInterfaceCaps {
+impl From<&Capabilities> for FabricsInterfaceCaps {
     fn from(value: &Capabilities) -> Self {
         let flags = (if value.blocking_operations {
-            mxl_sys::fabrics::MXL_FABRICS_IFACE_CAP_BLOCKING_OPERATIONS as u64
+            MXL_FABRICS_IFACE_CAP_BLOCKING_OPERATIONS as u64
         } else {
             0
         }) | (if value.remote_write {
-            mxl_sys::fabrics::MXL_FABRICS_IFACE_CAP_REMOTE_WRITE as u64
+            MXL_FABRICS_IFACE_CAP_REMOTE_WRITE as u64
         } else {
             0
         }) | (if value.send_recv {
-            mxl_sys::fabrics::MXL_FABRICS_IFACE_CAP_SEND_RECEIVE as u64
+            MXL_FABRICS_IFACE_CAP_SEND_RECEIVE as u64
         } else {
             0
         });
 
         Self {
-            version: mxl_sys::fabrics::MXL_FABRICS_API_VERSION as i32,
+            version: MXL_FABRICS_API_VERSION as i32,
             flags,
             maxMessageSize: value.max_message_size,
         }
     }
 }
-impl From<Capabilities> for mxl_sys::fabrics::FabricsInterfaceCaps {
+impl From<Capabilities> for FabricsInterfaceCaps {
     fn from(value: Capabilities) -> Self {
         (&value).into()
     }
 }
-impl From<mxl_sys::fabrics::FabricsInterfaceCaps> for Capabilities {
-    fn from(value: mxl_sys::fabrics::FabricsInterfaceCaps) -> Self {
+impl From<FabricsInterfaceCaps> for Capabilities {
+    fn from(value: FabricsInterfaceCaps) -> Self {
         let flags = value.flags;
         Self {
-            blocking_operations: (flags
-                & mxl_sys::fabrics::MXL_FABRICS_IFACE_CAP_BLOCKING_OPERATIONS as u64)
-                != 0,
-            remote_write: (flags & mxl_sys::fabrics::MXL_FABRICS_IFACE_CAP_REMOTE_WRITE as u64)
-                != 0,
-            send_recv: (flags & mxl_sys::fabrics::MXL_FABRICS_IFACE_CAP_SEND_RECEIVE as u64) != 0,
+            blocking_operations: (flags & MXL_FABRICS_IFACE_CAP_BLOCKING_OPERATIONS as u64) != 0,
+            remote_write: (flags & MXL_FABRICS_IFACE_CAP_REMOTE_WRITE as u64) != 0,
+            send_recv: (flags & MXL_FABRICS_IFACE_CAP_SEND_RECEIVE as u64) != 0,
             max_message_size: value.maxMessageSize,
         }
     }

--- a/rust/mxl/src/fabrics/config.rs
+++ b/rust/mxl/src/fabrics/config.rs
@@ -1,0 +1,29 @@
+use std::ffi::CString;
+
+use crate::Error;
+
+/// Address of a logical network endpoint. This is analogous to a hostname and port number in classic ipv4 networking.
+/// The actual values for node and service vary between providers, but often an ip address as the node value and a port number as the service
+/// value are sufficient.
+pub struct EndpointAddress<'a> {
+    pub node: Option<&'a str>,
+    pub service: Option<&'a str>,
+}
+
+impl<'a> TryFrom<&EndpointAddress<'a>> for mxl_sys::fabrics::FabricsEndpointAddress {
+    type Error = Error;
+
+    fn try_from(value: &EndpointAddress) -> Result<Self, Self::Error> {
+        let node = if let Some(node) = value.node {
+            CString::new(node)?.into_raw()
+        } else {
+            std::ptr::null_mut()
+        };
+        let service = if let Some(service) = value.service {
+            CString::new(service)?.into_raw()
+        } else {
+            std::ptr::null_mut()
+        };
+        Ok(mxl_sys::fabrics::FabricsEndpointAddress { node, service })
+    }
+}

--- a/rust/mxl/src/fabrics/config.rs
+++ b/rust/mxl/src/fabrics/config.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::ffi::CString;
 
 use crate::Error;

--- a/rust/mxl/src/fabrics/endpoint_address.rs
+++ b/rust/mxl/src/fabrics/endpoint_address.rs
@@ -14,27 +14,33 @@ pub struct EndpointAddress<'a> {
     pub service: Option<&'a str>,
 }
 
-impl<'a> TryFrom<&EndpointAddress<'a>> for mxl_sys::fabrics::FabricsEndpointAddress {
-    type Error = Error;
-
-    fn try_from(value: &EndpointAddress) -> Result<Self, Self::Error> {
-        let node = if let Some(node) = value.node {
-            CString::new(node)?.into_raw()
-        } else {
-            std::ptr::null_mut()
-        };
-        let service = if let Some(service) = value.service {
-            CString::new(service)?.into_raw()
-        } else {
-            std::ptr::null_mut()
-        };
-        Ok(mxl_sys::fabrics::FabricsEndpointAddress { node, service })
-    }
+/// A wrapper around the FFI representation of an EndpointAddress, which owns the underlying CStrings for node and service.
+pub(crate) struct OwnedEndpointAddress {
+    inner: mxl_sys::fabrics::FabricsEndpointAddress,
+    _node: Option<CString>,
+    _service: Option<CString>,
 }
-impl<'a> TryFrom<EndpointAddress<'a>> for mxl_sys::fabrics::FabricsEndpointAddress {
-    type Error = Error;
 
-    fn try_from(value: EndpointAddress) -> Result<Self, Self::Error> {
-        (&value).try_into()
+impl OwnedEndpointAddress {
+    pub(crate) fn new(value: &EndpointAddress<'_>) -> Result<Self, Error> {
+        let node = value.node.map(CString::new).transpose()?;
+        let service = value.service.map(CString::new).transpose()?;
+
+        Ok(Self {
+            inner: mxl_sys::fabrics::FabricsEndpointAddress {
+                node: node
+                    .as_ref()
+                    .map_or(std::ptr::null_mut(), |value| value.as_ptr() as *mut i8),
+                service: service
+                    .as_ref()
+                    .map_or(std::ptr::null_mut(), |value| value.as_ptr() as *mut i8),
+            },
+            _node: node,
+            _service: service,
+        })
+    }
+
+    pub(crate) fn as_ffi(&self) -> mxl_sys::fabrics::FabricsEndpointAddress {
+        self.inner
     }
 }

--- a/rust/mxl/src/fabrics/endpoint_address.rs
+++ b/rust/mxl/src/fabrics/endpoint_address.rs
@@ -8,6 +8,7 @@ use crate::Error;
 /// Address of a logical network endpoint. This is analogous to a hostname and port number in classic ipv4 networking.
 /// The actual values for node and service vary between providers, but often an ip address as the node value and a port number as the service
 /// value are sufficient.
+#[derive(Debug)]
 pub struct EndpointAddress<'a> {
     pub node: Option<&'a str>,
     pub service: Option<&'a str>,
@@ -28,5 +29,12 @@ impl<'a> TryFrom<&EndpointAddress<'a>> for mxl_sys::fabrics::FabricsEndpointAddr
             std::ptr::null_mut()
         };
         Ok(mxl_sys::fabrics::FabricsEndpointAddress { node, service })
+    }
+}
+impl<'a> TryFrom<EndpointAddress<'a>> for mxl_sys::fabrics::FabricsEndpointAddress {
+    type Error = Error;
+
+    fn try_from(value: EndpointAddress) -> Result<Self, Self::Error> {
+        (&value).try_into()
     }
 }

--- a/rust/mxl/src/fabrics/endpoint_address.rs
+++ b/rust/mxl/src/fabrics/endpoint_address.rs
@@ -1,7 +1,9 @@
 // SPDX-FileCopyrightText: 2026 Contributors to the Media eXchange Layer project.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::ffi::CString;
+use std::ffi::{CStr, CString};
+
+use mxl_sys::fabrics::FabricsEndpointAddress;
 
 use crate::Error;
 
@@ -9,38 +11,63 @@ use crate::Error;
 /// The actual values for node and service vary between providers, but often an ip address as the node value and a port number as the service
 /// value are sufficient.
 #[derive(Debug)]
-pub struct EndpointAddress<'a> {
-    pub node: Option<&'a str>,
-    pub service: Option<&'a str>,
+pub struct EndpointAddress {
+    pub node: Option<CString>,
+    pub service: Option<CString>,
 }
+impl EndpointAddress {
+    pub fn new(node: Option<&str>, service: Option<&str>) -> Result<Self, Error> {
+        // Here we can't guarantee that &str is null terminated, so need to convert to CString first,
+        // which will ensure include null termination and provide an owned value of the
+        // null-terminated string.
+        let node = node.map(CString::new).transpose()?;
+        let service = service.map(CString::new).transpose()?;
 
-/// A wrapper around the FFI representation of an EndpointAddress, which owns the underlying CStrings for node and service.
-pub(crate) struct OwnedEndpointAddress {
-    inner: mxl_sys::fabrics::FabricsEndpointAddress,
-    _node: Option<CString>,
-    _service: Option<CString>,
-}
-
-impl OwnedEndpointAddress {
-    pub(crate) fn new(value: &EndpointAddress<'_>) -> Result<Self, Error> {
-        let node = value.node.map(CString::new).transpose()?;
-        let service = value.service.map(CString::new).transpose()?;
-
-        Ok(Self {
-            inner: mxl_sys::fabrics::FabricsEndpointAddress {
-                node: node
-                    .as_ref()
-                    .map_or(std::ptr::null_mut(), |value| value.as_ptr() as *mut i8),
-                service: service
-                    .as_ref()
-                    .map_or(std::ptr::null_mut(), |value| value.as_ptr() as *mut i8),
-            },
-            _node: node,
-            _service: service,
-        })
+        Ok(Self { node, service })
     }
-
-    pub(crate) fn as_ffi(&self) -> mxl_sys::fabrics::FabricsEndpointAddress {
-        self.inner
+    pub fn node(&self) -> Result<Option<&str>, crate::Error> {
+        self.node
+            .as_ref()
+            .map(|s| {
+                s.to_str()
+                    .map_err(|_| crate::Error::Other("Invalid UTF-8".to_string()))
+            })
+            .transpose()
+    }
+    pub fn service(&self) -> Result<Option<&str>, crate::Error> {
+        self.service
+            .as_ref()
+            .map(|s| {
+                s.to_str()
+                    .map_err(|_| crate::Error::Other("Invalid UTF-8".to_string()))
+            })
+            .transpose()
+    }
+}
+impl From<&EndpointAddress> for FabricsEndpointAddress {
+    fn from(value: &EndpointAddress) -> Self {
+        let node = value.node.as_ref().map_or(std::ptr::null(), |s| s.as_ptr());
+        let service = value
+            .service
+            .as_ref()
+            .map_or(std::ptr::null(), |s| s.as_ptr());
+        Self { node, service }
+    }
+}
+impl From<&FabricsEndpointAddress> for EndpointAddress {
+    fn from(value: &FabricsEndpointAddress) -> Self {
+        let node = if value.node.is_null() {
+            None
+        } else {
+            //SAFETY: if the pointer is not null, then we assume the FFI layer has allocated a valid C string and we can safely convert it to a CString.
+            unsafe { Some(CStr::from_ptr(value.node as *mut i8).to_owned()) }
+        };
+        let service = if value.service.is_null() {
+            None
+        } else {
+            //SAFETY: if the pointer is not null, then we assume the FFI layer has allocated a valid C string and we can safely convert it to a CString.
+            unsafe { Some(CStr::from_ptr(value.service as *mut i8).to_owned()) }
+        };
+        Self { node, service }
     }
 }

--- a/rust/mxl/src/fabrics/endpoint_address.rs
+++ b/rust/mxl/src/fabrics/endpoint_address.rs
@@ -3,7 +3,7 @@
 
 use std::ffi::{CStr, CString};
 
-use mxl_sys::fabrics::FabricsEndpointAddress;
+use mxl_sys::types::FabricsEndpointAddress;
 
 use crate::Error;
 

--- a/rust/mxl/src/fabrics/initiator/config.rs
+++ b/rust/mxl/src/fabrics/initiator/config.rs
@@ -30,12 +30,8 @@ impl<'a> TryFrom<&Config<'a>> for mxl_sys::fabrics::FabricsInitiatorConfig {
         Ok(Self {
             version: value.version,
             interface: *OwnedInterfaceConfig::try_from(&value.interface)?.as_ffi(),
-            // SAFETY: The type cast is necessary, because this FlowReader is scoped in mxl_sys::fabrics::*, not mxl_sys::*, but this is the same type.
-            reader: unsafe {
-                std::mem::transmute::<mxl_sys::FlowReader, mxl_sys::fabrics::FlowReader>(
-                    value.flow_reader.inner(),
-                )
-            },
+            // SAFETY: Both types are equivalent opaque reader handles from different bindgen modules.
+            reader: value.flow_reader.inner().cast(),
         })
     }
 }

--- a/rust/mxl/src/fabrics/initiator/config.rs
+++ b/rust/mxl/src/fabrics/initiator/config.rs
@@ -34,7 +34,7 @@ impl<'a> TryFrom<&Config<'a>> for mxl_sys::fabrics::FabricsInitiatorConfig {
             version: value.version,
             endpointAddress: (&value.endpoint_addr).try_into()?,
             provider: (&value.provider).into(),
-            // SAFETY: The type cast is necessary, because this FlowReader is scoped in mxl_sys::fabrics::*, not mxl_sys::*
+            // SAFETY: The type cast is necessary, because this FlowReader is scoped in mxl_sys::fabrics::*, not mxl_sys::*, but this is the same type.
             reader: unsafe {
                 std::mem::transmute::<mxl_sys::FlowReader, mxl_sys::fabrics::FlowReader>(
                     value.flow_reader.inner(),

--- a/rust/mxl/src/fabrics/initiator/config.rs
+++ b/rust/mxl/src/fabrics/initiator/config.rs
@@ -1,0 +1,45 @@
+use crate::{
+    Error, FlowReader,
+    fabrics::{config::EndpointAddress, provider::Provider},
+};
+
+/// Configuration object required to set up an initiator.
+pub struct Config<'a> {
+    version: i32,
+    endpoint_addr: EndpointAddress<'a>,
+    provider: Provider,
+    flow_reader: &'a FlowReader,
+}
+
+impl<'a> Config<'a> {
+    pub fn new(
+        endpoint_addr: EndpointAddress<'a>,
+        provider: Provider,
+        flow_reader: &'a FlowReader,
+    ) -> Self {
+        Self {
+            version: 0,
+            endpoint_addr,
+            provider,
+            flow_reader,
+        }
+    }
+}
+
+impl<'a> TryFrom<&Config<'a>> for mxl_sys::fabrics::FabricsInitiatorConfig {
+    type Error = Error;
+
+    fn try_from(value: &Config) -> Result<Self, Self::Error> {
+        Ok(Self {
+            version: value.version,
+            endpointAddress: (&value.endpoint_addr).try_into()?,
+            provider: (&value.provider).into(),
+            // SAFETY: The type cast is necessary, because this FlowReader is scoped in mxl_sys::fabrics::*, not mxl_sys::*
+            reader: unsafe {
+                std::mem::transmute::<mxl_sys::FlowReader, mxl_sys::fabrics::FlowReader>(
+                    value.flow_reader.inner(),
+                )
+            },
+        })
+    }
+}

--- a/rust/mxl/src/fabrics/initiator/config.rs
+++ b/rust/mxl/src/fabrics/initiator/config.rs
@@ -1,29 +1,20 @@
 // SPDX-FileCopyrightText: 2026 Contributors to the Media eXchange Layer project.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    Error, FlowReader,
-    fabrics::{config::EndpointAddress, provider::Provider},
-};
+use crate::{Error, FlowReader, fabrics::InterfaceConfig};
 
 /// Configuration object required to set up an initiator.
 pub struct Config<'a> {
     version: i32,
-    endpoint_addr: EndpointAddress<'a>,
-    provider: Provider,
+    interface: InterfaceConfig<'a>,
     flow_reader: &'a FlowReader,
 }
 
 impl<'a> Config<'a> {
-    pub fn new(
-        endpoint_addr: EndpointAddress<'a>,
-        provider: Provider,
-        flow_reader: &'a FlowReader,
-    ) -> Self {
+    pub fn new(interface: InterfaceConfig<'a>, flow_reader: &'a FlowReader) -> Self {
         Self {
             version: 0,
-            endpoint_addr,
-            provider,
+            interface,
             flow_reader,
         }
     }
@@ -35,8 +26,7 @@ impl<'a> TryFrom<&Config<'a>> for mxl_sys::fabrics::FabricsInitiatorConfig {
     fn try_from(value: &Config) -> Result<Self, Self::Error> {
         Ok(Self {
             version: value.version,
-            endpointAddress: (&value.endpoint_addr).try_into()?,
-            provider: (&value.provider).into(),
+            interface: (&value.interface).try_into()?,
             // SAFETY: The type cast is necessary, because this FlowReader is scoped in mxl_sys::fabrics::*, not mxl_sys::*, but this is the same type.
             reader: unsafe {
                 std::mem::transmute::<mxl_sys::FlowReader, mxl_sys::fabrics::FlowReader>(

--- a/rust/mxl/src/fabrics/initiator/config.rs
+++ b/rust/mxl/src/fabrics/initiator/config.rs
@@ -1,13 +1,16 @@
 // SPDX-FileCopyrightText: 2026 Contributors to the Media eXchange Layer project.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{Error, FlowReader, fabrics::InterfaceConfig};
+use crate::{
+    Error, FlowReader,
+    fabrics::{InterfaceConfig, interface::config::OwnedInterfaceConfig},
+};
 
 /// Configuration object required to set up an initiator.
 pub struct Config<'a> {
     version: i32,
     interface: InterfaceConfig<'a>,
-    flow_reader: &'a FlowReader,
+    pub(crate) flow_reader: &'a FlowReader,
 }
 
 impl<'a> Config<'a> {
@@ -26,7 +29,7 @@ impl<'a> TryFrom<&Config<'a>> for mxl_sys::fabrics::FabricsInitiatorConfig {
     fn try_from(value: &Config) -> Result<Self, Self::Error> {
         Ok(Self {
             version: value.version,
-            interface: (&value.interface).try_into()?,
+            interface: *OwnedInterfaceConfig::try_from(&value.interface)?.as_ffi(),
             // SAFETY: The type cast is necessary, because this FlowReader is scoped in mxl_sys::fabrics::*, not mxl_sys::*, but this is the same type.
             reader: unsafe {
                 std::mem::transmute::<mxl_sys::FlowReader, mxl_sys::fabrics::FlowReader>(
@@ -34,5 +37,30 @@ impl<'a> TryFrom<&Config<'a>> for mxl_sys::fabrics::FabricsInitiatorConfig {
                 )
             },
         })
+    }
+}
+
+pub(crate) struct OwnedInitiatorConfig {
+    inner: mxl_sys::fabrics::FabricsInitiatorConfig,
+    _interface: OwnedInterfaceConfig,
+}
+
+impl OwnedInitiatorConfig {
+    pub(crate) fn new(value: &Config<'_>) -> Result<Self, Error> {
+        let interface = OwnedInterfaceConfig::new(&value.interface)?;
+
+        Ok(Self {
+            inner: mxl_sys::fabrics::FabricsInitiatorConfig {
+                version: value.version,
+                interface: *interface.as_ffi(),
+                // SAFETY: Both types are equivalent opaque reader handles from different bindgen modules.
+                reader: value.flow_reader.inner().cast(),
+            },
+            _interface: interface,
+        })
+    }
+
+    pub(crate) fn as_ffi(&self) -> &mxl_sys::fabrics::FabricsInitiatorConfig {
+        &self.inner
     }
 }

--- a/rust/mxl/src/fabrics/initiator/config.rs
+++ b/rust/mxl/src/fabrics/initiator/config.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::{
     Error, FlowReader,
     fabrics::{config::EndpointAddress, provider::Provider},

--- a/rust/mxl/src/fabrics/initiator/config.rs
+++ b/rust/mxl/src/fabrics/initiator/config.rs
@@ -1,62 +1,33 @@
 // SPDX-FileCopyrightText: 2026 Contributors to the Media eXchange Layer project.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    Error, FlowReader,
-    fabrics::{InterfaceConfig, interface::config::OwnedInterfaceConfig},
-};
+use crate::{Error, FlowReader, fabrics::InterfaceConfig};
 
 /// Configuration object required to set up an initiator.
 pub struct Config<'a> {
     version: i32,
-    interface: InterfaceConfig<'a>,
+    interface: InterfaceConfig,
     pub(crate) flow_reader: &'a FlowReader,
 }
 
 impl<'a> Config<'a> {
-    pub fn new(interface: InterfaceConfig<'a>, flow_reader: &'a FlowReader) -> Self {
+    pub fn new(interface: InterfaceConfig, flow_reader: &'a FlowReader) -> Self {
         Self {
-            version: 0,
+            version: mxl_sys::fabrics::MXL_FABRICS_API_VERSION as i32,
             interface,
             flow_reader,
         }
     }
 }
-
 impl<'a> TryFrom<&Config<'a>> for mxl_sys::fabrics::FabricsInitiatorConfig {
     type Error = Error;
 
     fn try_from(value: &Config) -> Result<Self, Self::Error> {
         Ok(Self {
             version: value.version,
-            interface: *OwnedInterfaceConfig::try_from(&value.interface)?.as_ffi(),
+            interface: mxl_sys::fabrics::FabricsInterfaceConfig::try_from(&value.interface)?,
             // SAFETY: Both types are equivalent opaque reader handles from different bindgen modules.
             reader: value.flow_reader.inner().cast(),
         })
-    }
-}
-
-pub(crate) struct OwnedInitiatorConfig {
-    inner: mxl_sys::fabrics::FabricsInitiatorConfig,
-    _interface: OwnedInterfaceConfig,
-}
-
-impl OwnedInitiatorConfig {
-    pub(crate) fn new(value: &Config<'_>) -> Result<Self, Error> {
-        let interface = OwnedInterfaceConfig::new(&value.interface)?;
-
-        Ok(Self {
-            inner: mxl_sys::fabrics::FabricsInitiatorConfig {
-                version: value.version,
-                interface: *interface.as_ffi(),
-                // SAFETY: Both types are equivalent opaque reader handles from different bindgen modules.
-                reader: value.flow_reader.inner().cast(),
-            },
-            _interface: interface,
-        })
-    }
-
-    pub(crate) fn as_ffi(&self) -> &mxl_sys::fabrics::FabricsInitiatorConfig {
-        &self.inner
     }
 }

--- a/rust/mxl/src/fabrics/initiator/config.rs
+++ b/rust/mxl/src/fabrics/initiator/config.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{Error, FlowReader, fabrics::InterfaceConfig};
+use mxl_sys::types::{FabricsInitiatorConfig, FabricsInterfaceConfig, MXL_FABRICS_API_VERSION};
 
 /// Configuration object required to set up an initiator.
 pub struct Config<'a> {
@@ -13,21 +14,20 @@ pub struct Config<'a> {
 impl<'a> Config<'a> {
     pub fn new(interface: InterfaceConfig, flow_reader: &'a FlowReader) -> Self {
         Self {
-            version: mxl_sys::fabrics::MXL_FABRICS_API_VERSION as i32,
+            version: MXL_FABRICS_API_VERSION as i32,
             interface,
             flow_reader,
         }
     }
 }
-impl<'a> TryFrom<&Config<'a>> for mxl_sys::fabrics::FabricsInitiatorConfig {
+impl<'a> TryFrom<&Config<'a>> for FabricsInitiatorConfig {
     type Error = Error;
 
     fn try_from(value: &Config) -> Result<Self, Self::Error> {
         Ok(Self {
             version: value.version,
-            interface: mxl_sys::fabrics::FabricsInterfaceConfig::try_from(&value.interface)?,
-            // SAFETY: Both types are equivalent opaque reader handles from different bindgen modules.
-            reader: value.flow_reader.inner().cast(),
+            interface: FabricsInterfaceConfig::try_from(&value.interface)?,
+            reader: value.flow_reader.inner(),
         })
     }
 }

--- a/rust/mxl/src/fabrics/initiator/grain.rs
+++ b/rust/mxl/src/fabrics/initiator/grain.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::time::Duration;
 
 use crate::{

--- a/rust/mxl/src/fabrics/initiator/grain.rs
+++ b/rust/mxl/src/fabrics/initiator/grain.rs
@@ -1,0 +1,71 @@
+use std::time::Duration;
+
+use crate::{
+    Error, Result,
+    fabrics::{TargetInfo, initiator::Grain, initiator::Initiator},
+};
+
+impl Initiator<Grain> {
+    /// Add a target to the initiator. This will allow the initiator to send data to the target in subsequent calls to
+    /// mxlFabricsInitiatorTransferGrain(). This function is always non-blocking. If additional connection setup is required
+    /// by the underlying implementation, it will only happen during a call to make_progress*().
+    pub fn add_target(&self, target: &TargetInfo) -> Result<()> {
+        Error::from_status(unsafe {
+            self.instance
+                .ctx
+                .api()
+                .fabrics_initiator_add_target(self.instance.inner, target.inner)
+        })
+    }
+
+    /// Remove a target from the initiator. This function is always non-blocking. If any additional communication for a graceful shutdown is
+    /// required it will happend during a call to make_progress*(). It is guaranteed that no new grain transfer operations will
+    /// be queued for this target during calls to transfer() after the target was removed, but it is only guaranteed that
+    /// the connection shutdown has completed after make_progress*() no longer returns Error::NotReady.
+    pub fn remove_target(&self, target: &TargetInfo) -> Result<()> {
+        Error::from_status(unsafe {
+            self.instance
+                .ctx
+                .api()
+                .fabrics_initiator_remove_target(self.instance.inner, target.inner)
+        })
+    }
+
+    /// This function must be called regularly for the initiator to make progress on queued transfer operations, connection establishment
+    /// operations and connection shutdown operations.
+    pub fn make_progress_non_blocking(&self) -> Result<()> {
+        Error::from_status(unsafe {
+            self.instance
+                .ctx
+                .api()
+                .fabrics_initiator_make_progress_non_blocking(self.instance.inner)
+        })
+    }
+
+    /// This function must be called regularly for the initiator to make progress on queued transfer operations, connection establishment
+    /// operations and connection shutdown operations.
+    pub fn make_progress(&self, timeout: Duration) -> Result<()> {
+        Error::from_status(unsafe {
+            self.instance
+                .ctx
+                .api()
+                .fabrics_initiator_make_progress_blocking(
+                    self.instance.inner,
+                    timeout.as_millis() as u16,
+                )
+        })
+    }
+
+    /// Enqueue a transfer operation to all added targets. This function is always non-blocking. The transfer operation might be started right
+    /// away, but is only guaranteed to have completed after mxlFabricsInitiatorMakeProgress*() no longer returns Error::NotReady.
+    pub fn transfer(&self, grain_index: u64, start_slice: u16, end_slice: u16) -> Result<()> {
+        Error::from_status(unsafe {
+            self.instance.ctx.api().fabrics_initiator_transfer_grain(
+                self.instance.inner,
+                grain_index,
+                start_slice,
+                end_slice,
+            )
+        })
+    }
+}

--- a/rust/mxl/src/fabrics/initiator/grain.rs
+++ b/rust/mxl/src/fabrics/initiator/grain.rs
@@ -22,7 +22,7 @@ impl Initiator<Grain> {
     }
 
     /// Remove a target from the initiator. This function is always non-blocking. If any additional communication for a graceful shutdown is
-    /// required it will happend during a call to make_progress*(). It is guaranteed that no new grain transfer operations will
+    /// required it will happen during a call to make_progress*(). It is guaranteed that no new grain transfer operations will
     /// be queued for this target during calls to transfer() after the target was removed, but it is only guaranteed that
     /// the connection shutdown has completed after make_progress*() no longer returns Error::NotReady.
     pub fn remove_target(&self, target: &TargetInfo) -> Result<()> {

--- a/rust/mxl/src/fabrics/initiator/grain.rs
+++ b/rust/mxl/src/fabrics/initiator/grain.rs
@@ -54,7 +54,7 @@ impl Initiator<Grain> {
                 .api()
                 .fabrics_initiator_make_progress_blocking(
                     self.instance.inner,
-                    timeout.as_millis() as u16,
+                    u16::try_from(timeout.as_millis()).map_err(|_| Error::InvalidArg)?,
                 )
         })
     }

--- a/rust/mxl/src/fabrics/initiator/grain.rs
+++ b/rust/mxl/src/fabrics/initiator/grain.rs
@@ -1,64 +1,12 @@
 // SPDX-FileCopyrightText: 2026 Contributors to the Media eXchange Layer project.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::time::Duration;
-
 use crate::{
     Error, Result,
-    fabrics::{TargetInfo, initiator::Grain, initiator::Initiator},
+    fabrics::{initiator::Grain, initiator::Initiator},
 };
 
 impl Initiator<Grain> {
-    /// Add a target to the initiator. This will allow the initiator to send data to the target in subsequent calls to
-    /// mxlFabricsInitiatorTransferGrain(). This function is always non-blocking. If additional connection setup is required
-    /// by the underlying implementation, it will only happen during a call to make_progress*().
-    pub fn add_target(&self, target: &TargetInfo) -> Result<()> {
-        Error::from_status(unsafe {
-            self.instance
-                .ctx
-                .api()
-                .fabrics_initiator_add_target(self.instance.inner, target.inner)
-        })
-    }
-
-    /// Remove a target from the initiator. This function is always non-blocking. If any additional communication for a graceful shutdown is
-    /// required it will happen during a call to make_progress*(). It is guaranteed that no new grain transfer operations will
-    /// be queued for this target during calls to transfer() after the target was removed, but it is only guaranteed that
-    /// the connection shutdown has completed after make_progress*() no longer returns Error::NotReady.
-    pub fn remove_target(&self, target: &TargetInfo) -> Result<()> {
-        Error::from_status(unsafe {
-            self.instance
-                .ctx
-                .api()
-                .fabrics_initiator_remove_target(self.instance.inner, target.inner)
-        })
-    }
-
-    /// This function must be called regularly for the initiator to make progress on queued transfer operations, connection establishment
-    /// operations and connection shutdown operations.
-    pub fn make_progress_non_blocking(&self) -> Result<()> {
-        Error::from_status(unsafe {
-            self.instance
-                .ctx
-                .api()
-                .fabrics_initiator_make_progress_non_blocking(self.instance.inner)
-        })
-    }
-
-    /// This function must be called regularly for the initiator to make progress on queued transfer operations, connection establishment
-    /// operations and connection shutdown operations.
-    pub fn make_progress(&self, timeout: Duration) -> Result<()> {
-        Error::from_status(unsafe {
-            self.instance
-                .ctx
-                .api()
-                .fabrics_initiator_make_progress_blocking(
-                    self.instance.inner,
-                    u16::try_from(timeout.as_millis()).map_err(|_| Error::InvalidArg)?,
-                )
-        })
-    }
-
     /// Enqueue a transfer operation to all added targets. This function is always non-blocking. The transfer operation might be started right
     /// away, but is only guaranteed to have completed after mxlFabricsInitiatorMakeProgress*() no longer returns Error::NotReady.
     pub fn transfer(&self, grain_index: u64, start_slice: u16, end_slice: u16) -> Result<()> {

--- a/rust/mxl/src/fabrics/initiator/mod.rs
+++ b/rust/mxl/src/fabrics/initiator/mod.rs
@@ -1,0 +1,140 @@
+mod config;
+mod grain;
+mod samples;
+
+use crate::{
+    FlowConfigInfo,
+    error::{Error, Result},
+    fabrics::instance::FabricsInstanceContext,
+};
+
+pub use config::Config;
+
+use std::{marker::PhantomData, rc::Rc};
+
+use states::*;
+
+pub mod states {
+    /// Used to create a new initiator
+    pub struct New {}
+
+    /// Waiting for the initiator to be initialized with the setup function
+    pub struct Initializing {}
+
+    /// The setup function has been called, but the initiator has not yet been specialized into a
+    /// grain or samples initiator
+    pub struct Specializing {}
+
+    /// The initiator has been specialized into a grain initiator. It can only transfer grains to
+    /// targets.
+    pub struct Grain {}
+
+    /// The initiator has been specialized into a samples initiator. It can only transfer samples to
+    pub struct Samples {}
+
+    impl InitiatorState for New {}
+    impl InitiatorState for Initializing {}
+    impl InitiatorState for Specializing {}
+    impl InitiatorState for Grain {}
+    impl InitiatorState for Samples {}
+
+    pub trait InitiatorState {}
+}
+
+/// Wrapper class that holds a reference count to the Fabrics Instance and the actual initiator instance.
+struct InitiatorInstance {
+    ctx: Rc<FabricsInstanceContext>,
+    inner: mxl_sys::fabrics::FabricsInitiator,
+}
+impl Drop for InitiatorInstance {
+    fn drop(&mut self) {
+        if !self.inner.is_null() {
+            unsafe {
+                self.ctx
+                    .api()
+                    .fabrics_destroy_initiator(self.ctx.inner, self.inner);
+            }
+        }
+    }
+}
+
+pub struct Initiator<S: InitiatorState> {
+    instance: InitiatorInstance,
+    _marker: std::marker::PhantomData<S>,
+}
+
+pub enum Either {
+    Grain(Initiator<Grain>),
+    Samples(Initiator<Samples>),
+}
+
+impl Initiator<New> {
+    /// Create a new initiator
+    pub(crate) fn new(
+        ctx: Rc<FabricsInstanceContext>,
+        initiator: mxl_sys::fabrics::FabricsInitiator,
+    ) -> Initiator<Initializing> {
+        let instance = InitiatorInstance {
+            ctx,
+            inner: initiator,
+        };
+        Initiator {
+            instance,
+            _marker: std::marker::PhantomData,
+        }
+    }
+}
+
+impl Initiator<Initializing> {
+    ///  Configure the initiator.
+    pub fn setup(self, config: &Config) -> Result<Initiator<Specializing>> {
+        Error::from_status(unsafe {
+            self.instance.ctx.api().fabrics_initiator_setup(
+                self.instance.inner,
+                &config.try_into()?,
+                std::ptr::null(), // Unused for now
+            )
+        })?;
+        Ok(Initiator {
+            instance: self.instance,
+            _marker: PhantomData,
+        })
+    }
+}
+
+impl Initiator<Specializing> {
+    /// Specialize the initator into a concrete grain or samples initator
+    pub fn specialize(self, flow_config: &FlowConfigInfo) -> Either {
+        if flow_config.is_discrete_flow() {
+            Either::Grain(Initiator {
+                instance: self.instance,
+                _marker: PhantomData,
+            })
+        } else {
+            Either::Samples(Initiator {
+                instance: self.instance,
+                _marker: PhantomData,
+            })
+        }
+    }
+}
+
+/// Create a new initiator
+#[doc(hidden)]
+pub(crate) fn create_initiator(
+    ctx: &Rc<FabricsInstanceContext>,
+) -> Result<Initiator<Initializing>> {
+    let mut initiator = mxl_sys::fabrics::FabricsInitiator::default();
+    unsafe {
+        Error::from_status(
+            ctx.api()
+                .fabrics_create_initiator(ctx.inner, &mut initiator),
+        )?;
+    }
+    if initiator.is_null() {
+        return Err(Error::Other(
+            "Failed to create fabrics initiator.".to_string(),
+        ));
+    }
+    Ok(Initiator::new(ctx.clone(), initiator))
+}

--- a/rust/mxl/src/fabrics/initiator/mod.rs
+++ b/rust/mxl/src/fabrics/initiator/mod.rs
@@ -129,7 +129,7 @@ pub(crate) fn create_initiator(
         Error::from_status(
             ctx.api()
                 .fabrics_create_initiator(ctx.inner, &mut initiator),
-        )?;
+        )?
     }
     if initiator.is_null() {
         return Err(Error::Other(

--- a/rust/mxl/src/fabrics/initiator/mod.rs
+++ b/rust/mxl/src/fabrics/initiator/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: Apache-2.0
+
 mod config;
 mod grain;
 mod samples;

--- a/rust/mxl/src/fabrics/initiator/mod.rs
+++ b/rust/mxl/src/fabrics/initiator/mod.rs
@@ -8,7 +8,7 @@ mod samples;
 use crate::{
     FlowConfigInfo,
     error::{Error, Result},
-    fabrics::instance::FabricsInstanceContext,
+    fabrics::{initiator::config::OwnedInitiatorConfig, instance::FabricsInstanceContext},
 };
 
 pub use config::Config;
@@ -95,10 +95,11 @@ impl Initiator<New> {
 impl Initiator<Initializing> {
     ///  Configure the initiator.
     pub fn setup(self, config: &Config) -> Result<Initiator<Specializing>> {
+        let config = OwnedInitiatorConfig::new(config)?;
         Error::from_status(unsafe {
             self.instance.ctx.api().fabrics_initiator_setup(
                 self.instance.inner,
-                &config.try_into()?,
+                config.as_ffi(),
                 std::ptr::null(), // Unused for now
             )
         })?;

--- a/rust/mxl/src/fabrics/initiator/mod.rs
+++ b/rust/mxl/src/fabrics/initiator/mod.rs
@@ -10,7 +10,7 @@ use crate::{
 
 pub use config::Config;
 
-use std::{marker::PhantomData, rc::Rc};
+use std::{marker::PhantomData, sync::Arc};
 
 use states::*;
 
@@ -43,9 +43,11 @@ pub mod states {
 
 /// Wrapper class that holds a reference count to the Fabrics Instance and the actual initiator instance.
 struct InitiatorInstance {
-    ctx: Rc<FabricsInstanceContext>,
+    ctx: Arc<FabricsInstanceContext>,
     inner: mxl_sys::fabrics::FabricsInitiator,
 }
+unsafe impl Send for InitiatorInstance {}
+
 impl Drop for InitiatorInstance {
     fn drop(&mut self) {
         if !self.inner.is_null() {
@@ -62,6 +64,8 @@ pub struct Initiator<S: InitiatorState> {
     instance: InitiatorInstance,
     _marker: std::marker::PhantomData<S>,
 }
+//SAFETY: An initiator is safe to be sent across threads, but it's not thread-safe to use its API functions.
+unsafe impl<S: InitiatorState> Send for Initiator<S> {}
 
 pub enum Either {
     Grain(Initiator<Grain>),
@@ -71,7 +75,7 @@ pub enum Either {
 impl Initiator<New> {
     /// Create a new initiator
     pub(crate) fn new(
-        ctx: Rc<FabricsInstanceContext>,
+        ctx: Arc<FabricsInstanceContext>,
         initiator: mxl_sys::fabrics::FabricsInitiator,
     ) -> Initiator<Initializing> {
         let instance = InitiatorInstance {
@@ -122,7 +126,7 @@ impl Initiator<Specializing> {
 /// Create a new initiator
 #[doc(hidden)]
 pub(crate) fn create_initiator(
-    ctx: &Rc<FabricsInstanceContext>,
+    ctx: Arc<FabricsInstanceContext>,
 ) -> Result<Initiator<Initializing>> {
     let mut initiator = mxl_sys::fabrics::FabricsInitiator::default();
     unsafe {

--- a/rust/mxl/src/fabrics/initiator/mod.rs
+++ b/rust/mxl/src/fabrics/initiator/mod.rs
@@ -7,13 +7,13 @@ mod samples;
 
 use crate::{
     error::{Error, Result},
-    fabrics::instance::FabricsInstanceContext,
+    fabrics::{TargetInfo, instance::FabricsInstanceContext},
 };
 
 pub use config::Config;
 use mxl_sys::types::{FabricsInitiator, FabricsInitiatorConfig};
 
-use std::{marker::PhantomData, sync::Arc};
+use std::{marker::PhantomData, sync::Arc, time::Duration};
 
 use states::*;
 
@@ -36,7 +36,14 @@ pub mod states {
     impl InitiatorState for Grain {}
     impl InitiatorState for Samples {}
 
+    /// State of the initiator. This is used to ensure that the initiator is in a valid state before calling certain functions.
     pub trait InitiatorState {}
+
+    /// In this state, the initiator can add/remove targets and make progress.
+    pub trait InitiatorOperational: InitiatorState {}
+
+    impl InitiatorOperational for Grain {}
+    impl InitiatorOperational for Samples {}
 }
 
 /// Wrapper class that holds a reference count to the Fabrics Instance and the actual initiator instance.
@@ -112,6 +119,58 @@ impl Initiator<Initializing> {
                 _marker: PhantomData,
             }))
         }
+    }
+}
+
+impl<S: InitiatorOperational> Initiator<S> {
+    /// Add a target to the initiator. This will allow the initiator to send data to the target in subsequent calls.
+    /// This function is always non-blocking. If additional connection setup is required
+    /// by the underlying implementation, it will only happen during a call to make_progress*().
+    pub fn add_target(&self, target: &TargetInfo) -> Result<()> {
+        Error::from_status(unsafe {
+            self.instance
+                .ctx
+                .api()
+                .fabrics_initiator_add_target(self.instance.inner, target.inner)
+        })
+    }
+
+    /// Remove a target from the initiator. This function is always non-blocking. If any additional communication for a graceful shutdown is
+    /// required it will happen during a call to make_progress*(). It is guaranteed that no new grain/samples transfer operations will
+    /// be queued for this target during calls to transfer() after the target was removed, but it is only guaranteed that
+    /// the connection shutdown has completed after make_progress*() no longer returns Error::NotReady.
+    pub fn remove_target(&self, target: &TargetInfo) -> Result<()> {
+        Error::from_status(unsafe {
+            self.instance
+                .ctx
+                .api()
+                .fabrics_initiator_remove_target(self.instance.inner, target.inner)
+        })
+    }
+
+    /// This function must be called regularly for the initiator to make progress on queued transfer operations, connection establishment
+    /// operations and connection shutdown operations.
+    pub fn make_progress_non_blocking(&self) -> Result<()> {
+        Error::from_status(unsafe {
+            self.instance
+                .ctx
+                .api()
+                .fabrics_initiator_make_progress_non_blocking(self.instance.inner)
+        })
+    }
+
+    /// This function must be called regularly for the initiator to make progress on queued transfer operations, connection establishment
+    /// operations and connection shutdown operations.
+    pub fn make_progress(&self, timeout: Duration) -> Result<()> {
+        Error::from_status(unsafe {
+            self.instance
+                .ctx
+                .api()
+                .fabrics_initiator_make_progress_blocking(
+                    self.instance.inner,
+                    u16::try_from(timeout.as_millis()).map_err(|_| Error::InvalidArg)?,
+                )
+        })
     }
 }
 

--- a/rust/mxl/src/fabrics/initiator/mod.rs
+++ b/rust/mxl/src/fabrics/initiator/mod.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 
 pub use config::Config;
-use mxl_sys::fabrics::FabricsInitiatorConfig;
+use mxl_sys::types::{FabricsInitiator, FabricsInitiatorConfig};
 
 use std::{marker::PhantomData, sync::Arc};
 
@@ -42,7 +42,7 @@ pub mod states {
 /// Wrapper class that holds a reference count to the Fabrics Instance and the actual initiator instance.
 struct InitiatorInstance {
     ctx: Arc<FabricsInstanceContext>,
-    inner: mxl_sys::fabrics::FabricsInitiator,
+    inner: FabricsInitiator,
 }
 unsafe impl Send for InitiatorInstance {}
 
@@ -74,7 +74,7 @@ impl Initiator<New> {
     /// Create a new initiator
     pub(crate) fn new(
         ctx: Arc<FabricsInstanceContext>,
-        initiator: mxl_sys::fabrics::FabricsInitiator,
+        initiator: FabricsInitiator,
     ) -> Initiator<Initializing> {
         let instance = InitiatorInstance {
             ctx,
@@ -120,7 +120,7 @@ impl Initiator<Initializing> {
 pub(crate) fn create_initiator(
     ctx: Arc<FabricsInstanceContext>,
 ) -> Result<Initiator<Initializing>> {
-    let mut initiator = mxl_sys::fabrics::FabricsInitiator::default();
+    let mut initiator = FabricsInitiator::default();
     unsafe {
         Error::from_status(
             ctx.api()

--- a/rust/mxl/src/fabrics/initiator/mod.rs
+++ b/rust/mxl/src/fabrics/initiator/mod.rs
@@ -6,12 +6,12 @@ mod grain;
 mod samples;
 
 use crate::{
-    FlowConfigInfo,
     error::{Error, Result},
-    fabrics::{initiator::config::OwnedInitiatorConfig, instance::FabricsInstanceContext},
+    fabrics::instance::FabricsInstanceContext,
 };
 
 pub use config::Config;
+use mxl_sys::fabrics::FabricsInitiatorConfig;
 
 use std::{marker::PhantomData, sync::Arc};
 
@@ -24,10 +24,6 @@ pub mod states {
     /// Waiting for the initiator to be initialized with the setup function
     pub struct Initializing {}
 
-    /// The setup function has been called, but the initiator has not yet been specialized into a
-    /// grain or samples initiator
-    pub struct Specializing {}
-
     /// The initiator has been specialized into a grain initiator. It can only transfer grains to
     /// targets.
     pub struct Grain {}
@@ -37,7 +33,6 @@ pub mod states {
 
     impl InitiatorState for New {}
     impl InitiatorState for Initializing {}
-    impl InitiatorState for Specializing {}
     impl InitiatorState for Grain {}
     impl InitiatorState for Samples {}
 
@@ -70,7 +65,7 @@ pub struct Initiator<S: InitiatorState> {
 //SAFETY: An initiator is safe to be sent across threads, but it's not thread-safe to use its API functions.
 unsafe impl<S: InitiatorState> Send for Initiator<S> {}
 
-pub enum Either {
+pub enum InitiatorFlavor {
     Grain(Initiator<Grain>),
     Samples(Initiator<Samples>),
 }
@@ -94,35 +89,28 @@ impl Initiator<New> {
 
 impl Initiator<Initializing> {
     ///  Configure the initiator.
-    pub fn setup(self, config: &Config) -> Result<Initiator<Specializing>> {
-        let config = OwnedInitiatorConfig::new(config)?;
+    pub fn setup(self, config: &Config) -> Result<InitiatorFlavor> {
+        let initiator_config = FabricsInitiatorConfig::try_from(config)?;
         Error::from_status(unsafe {
             self.instance.ctx.api().fabrics_initiator_setup(
                 self.instance.inner,
-                config.as_ffi(),
+                // Pointer does not need to outlive the call, so we can safely pass a pointer to the stack variable.
+                &initiator_config as *const _,
                 std::ptr::null(), // Unused for now
             )
         })?;
-        Ok(Initiator {
-            instance: self.instance,
-            _marker: PhantomData,
-        })
-    }
-}
 
-impl Initiator<Specializing> {
-    /// Specialize the initator into a concrete grain or samples initator
-    pub fn specialize(self, flow_config: &FlowConfigInfo) -> Either {
-        if flow_config.is_discrete_flow() {
-            Either::Grain(Initiator {
+        let flow_info = config.flow_reader.get_info()?;
+        if flow_info.config.is_discrete_flow() {
+            Ok(InitiatorFlavor::Grain(Initiator {
                 instance: self.instance,
                 _marker: PhantomData,
-            })
+            }))
         } else {
-            Either::Samples(Initiator {
+            Ok(InitiatorFlavor::Samples(Initiator {
                 instance: self.instance,
                 _marker: PhantomData,
-            })
+            }))
         }
     }
 }

--- a/rust/mxl/src/fabrics/initiator/samples.rs
+++ b/rust/mxl/src/fabrics/initiator/samples.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::time::Duration;
 
 use crate::{

--- a/rust/mxl/src/fabrics/initiator/samples.rs
+++ b/rust/mxl/src/fabrics/initiator/samples.rs
@@ -1,0 +1,70 @@
+use std::time::Duration;
+
+use crate::{
+    Error, Result,
+    fabrics::{TargetInfo, initiator::Initiator, initiator::Samples},
+};
+
+impl Initiator<Samples> {
+    /// Add a target to the initiator. This will allow the initiator to send data to the target in subsequent calls to
+    /// mxlFabricsInitiatorTransferGrain(). This function is always non-blocking. If additional connection setup is required
+    /// by the underlying implementation, it will only happen during a call to make_progress*().
+    pub fn add_target(&self, target: &TargetInfo) -> Result<()> {
+        Error::from_status(unsafe {
+            self.instance
+                .ctx
+                .api()
+                .fabrics_initiator_add_target(self.instance.inner, target.inner)
+        })
+    }
+
+    /// Remove a target from the initiator. This function is always non-blocking. If any additional communication for a graceful shutdown is
+    /// required it will happend during a call to make_progress*(). It is guaranteed that no new grain transfer operations will
+    /// be queued for this target during calls to transfer() after the target was removed, but it is only guaranteed that
+    /// the connection shutdown has completed after make_progress*() no longer returns Error::NotReady.
+    pub fn remove_target(&self, target: &TargetInfo) -> Result<()> {
+        Error::from_status(unsafe {
+            self.instance
+                .ctx
+                .api()
+                .fabrics_initiator_remove_target(self.instance.inner, target.inner)
+        })
+    }
+
+    /// This function must be called regularly for the initiator to make progress on queued transfer operations, connection establishment
+    /// operations and connection shutdown operations.
+    pub fn make_progress_non_blocking(&self) -> Result<()> {
+        Error::from_status(unsafe {
+            self.instance
+                .ctx
+                .api()
+                .fabrics_initiator_make_progress_non_blocking(self.instance.inner)
+        })
+    }
+
+    /// This function must be called regularly for the initiator to make progress on queued transfer operations, connection establishment
+    /// operations and connection shutdown operations.
+    pub fn make_progress(&self, timeout: Duration) -> Result<()> {
+        Error::from_status(unsafe {
+            self.instance
+                .ctx
+                .api()
+                .fabrics_initiator_make_progress_blocking(
+                    self.instance.inner,
+                    timeout.as_millis() as u16,
+                )
+        })
+    }
+
+    /// Enqueue a transfer operation to all added targets. This function is always non-blocking. The transfer operation might be started right
+    /// away, but is only guaranteed to have completed after mxlFabricsInitiatorMakeProgress*() no longer returns Error::NotReady.
+    pub fn transfer(&self, head_index: u64, count: usize) -> Result<()> {
+        Error::from_status(unsafe {
+            self.instance.ctx.api().fabrics_initiator_transfer_samples(
+                self.instance.inner,
+                head_index,
+                count,
+            )
+        })
+    }
+}

--- a/rust/mxl/src/fabrics/initiator/samples.rs
+++ b/rust/mxl/src/fabrics/initiator/samples.rs
@@ -1,64 +1,12 @@
 // SPDX-FileCopyrightText: 2026 Contributors to the Media eXchange Layer project.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::time::Duration;
-
 use crate::{
     Error, Result,
-    fabrics::{TargetInfo, initiator::Initiator, initiator::Samples},
+    fabrics::{initiator::Initiator, initiator::Samples},
 };
 
 impl Initiator<Samples> {
-    /// Add a target to the initiator. This will allow the initiator to send data to the target in subsequent calls to
-    /// mxlFabricsInitiatorTransferSamples(). This function is always non-blocking. If additional connection setup is required
-    /// by the underlying implementation, it will only happen during a call to make_progress*().
-    pub fn add_target(&self, target: &TargetInfo) -> Result<()> {
-        Error::from_status(unsafe {
-            self.instance
-                .ctx
-                .api()
-                .fabrics_initiator_add_target(self.instance.inner, target.inner)
-        })
-    }
-
-    /// Remove a target from the initiator. This function is always non-blocking. If any additional communication for a graceful shutdown is
-    /// required it will happend during a call to make_progress*(). It is guaranteed that no new sample transfer operations will
-    /// be queued for this target during calls to transfer() after the target was removed, but it is only guaranteed that
-    /// the connection shutdown has completed after make_progress*() no longer returns Error::NotReady.
-    pub fn remove_target(&self, target: &TargetInfo) -> Result<()> {
-        Error::from_status(unsafe {
-            self.instance
-                .ctx
-                .api()
-                .fabrics_initiator_remove_target(self.instance.inner, target.inner)
-        })
-    }
-
-    /// This function must be called regularly for the initiator to make progress on queued transfer operations, connection establishment
-    /// operations and connection shutdown operations.
-    pub fn make_progress_non_blocking(&self) -> Result<()> {
-        Error::from_status(unsafe {
-            self.instance
-                .ctx
-                .api()
-                .fabrics_initiator_make_progress_non_blocking(self.instance.inner)
-        })
-    }
-
-    /// This function must be called regularly for the initiator to make progress on queued transfer operations, connection establishment
-    /// operations and connection shutdown operations.
-    pub fn make_progress(&self, timeout: Duration) -> Result<()> {
-        Error::from_status(unsafe {
-            self.instance
-                .ctx
-                .api()
-                .fabrics_initiator_make_progress_blocking(
-                    self.instance.inner,
-                    timeout.as_millis() as u16,
-                )
-        })
-    }
-
     /// Enqueue a transfer operation to all added targets. This function is always non-blocking. The transfer operation might be started right
     /// away, but is only guaranteed to have completed after mxlFabricsInitiatorMakeProgress*() no longer returns Error::NotReady.
     pub fn transfer(&self, head_index: u64, count: usize) -> Result<()> {

--- a/rust/mxl/src/fabrics/initiator/samples.rs
+++ b/rust/mxl/src/fabrics/initiator/samples.rs
@@ -10,7 +10,7 @@ use crate::{
 
 impl Initiator<Samples> {
     /// Add a target to the initiator. This will allow the initiator to send data to the target in subsequent calls to
-    /// mxlFabricsInitiatorTransferGrain(). This function is always non-blocking. If additional connection setup is required
+    /// mxlFabricsInitiatorTransferSamples(). This function is always non-blocking. If additional connection setup is required
     /// by the underlying implementation, it will only happen during a call to make_progress*().
     pub fn add_target(&self, target: &TargetInfo) -> Result<()> {
         Error::from_status(unsafe {
@@ -22,7 +22,7 @@ impl Initiator<Samples> {
     }
 
     /// Remove a target from the initiator. This function is always non-blocking. If any additional communication for a graceful shutdown is
-    /// required it will happend during a call to make_progress*(). It is guaranteed that no new grain transfer operations will
+    /// required it will happend during a call to make_progress*(). It is guaranteed that no new sample transfer operations will
     /// be queued for this target during calls to transfer() after the target was removed, but it is only guaranteed that
     /// the connection shutdown has completed after make_progress*() no longer returns Error::NotReady.
     pub fn remove_target(&self, target: &TargetInfo) -> Result<()> {

--- a/rust/mxl/src/fabrics/instance.rs
+++ b/rust/mxl/src/fabrics/instance.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::sync::Arc;
 
 use crate::{

--- a/rust/mxl/src/fabrics/instance.rs
+++ b/rust/mxl/src/fabrics/instance.rs
@@ -1,4 +1,3 @@
-use std::rc::Rc;
 use std::sync::Arc;
 
 use crate::{
@@ -14,7 +13,7 @@ use crate::{
 };
 
 pub(crate) fn create_instance(
-    ctx: &Arc<InstanceContext>,
+    ctx: Arc<InstanceContext>,
     fabrics_api: &MxlFabricsAPiHandle,
 ) -> Result<FabricsInstance> {
     let mut inst = std::ptr::null_mut();
@@ -33,7 +32,9 @@ pub(crate) fn create_instance(
         ));
     }
 
-    let ctx = Rc::new(FabricsInstanceContext {
+    #[allow(clippy::arc_with_non_send_sync)]
+    // This is intentional, this Arc<T> only implement Send, because fabric API as a whole is not thread-safe to use.
+    let ctx = Arc::new(FabricsInstanceContext {
         _parent_ctx: ctx.clone(),
         api: fabrics_api.clone(),
         inner: inst,
@@ -47,6 +48,7 @@ pub(crate) struct FabricsInstanceContext {
     api: MxlFabricsAPiHandle,
     pub(crate) inner: mxl_sys::fabrics::FabricsInstance,
 }
+unsafe impl Send for FabricsInstanceContext {}
 
 impl FabricsInstanceContext {
     pub(crate) fn api(&self) -> &MxlFabricsAPiHandle {
@@ -68,21 +70,25 @@ impl Drop for FabricsInstanceContext {
 /// The fabrics instance and its pointer are held in the `FabricsInstanceContext`` object.
 /// This is created via an [MxlInstance](crate::MxlInstance).
 pub struct FabricsInstance {
-    ctx: Rc<FabricsInstanceContext>,
+    /// The fabric API is not-thread safe (Sync).
+    ctx: Arc<FabricsInstanceContext>,
 }
+/// SAFETY: FabricsInstance is safe to send to another thread, but fabric API as a whole is not thread-safe
+unsafe impl Send for FabricsInstance {}
+
 impl FabricsInstance {
-    fn new(ctx: Rc<FabricsInstanceContext>) -> Self {
+    fn new(ctx: Arc<FabricsInstanceContext>) -> Self {
         Self { ctx }
     }
 
     /// Create a fabrics target. The target is the receiver of write operations from an initiator.
     pub fn create_target(&self) -> Result<Target<target::states::Initializing>> {
-        create_target(&self.ctx)
+        create_target(self.ctx.clone())
     }
 
     /// Create a fabrics initiator instance.
     pub fn create_initiator(&self) -> Result<Initiator<initiator::states::Initializing>> {
-        create_initiator(&self.ctx)
+        create_initiator(self.ctx.clone())
     }
 
     pub fn provider_from_str(&self, provider: &str) -> Result<Provider> {

--- a/rust/mxl/src/fabrics/instance.rs
+++ b/rust/mxl/src/fabrics/instance.rs
@@ -24,9 +24,8 @@ pub(crate) fn create_instance(
     let mut inst = std::ptr::null_mut();
     Error::from_status(unsafe {
         fabrics_api.fabrics_create_instance(
-            std::mem::transmute::<*mut mxl_sys::Instance_t, *mut mxl_sys::fabrics::Instance_t>(
-                ctx.instance,
-            ),
+            //SAFETY: Both types are equivalent opaque handles from different bindgen modules.
+            ctx.instance.cast(),
             std::ptr::null(), // Unused for now
             &mut inst,
         )

--- a/rust/mxl/src/fabrics/instance.rs
+++ b/rust/mxl/src/fabrics/instance.rs
@@ -1,0 +1,95 @@
+use std::rc::Rc;
+use std::sync::Arc;
+
+use crate::{
+    api::MxlFabricsAPiHandle,
+    error::{Error, Result},
+    fabrics::{
+        initiator::{self, Initiator, create_initiator},
+        provider::Provider,
+        target::{self, Target, create_target},
+        target_info::TargetInfo,
+    },
+    instance::InstanceContext,
+};
+
+pub(crate) fn create_instance(
+    ctx: &Arc<InstanceContext>,
+    fabrics_api: &MxlFabricsAPiHandle,
+) -> Result<FabricsInstance> {
+    let mut inst = std::ptr::null_mut();
+    unsafe {
+        Error::from_status(fabrics_api.fabrics_create_instance(
+            std::mem::transmute::<*mut mxl_sys::Instance_t, *mut mxl_sys::fabrics::Instance_t>(
+                ctx.instance,
+            ),
+            std::ptr::null(), // Unused for now
+            &mut inst,
+        ))?;
+    }
+    if inst.is_null() {
+        return Err(Error::Other(
+            "Failed to create fabrics instance.".to_string(),
+        ));
+    }
+
+    let ctx = Rc::new(FabricsInstanceContext {
+        _parent_ctx: ctx.clone(),
+        api: fabrics_api.clone(),
+        inner: inst,
+    });
+
+    Ok(FabricsInstance::new(ctx))
+}
+
+pub(crate) struct FabricsInstanceContext {
+    _parent_ctx: Arc<InstanceContext>,
+    api: MxlFabricsAPiHandle,
+    pub(crate) inner: mxl_sys::fabrics::FabricsInstance,
+}
+
+impl FabricsInstanceContext {
+    pub(crate) fn api(&self) -> &MxlFabricsAPiHandle {
+        &self.api
+    }
+}
+
+impl Drop for FabricsInstanceContext {
+    fn drop(&mut self) {
+        if !self.inner.is_null() {
+            unsafe {
+                let _ = self.api.fabrics_destroy_instance(self.inner);
+            }
+        }
+    }
+}
+
+/// This is just a factory type for creating Fabrics related objects such as Targets, Initiators, etc.
+/// The fabrics instance and its pointer are held in the `FabricsInstanceContext`` object.
+/// This is created via an [MxlInstance](crate::MxlInstance).
+pub struct FabricsInstance {
+    ctx: Rc<FabricsInstanceContext>,
+}
+impl FabricsInstance {
+    fn new(ctx: Rc<FabricsInstanceContext>) -> Self {
+        Self { ctx }
+    }
+
+    /// Create a fabrics target. The target is the receiver of write operations from an initiator.
+    pub fn create_target(&self) -> Result<Target<target::states::Initializing>> {
+        create_target(&self.ctx)
+    }
+
+    /// Create a fabrics initiator instance.
+    pub fn create_initiator(&self) -> Result<Initiator<initiator::states::Initializing>> {
+        create_initiator(&self.ctx)
+    }
+
+    pub fn provider_from_str(&self, provider: &str) -> Result<Provider> {
+        Provider::from_str(self.ctx.clone(), provider)
+    }
+
+    pub fn target_info_from_str(&self, target_info: &str) -> Result<TargetInfo> {
+        TargetInfo::from_str(self.ctx.clone(), target_info)
+    }
+}

--- a/rust/mxl/src/fabrics/instance.rs
+++ b/rust/mxl/src/fabrics/instance.rs
@@ -7,7 +7,9 @@ use crate::{
     api::MxlFabricsAPiHandle,
     error::{Error, Result},
     fabrics::{
+        InterfaceConfig,
         initiator::{self, Initiator, create_initiator},
+        interface::Interfaces,
         provider::Provider,
         target::{self, Target, create_target},
         target_info::TargetInfo,
@@ -100,5 +102,9 @@ impl FabricsInstance {
 
     pub fn target_info_from_str(&self, target_info: &str) -> Result<TargetInfo> {
         TargetInfo::from_str(self.ctx.clone(), target_info)
+    }
+
+    pub fn get_interfaces(&self, query: Option<InterfaceConfig>) -> Result<Interfaces> {
+        Interfaces::get(self.ctx.clone(), query)
     }
 }

--- a/rust/mxl/src/fabrics/instance.rs
+++ b/rust/mxl/src/fabrics/instance.rs
@@ -22,15 +22,15 @@ pub(crate) fn create_instance(
     fabrics_api: &MxlFabricsAPiHandle,
 ) -> Result<FabricsInstance> {
     let mut inst = std::ptr::null_mut();
-    unsafe {
-        Error::from_status(fabrics_api.fabrics_create_instance(
+    Error::from_status(unsafe {
+        fabrics_api.fabrics_create_instance(
             std::mem::transmute::<*mut mxl_sys::Instance_t, *mut mxl_sys::fabrics::Instance_t>(
                 ctx.instance,
             ),
             std::ptr::null(), // Unused for now
             &mut inst,
-        ))?;
-    }
+        )
+    })?;
     if inst.is_null() {
         return Err(Error::Other(
             "Failed to create fabrics instance.".to_string(),

--- a/rust/mxl/src/fabrics/instance.rs
+++ b/rust/mxl/src/fabrics/instance.rs
@@ -4,7 +4,7 @@
 use std::sync::Arc;
 
 use crate::{
-    api::MxlFabricsAPiHandle,
+    api::MxlFabricsApiHandle,
     error::{Error, Result},
     fabrics::{
         InterfaceConfig,
@@ -19,7 +19,7 @@ use crate::{
 
 pub(crate) fn create_instance(
     ctx: Arc<InstanceContext>,
-    fabrics_api: &MxlFabricsAPiHandle,
+    fabrics_api: &MxlFabricsApiHandle,
 ) -> Result<FabricsInstance> {
     let mut inst = std::ptr::null_mut();
     Error::from_status(unsafe {
@@ -49,13 +49,13 @@ pub(crate) fn create_instance(
 
 pub(crate) struct FabricsInstanceContext {
     _parent_ctx: Arc<InstanceContext>,
-    api: MxlFabricsAPiHandle,
+    api: MxlFabricsApiHandle,
     pub(crate) inner: mxl_sys::fabrics::FabricsInstance,
 }
 unsafe impl Send for FabricsInstanceContext {}
 
 impl FabricsInstanceContext {
-    pub(crate) fn api(&self) -> &MxlFabricsAPiHandle {
+    pub(crate) fn api(&self) -> &MxlFabricsApiHandle {
         &self.api
     }
 }

--- a/rust/mxl/src/fabrics/instance.rs
+++ b/rust/mxl/src/fabrics/instance.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Contributors to the Media eXchange Layer project.
 // SPDX-License-Identifier: Apache-2.0
 
+use mxl_sys::types::FabricsInstance as FabricsInstanceHandle;
 use std::sync::Arc;
 
 use crate::{
@@ -24,8 +25,7 @@ pub(crate) fn create_instance(
     let mut inst = std::ptr::null_mut();
     Error::from_status(unsafe {
         fabrics_api.fabrics_create_instance(
-            //SAFETY: Both types are equivalent opaque handles from different bindgen modules.
-            ctx.instance.cast(),
+            ctx.instance,
             std::ptr::null(), // Unused for now
             &mut inst,
         )
@@ -50,7 +50,7 @@ pub(crate) fn create_instance(
 pub(crate) struct FabricsInstanceContext {
     _parent_ctx: Arc<InstanceContext>,
     api: MxlFabricsApiHandle,
-    pub(crate) inner: mxl_sys::fabrics::FabricsInstance,
+    pub(crate) inner: FabricsInstanceHandle,
 }
 unsafe impl Send for FabricsInstanceContext {}
 

--- a/rust/mxl/src/fabrics/interface/config.rs
+++ b/rust/mxl/src/fabrics/interface/config.rs
@@ -1,7 +1,12 @@
 use crate::{
     Error,
-    fabrics::{EndpointAddress, capabilities::Capabilities, provider::ProviderType},
+    fabrics::{
+        EndpointAddress, capabilities::Capabilities, endpoint_address::OwnedEndpointAddress,
+        provider::ProviderType,
+    },
 };
+
+use std::ffi::CString;
 
 pub struct InterfaceConfigBuilder<'a> {
     provider: Option<ProviderType>,
@@ -11,7 +16,7 @@ pub struct InterfaceConfigBuilder<'a> {
 }
 
 impl<'a> InterfaceConfigBuilder<'a> {
-    pub fn new(endpoint_address: EndpointAddress<'a>) -> Self {
+    pub(crate) fn new(endpoint_address: EndpointAddress<'a>) -> Self {
         Self {
             provider: None,
             caps: None,
@@ -20,11 +25,13 @@ impl<'a> InterfaceConfigBuilder<'a> {
         }
     }
 
+    /// Sets the provider type for the interface configuration.
     pub fn provider(mut self, provider: ProviderType) -> Self {
         self.provider = Some(provider);
         self
     }
 
+    /// Sets the capabilities for the interface configuration.
     pub fn caps(mut self, caps: Capabilities) -> Self {
         self.caps = Some(caps);
         self
@@ -35,16 +42,18 @@ impl<'a> InterfaceConfigBuilder<'a> {
         self
     }
 
-    pub fn build(self) -> Result<InterfaceConfig<'a>, Error> {
-        Ok(InterfaceConfig {
+    /// Builds the `InterfaceConfig`
+    pub fn build(self) -> InterfaceConfig<'a> {
+        InterfaceConfig {
             provider: self.provider.unwrap_or(ProviderType::Any),
             caps: self.caps.unwrap_or_default(),
             endpoint_address: self.endpoint_address,
             attr: self.attr,
-        })
+        }
     }
 }
 
+/// A configuration for a network interface, including the provider type, capabilities, endpoint address, and optional attributes.
 #[derive(Debug)]
 pub struct InterfaceConfig<'a> {
     pub provider: ProviderType,
@@ -60,28 +69,42 @@ impl<'a> InterfaceConfig<'a> {
         self.endpoint_address = endpoint_address;
     }
 }
-impl<'a> TryFrom<&InterfaceConfig<'a>> for mxl_sys::fabrics::FabricsInterfaceConfig {
-    type Error = crate::Error;
-
-    fn try_from(value: &InterfaceConfig) -> Result<Self, Self::Error> {
-        Ok(Self {
-            version: mxl_sys::fabrics::MXL_FABRICS_API_VERSION as i32,
-            provider: (&value.provider).into(),
-            caps: (&value.caps).into(),
-            address: (&value.endpoint_address).try_into()?,
-            attr: if let Some(attr) = value.attr {
-                std::ffi::CString::new(attr)?.into_raw()
-            } else {
-                std::ptr::null_mut()
-            },
-        })
+impl TryFrom<&InterfaceConfig<'_>> for OwnedInterfaceConfig {
+    type Error = Error;
+    fn try_from(value: &InterfaceConfig<'_>) -> Result<Self, Self::Error> {
+        OwnedInterfaceConfig::new(value)
     }
 }
-impl<'a> TryFrom<InterfaceConfig<'a>> for mxl_sys::fabrics::FabricsInterfaceConfig {
-    type Error = crate::Error;
 
-    fn try_from(value: InterfaceConfig) -> Result<Self, Self::Error> {
-        (&value).try_into()
+/// A wrapper around `mxl_sys::fabrics::FabricsInterfaceConfig` that owns the memory for the endpoint address and attribute strings.
+pub(crate) struct OwnedInterfaceConfig {
+    inner: mxl_sys::fabrics::FabricsInterfaceConfig,
+    _address: OwnedEndpointAddress,
+    _attr: Option<CString>,
+}
+
+impl OwnedInterfaceConfig {
+    pub(crate) fn new(value: &InterfaceConfig<'_>) -> Result<Self, Error> {
+        let address = OwnedEndpointAddress::new(&value.endpoint_address)?;
+        let attr = value.attr.map(CString::new).transpose()?;
+
+        Ok(Self {
+            inner: mxl_sys::fabrics::FabricsInterfaceConfig {
+                version: mxl_sys::fabrics::MXL_FABRICS_API_VERSION as i32,
+                provider: (&value.provider).into(),
+                caps: (&value.caps).into(),
+                address: address.as_ffi(),
+                attr: attr
+                    .as_ref()
+                    .map_or(std::ptr::null_mut(), |value| value.as_ptr() as *mut i8),
+            },
+            _address: address,
+            _attr: attr,
+        })
+    }
+
+    pub(crate) fn as_ffi(&self) -> &mxl_sys::fabrics::FabricsInterfaceConfig {
+        &self.inner
     }
 }
 impl<'a> TryFrom<mxl_sys::fabrics::FabricsInterfaceConfig> for InterfaceConfig<'a> {
@@ -90,34 +113,21 @@ impl<'a> TryFrom<mxl_sys::fabrics::FabricsInterfaceConfig> for InterfaceConfig<'
         let provider = (value.provider as mxl_sys::fabrics::FabricsProvider).into();
         let caps = value.caps.into();
         let endpoint_address = EndpointAddress {
-            node: if value.address.node.is_null() {
-                None
-            } else {
-                Some(
-                    unsafe { std::ffi::CStr::from_ptr(value.address.node) }
-                        .to_str()
-                        .map_err(|e| Error::Other(e.to_string()))?,
-                )
-            },
-            service: if value.address.service.is_null() {
-                None
-            } else {
-                Some(
-                    unsafe { std::ffi::CStr::from_ptr(value.address.service) }
-                        .to_str()
-                        .map_err(|e| Error::Other(e.to_string()))?,
-                )
-            },
+            node: (!value.address.node.is_null())
+                .then(|| unsafe { std::ffi::CStr::from_ptr(value.address.node) }.to_str())
+                .transpose()
+                .map_err(|e| Error::Other(e.to_string()))?,
+            service: (!value.address.service.is_null())
+                .then(|| unsafe { std::ffi::CStr::from_ptr(value.address.service) }.to_str())
+                .transpose()
+                .map_err(|e| Error::Other(e.to_string()))?,
         };
-        let attr = if value.attr.is_null() {
-            None
-        } else {
-            Some(
-                unsafe { std::ffi::CStr::from_ptr(value.attr) }
-                    .to_str()
-                    .map_err(|e| Error::Other(e.to_string()))?,
-            )
-        };
+
+        let attr = (!value.attr.is_null())
+            .then(|| unsafe { std::ffi::CStr::from_ptr(value.attr) }.to_str())
+            .transpose()
+            .map_err(|e| Error::Other(e.to_string()))?;
+
         Ok(Self {
             provider,
             caps,

--- a/rust/mxl/src/fabrics/interface/config.rs
+++ b/rust/mxl/src/fabrics/interface/config.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::{
     Error,
     fabrics::{

--- a/rust/mxl/src/fabrics/interface/config.rs
+++ b/rust/mxl/src/fabrics/interface/config.rs
@@ -1,0 +1,128 @@
+use crate::{
+    Error,
+    fabrics::{EndpointAddress, capabilities::Capabilities, provider::ProviderType},
+};
+
+pub struct InterfaceConfigBuilder<'a> {
+    provider: Option<ProviderType>,
+    caps: Option<Capabilities>,
+    endpoint_address: EndpointAddress<'a>,
+    attr: Option<&'a str>,
+}
+
+impl<'a> InterfaceConfigBuilder<'a> {
+    pub fn new(endpoint_address: EndpointAddress<'a>) -> Self {
+        Self {
+            provider: None,
+            caps: None,
+            endpoint_address,
+            attr: None,
+        }
+    }
+
+    pub fn provider(mut self, provider: ProviderType) -> Self {
+        self.provider = Some(provider);
+        self
+    }
+
+    pub fn caps(mut self, caps: Capabilities) -> Self {
+        self.caps = Some(caps);
+        self
+    }
+
+    pub fn attr(mut self, attr: &'a str) -> Self {
+        self.attr = Some(attr);
+        self
+    }
+
+    pub fn build(self) -> Result<InterfaceConfig<'a>, Error> {
+        Ok(InterfaceConfig {
+            provider: self.provider.unwrap_or(ProviderType::Any),
+            caps: self.caps.unwrap_or_default(),
+            endpoint_address: self.endpoint_address,
+            attr: self.attr,
+        })
+    }
+}
+
+#[derive(Debug)]
+pub struct InterfaceConfig<'a> {
+    pub provider: ProviderType,
+    pub caps: Capabilities,
+    pub endpoint_address: EndpointAddress<'a>,
+    pub attr: Option<&'a str>,
+}
+impl<'a> InterfaceConfig<'a> {
+    pub fn builder(endpoint_address: EndpointAddress<'a>) -> InterfaceConfigBuilder<'a> {
+        InterfaceConfigBuilder::new(endpoint_address)
+    }
+    pub fn set_endpoint_address(&mut self, endpoint_address: EndpointAddress<'a>) {
+        self.endpoint_address = endpoint_address;
+    }
+}
+impl<'a> TryFrom<&InterfaceConfig<'a>> for mxl_sys::fabrics::FabricsInterfaceConfig {
+    type Error = crate::Error;
+
+    fn try_from(value: &InterfaceConfig) -> Result<Self, Self::Error> {
+        Ok(Self {
+            version: mxl_sys::fabrics::MXL_FABRICS_API_VERSION as i32,
+            provider: (&value.provider).into(),
+            caps: (&value.caps).into(),
+            address: (&value.endpoint_address).try_into()?,
+            attr: if let Some(attr) = value.attr {
+                std::ffi::CString::new(attr)?.into_raw()
+            } else {
+                std::ptr::null_mut()
+            },
+        })
+    }
+}
+impl<'a> TryFrom<InterfaceConfig<'a>> for mxl_sys::fabrics::FabricsInterfaceConfig {
+    type Error = crate::Error;
+
+    fn try_from(value: InterfaceConfig) -> Result<Self, Self::Error> {
+        (&value).try_into()
+    }
+}
+impl<'a> TryFrom<mxl_sys::fabrics::FabricsInterfaceConfig> for InterfaceConfig<'a> {
+    type Error = crate::Error;
+    fn try_from(value: mxl_sys::fabrics::FabricsInterfaceConfig) -> Result<Self, Self::Error> {
+        let provider = (value.provider as mxl_sys::fabrics::FabricsProvider).into();
+        let caps = value.caps.into();
+        let endpoint_address = EndpointAddress {
+            node: if value.address.node.is_null() {
+                None
+            } else {
+                Some(
+                    unsafe { std::ffi::CStr::from_ptr(value.address.node) }
+                        .to_str()
+                        .map_err(|e| Error::Other(e.to_string()))?,
+                )
+            },
+            service: if value.address.service.is_null() {
+                None
+            } else {
+                Some(
+                    unsafe { std::ffi::CStr::from_ptr(value.address.service) }
+                        .to_str()
+                        .map_err(|e| Error::Other(e.to_string()))?,
+                )
+            },
+        };
+        let attr = if value.attr.is_null() {
+            None
+        } else {
+            Some(
+                unsafe { std::ffi::CStr::from_ptr(value.attr) }
+                    .to_str()
+                    .map_err(|e| Error::Other(e.to_string()))?,
+            )
+        };
+        Ok(Self {
+            provider,
+            caps,
+            endpoint_address,
+            attr,
+        })
+    }
+}

--- a/rust/mxl/src/fabrics/interface/config.rs
+++ b/rust/mxl/src/fabrics/interface/config.rs
@@ -91,7 +91,8 @@ impl TryFrom<FabricsInterfaceConfig> for InterfaceConfig {
         let provider = (value.provider as FabricsProvider).try_into()?;
         let caps = value.caps.into();
         let endpoint_address = EndpointAddress::from(&value.address);
-        let attr = (!value.attr.is_null()).then(|| unsafe { CStr::from_ptr(value.attr).into() });
+        let attr =
+            (!value.attr.is_null()).then(|| unsafe { CStr::from_ptr(value.attr).to_owned() });
 
         Ok(Self {
             provider,

--- a/rust/mxl/src/fabrics/interface/config.rs
+++ b/rust/mxl/src/fabrics/interface/config.rs
@@ -6,6 +6,7 @@ use crate::{
     fabrics::{EndpointAddress, capabilities::Capabilities, provider::ProviderType},
 };
 
+use mxl_sys::types::{FabricsInterfaceConfig, FabricsProvider, MXL_FABRICS_API_VERSION};
 use std::ffi::CString;
 
 pub struct InterfaceConfigBuilder<'a> {
@@ -69,11 +70,11 @@ impl<'a> InterfaceConfig {
         self.endpoint_address = endpoint_address;
     }
 }
-impl TryFrom<&InterfaceConfig> for mxl_sys::fabrics::FabricsInterfaceConfig {
+impl TryFrom<&InterfaceConfig> for FabricsInterfaceConfig {
     type Error = Error;
     fn try_from(value: &InterfaceConfig) -> Result<Self, Self::Error> {
-        Ok(mxl_sys::fabrics::FabricsInterfaceConfig {
-            version: mxl_sys::fabrics::MXL_FABRICS_API_VERSION as i32,
+        Ok(FabricsInterfaceConfig {
+            version: MXL_FABRICS_API_VERSION as i32,
             provider: (&value.provider).into(),
             caps: (&value.caps).into(),
             address: (&value.endpoint_address).into(),
@@ -84,10 +85,10 @@ impl TryFrom<&InterfaceConfig> for mxl_sys::fabrics::FabricsInterfaceConfig {
         })
     }
 }
-impl TryFrom<mxl_sys::fabrics::FabricsInterfaceConfig> for InterfaceConfig {
+impl TryFrom<FabricsInterfaceConfig> for InterfaceConfig {
     type Error = crate::Error;
-    fn try_from(value: mxl_sys::fabrics::FabricsInterfaceConfig) -> Result<Self, Self::Error> {
-        let provider = (value.provider as mxl_sys::fabrics::FabricsProvider).try_into()?;
+    fn try_from(value: FabricsInterfaceConfig) -> Result<Self, Self::Error> {
+        let provider = (value.provider as FabricsProvider).try_into()?;
         let caps = value.caps.into();
         let endpoint_address = EndpointAddress::from(&value.address);
         let attr =

--- a/rust/mxl/src/fabrics/interface/config.rs
+++ b/rust/mxl/src/fabrics/interface/config.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 
 use mxl_sys::types::{FabricsInterfaceConfig, FabricsProvider, MXL_FABRICS_API_VERSION};
-use std::ffi::CString;
+use std::ffi::{CStr, CString};
 
 pub struct InterfaceConfigBuilder<'a> {
     provider: Option<ProviderType>,
@@ -91,8 +91,7 @@ impl TryFrom<FabricsInterfaceConfig> for InterfaceConfig {
         let provider = (value.provider as FabricsProvider).try_into()?;
         let caps = value.caps.into();
         let endpoint_address = EndpointAddress::from(&value.address);
-        let attr =
-            (!value.attr.is_null()).then(|| unsafe { CString::from_raw(value.attr as *mut i8) });
+        let attr = (!value.attr.is_null()).then(|| unsafe { CStr::from_ptr(value.attr).into() });
 
         Ok(Self {
             provider,

--- a/rust/mxl/src/fabrics/interface/config.rs
+++ b/rust/mxl/src/fabrics/interface/config.rs
@@ -3,10 +3,7 @@
 
 use crate::{
     Error,
-    fabrics::{
-        EndpointAddress, capabilities::Capabilities, endpoint_address::OwnedEndpointAddress,
-        provider::ProviderType,
-    },
+    fabrics::{EndpointAddress, capabilities::Capabilities, provider::ProviderType},
 };
 
 use std::ffi::CString;
@@ -14,12 +11,12 @@ use std::ffi::CString;
 pub struct InterfaceConfigBuilder<'a> {
     provider: Option<ProviderType>,
     caps: Option<Capabilities>,
-    endpoint_address: EndpointAddress<'a>,
+    endpoint_address: EndpointAddress,
     attr: Option<&'a str>,
 }
 
 impl<'a> InterfaceConfigBuilder<'a> {
-    pub(crate) fn new(endpoint_address: EndpointAddress<'a>) -> Self {
+    pub(crate) fn new(endpoint_address: EndpointAddress) -> Self {
         Self {
             provider: None,
             caps: None,
@@ -46,90 +43,55 @@ impl<'a> InterfaceConfigBuilder<'a> {
     }
 
     /// Builds the `InterfaceConfig`
-    pub fn build(self) -> InterfaceConfig<'a> {
-        InterfaceConfig {
+    pub fn build(self) -> Result<InterfaceConfig, crate::Error> {
+        Ok(InterfaceConfig {
             provider: self.provider.unwrap_or(ProviderType::Any),
             caps: self.caps.unwrap_or_default(),
             endpoint_address: self.endpoint_address,
-            attr: self.attr,
-        }
+            attr: self.attr.map(CString::new).transpose()?,
+        })
     }
 }
 
 /// A configuration for a network interface, including the provider type, capabilities, endpoint address, and optional attributes.
 #[derive(Debug)]
-pub struct InterfaceConfig<'a> {
+pub struct InterfaceConfig {
     pub provider: ProviderType,
     pub caps: Capabilities,
-    pub endpoint_address: EndpointAddress<'a>,
-    pub attr: Option<&'a str>,
+    pub endpoint_address: EndpointAddress,
+    pub attr: Option<CString>,
 }
-impl<'a> InterfaceConfig<'a> {
-    pub fn builder(endpoint_address: EndpointAddress<'a>) -> InterfaceConfigBuilder<'a> {
+impl<'a> InterfaceConfig {
+    pub fn builder(endpoint_address: EndpointAddress) -> InterfaceConfigBuilder<'a> {
         InterfaceConfigBuilder::new(endpoint_address)
     }
-    pub fn set_endpoint_address(&mut self, endpoint_address: EndpointAddress<'a>) {
+    pub fn set_endpoint_address(&mut self, endpoint_address: EndpointAddress) {
         self.endpoint_address = endpoint_address;
     }
 }
-impl TryFrom<&InterfaceConfig<'_>> for OwnedInterfaceConfig {
+impl TryFrom<&InterfaceConfig> for mxl_sys::fabrics::FabricsInterfaceConfig {
     type Error = Error;
-    fn try_from(value: &InterfaceConfig<'_>) -> Result<Self, Self::Error> {
-        OwnedInterfaceConfig::new(value)
-    }
-}
-
-/// A wrapper around `mxl_sys::fabrics::FabricsInterfaceConfig` that owns the memory for the endpoint address and attribute strings.
-pub(crate) struct OwnedInterfaceConfig {
-    inner: mxl_sys::fabrics::FabricsInterfaceConfig,
-    _address: OwnedEndpointAddress,
-    _attr: Option<CString>,
-}
-
-impl OwnedInterfaceConfig {
-    pub(crate) fn new(value: &InterfaceConfig<'_>) -> Result<Self, Error> {
-        let address = OwnedEndpointAddress::new(&value.endpoint_address)?;
-        let attr = value.attr.map(CString::new).transpose()?;
-
-        Ok(Self {
-            inner: mxl_sys::fabrics::FabricsInterfaceConfig {
-                version: mxl_sys::fabrics::MXL_FABRICS_API_VERSION as i32,
-                provider: (&value.provider).into(),
-                caps: (&value.caps).into(),
-                address: address.as_ffi(),
-                attr: attr
-                    .as_ref()
-                    .map_or(std::ptr::null_mut(), |value| value.as_ptr() as *mut i8),
-            },
-            _address: address,
-            _attr: attr,
+    fn try_from(value: &InterfaceConfig) -> Result<Self, Self::Error> {
+        Ok(mxl_sys::fabrics::FabricsInterfaceConfig {
+            version: mxl_sys::fabrics::MXL_FABRICS_API_VERSION as i32,
+            provider: (&value.provider).into(),
+            caps: (&value.caps).into(),
+            address: (&value.endpoint_address).into(),
+            attr: value
+                .attr
+                .as_ref()
+                .map_or(std::ptr::null_mut(), |v| v.as_ptr()),
         })
     }
-
-    pub(crate) fn as_ffi(&self) -> &mxl_sys::fabrics::FabricsInterfaceConfig {
-        &self.inner
-    }
 }
-impl<'a> TryFrom<mxl_sys::fabrics::FabricsInterfaceConfig> for InterfaceConfig<'a> {
+impl TryFrom<mxl_sys::fabrics::FabricsInterfaceConfig> for InterfaceConfig {
     type Error = crate::Error;
     fn try_from(value: mxl_sys::fabrics::FabricsInterfaceConfig) -> Result<Self, Self::Error> {
-        let provider = (value.provider as mxl_sys::fabrics::FabricsProvider).into();
+        let provider = (value.provider as mxl_sys::fabrics::FabricsProvider).try_into()?;
         let caps = value.caps.into();
-        let endpoint_address = EndpointAddress {
-            node: (!value.address.node.is_null())
-                .then(|| unsafe { std::ffi::CStr::from_ptr(value.address.node) }.to_str())
-                .transpose()
-                .map_err(|e| Error::Other(e.to_string()))?,
-            service: (!value.address.service.is_null())
-                .then(|| unsafe { std::ffi::CStr::from_ptr(value.address.service) }.to_str())
-                .transpose()
-                .map_err(|e| Error::Other(e.to_string()))?,
-        };
-
-        let attr = (!value.attr.is_null())
-            .then(|| unsafe { std::ffi::CStr::from_ptr(value.attr) }.to_str())
-            .transpose()
-            .map_err(|e| Error::Other(e.to_string()))?;
+        let endpoint_address = EndpointAddress::from(&value.address);
+        let attr =
+            (!value.attr.is_null()).then(|| unsafe { CString::from_raw(value.attr as *mut i8) });
 
         Ok(Self {
             provider,

--- a/rust/mxl/src/fabrics/interface/mod.rs
+++ b/rust/mxl/src/fabrics/interface/mod.rs
@@ -1,0 +1,80 @@
+use std::sync::Arc;
+
+use crate::{
+    Error,
+    fabrics::{instance::FabricsInstanceContext, interface::config::InterfaceConfig},
+};
+
+pub mod config;
+
+pub struct Interfaces {
+    ctx: Arc<FabricsInstanceContext>,
+    inner: *mut mxl_sys::fabrics::FabricsInterfaceList,
+}
+
+impl Interfaces {
+    pub(crate) fn get(
+        ctx: Arc<FabricsInstanceContext>,
+        query: Option<InterfaceConfig>,
+    ) -> Result<Self, crate::Error> {
+        let query_storage = match query {
+            Some(q) => Some::<mxl_sys::fabrics::FabricsInterfaceConfig>(q.try_into()?),
+            None => None,
+        };
+        let query_ptr = query_storage
+            .as_ref()
+            .map_or(std::ptr::null(), |q| q as *const _);
+
+        let mut out_list: *mut mxl_sys::fabrics::FabricsInterfaceList = std::ptr::null_mut();
+
+        Error::from_status(unsafe {
+            ctx.api()
+                .fabrics_get_interfaces(ctx.inner, query_ptr, &mut out_list)
+        })?;
+
+        Ok(Self {
+            ctx,
+            inner: out_list,
+        })
+    }
+    pub fn iter(&self) -> InterfaceIter<'_> {
+        InterfaceIter {
+            it: self.inner,
+            _marker: std::marker::PhantomData,
+        }
+    }
+}
+
+impl Drop for Interfaces {
+    fn drop(&mut self) {
+        if !self.inner.is_null() {
+            unsafe {
+                self.ctx.api().fabrics_free_interface_list(
+                    self.inner as *mut mxl_sys::fabrics::FabricsInterfaceList,
+                );
+            }
+        }
+    }
+}
+
+pub struct InterfaceIter<'a> {
+    it: *mut mxl_sys::fabrics::FabricsInterfaceList,
+    _marker: std::marker::PhantomData<&'a ()>,
+}
+
+impl<'a> Iterator for InterfaceIter<'a> {
+    type Item = InterfaceConfig<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.it.is_null() {
+            return None;
+        }
+
+        let iface = unsafe { &*self.it };
+        let out = iface.interface.try_into().ok();
+
+        self.it = iface.next;
+
+        out
+    }
+}

--- a/rust/mxl/src/fabrics/interface/mod.rs
+++ b/rust/mxl/src/fabrics/interface/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: Apache-2.0
+//
 use std::sync::Arc;
 
 use crate::{
@@ -28,7 +31,7 @@ impl Interfaces {
             .as_ref()
             .map_or(std::ptr::null(), |q| q.as_ffi() as *const _);
 
-        let mut out_list: *mut mxl_sys::fabrics::FabricsInterfaceList = std::ptr::null_mut();
+        let mut out_list = std::ptr::null_mut();
 
         Error::from_status(unsafe {
             ctx.api()

--- a/rust/mxl/src/fabrics/interface/mod.rs
+++ b/rust/mxl/src/fabrics/interface/mod.rs
@@ -2,7 +2,10 @@ use std::sync::Arc;
 
 use crate::{
     Error,
-    fabrics::{instance::FabricsInstanceContext, interface::config::InterfaceConfig},
+    fabrics::{
+        instance::FabricsInstanceContext,
+        interface::config::{InterfaceConfig, OwnedInterfaceConfig},
+    },
 };
 
 pub mod config;
@@ -18,12 +21,12 @@ impl Interfaces {
         query: Option<InterfaceConfig>,
     ) -> Result<Self, crate::Error> {
         let query_storage = match query {
-            Some(q) => Some::<mxl_sys::fabrics::FabricsInterfaceConfig>(q.try_into()?),
+            Some(q) => Some(OwnedInterfaceConfig::new(&q)?),
             None => None,
         };
         let query_ptr = query_storage
             .as_ref()
-            .map_or(std::ptr::null(), |q| q as *const _);
+            .map_or(std::ptr::null(), |q| q.as_ffi() as *const _);
 
         let mut out_list: *mut mxl_sys::fabrics::FabricsInterfaceList = std::ptr::null_mut();
 

--- a/rust/mxl/src/fabrics/interface/mod.rs
+++ b/rust/mxl/src/fabrics/interface/mod.rs
@@ -3,7 +3,7 @@
 //
 use std::sync::Arc;
 
-use mxl_sys::fabrics::FabricsInterfaceConfig;
+use mxl_sys::types::{FabricsInterfaceConfig, FabricsInterfaceList};
 
 use crate::{
     Error,
@@ -14,7 +14,7 @@ pub mod config;
 
 pub struct Interfaces {
     ctx: Arc<FabricsInstanceContext>,
-    inner: *mut mxl_sys::fabrics::FabricsInterfaceList,
+    inner: *mut FabricsInterfaceList,
 }
 impl Interfaces {
     pub(crate) fn get(
@@ -53,16 +53,16 @@ impl Drop for Interfaces {
     fn drop(&mut self) {
         if !self.inner.is_null() {
             unsafe {
-                self.ctx.api().fabrics_free_interface_list(
-                    self.inner as *mut mxl_sys::fabrics::FabricsInterfaceList,
-                );
+                self.ctx
+                    .api()
+                    .fabrics_free_interface_list(self.inner as *mut FabricsInterfaceList);
             }
         }
     }
 }
 
 pub struct InterfaceIter<'a> {
-    it: *mut mxl_sys::fabrics::FabricsInterfaceList,
+    it: *mut FabricsInterfaceList,
     _marker: std::marker::PhantomData<&'a ()>,
 }
 impl<'a> Iterator for InterfaceIter<'a> {

--- a/rust/mxl/src/fabrics/interface/mod.rs
+++ b/rust/mxl/src/fabrics/interface/mod.rs
@@ -3,12 +3,11 @@
 //
 use std::sync::Arc;
 
+use mxl_sys::fabrics::FabricsInterfaceConfig;
+
 use crate::{
     Error,
-    fabrics::{
-        instance::FabricsInstanceContext,
-        interface::config::{InterfaceConfig, OwnedInterfaceConfig},
-    },
+    fabrics::{instance::FabricsInstanceContext, interface::config::InterfaceConfig},
 };
 
 pub mod config;
@@ -17,19 +16,19 @@ pub struct Interfaces {
     ctx: Arc<FabricsInstanceContext>,
     inner: *mut mxl_sys::fabrics::FabricsInterfaceList,
 }
-
 impl Interfaces {
     pub(crate) fn get(
         ctx: Arc<FabricsInstanceContext>,
         query: Option<InterfaceConfig>,
     ) -> Result<Self, crate::Error> {
-        let query_storage = match query {
-            Some(q) => Some(OwnedInterfaceConfig::new(&q)?),
-            None => None,
-        };
-        let query_ptr = query_storage
+        let query_raw = query
             .as_ref()
-            .map_or(std::ptr::null(), |q| q.as_ffi() as *const _);
+            .map(FabricsInterfaceConfig::try_from)
+            .transpose()?;
+
+        let query_ptr = query_raw
+            .as_ref()
+            .map_or(std::ptr::null(), |q| q as *const _);
 
         let mut out_list = std::ptr::null_mut();
 
@@ -50,7 +49,6 @@ impl Interfaces {
         }
     }
 }
-
 impl Drop for Interfaces {
     fn drop(&mut self) {
         if !self.inner.is_null() {
@@ -67,9 +65,8 @@ pub struct InterfaceIter<'a> {
     it: *mut mxl_sys::fabrics::FabricsInterfaceList,
     _marker: std::marker::PhantomData<&'a ()>,
 }
-
 impl<'a> Iterator for InterfaceIter<'a> {
-    type Item = InterfaceConfig<'a>;
+    type Item = InterfaceConfig;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.it.is_null() {
@@ -77,7 +74,12 @@ impl<'a> Iterator for InterfaceIter<'a> {
         }
 
         let iface = unsafe { &*self.it };
-        let out = iface.interface.try_into().ok();
+
+        let out = iface
+            .interface
+            .try_into()
+            .inspect_err(|e| tracing::error!(error=%e, "Failed to convert interface config."))
+            .ok();
 
         self.it = iface.next;
 

--- a/rust/mxl/src/fabrics/mod.rs
+++ b/rust/mxl/src/fabrics/mod.rs
@@ -1,0 +1,32 @@
+//! This module provides the Fabrics API extension for this library. The main type is the
+//! [FabricsInstance], which is used to create Targets and Initiators for remote data transfers.
+//! This module is gated by the `mxl-fabrics-ofi` feature flag.
+//!
+//! # Details
+//! - To get a FabricsInstance, you must create it from MXL instance and a loaded Fabrics API.
+//! ```
+//! let mxl_api = mxl::load_api(mxl::config::get_mxl_so_path()) .unwrap();
+//! let instance = mxl::MxlInstance::new(mxl_api, "/dev/shm","").unwrap();
+//!
+//! let mxl_fabrics_api = mxl::load_fabrics_api(mxl::config::get_mxl_fabrics_ofi_so_path());
+//! let fabrics_instance = instance.create_fabrics_instance(&mxl_fabrics_api.unwrap()).unwrap();
+//!
+//! // You can now create Targets and Initiators from the fabrics_instance
+//! let target = fabrics_instance.create_target().unwrap();
+//! let initiator = fabrics_instance.create_initiator().unwrap();
+//! ````
+mod config;
+pub mod initiator;
+mod instance;
+mod provider;
+pub mod target;
+mod target_info;
+
+pub use config::EndpointAddress;
+// pub use initiator::{Config as InitiatorConfig, Either as InitiatorEither, Initiator};
+pub use instance::FabricsInstance;
+pub use provider::Provider;
+// pub use target::{Config as TargetConfig, Target};
+pub use target_info::TargetInfo;
+
+pub(crate) use instance::create_instance;

--- a/rust/mxl/src/fabrics/mod.rs
+++ b/rust/mxl/src/fabrics/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: Apache-2.0
+
 //! This module provides the Fabrics API extension for this library. The main type is the
 //! [FabricsInstance], which is used to create Targets and Initiators for remote data transfers.
 //! This module is gated by the `mxl-fabrics-ofi` feature flag.

--- a/rust/mxl/src/fabrics/mod.rs
+++ b/rust/mxl/src/fabrics/mod.rs
@@ -23,10 +23,8 @@ pub mod target;
 mod target_info;
 
 pub use config::EndpointAddress;
-// pub use initiator::{Config as InitiatorConfig, Either as InitiatorEither, Initiator};
 pub use instance::FabricsInstance;
 pub use provider::Provider;
-// pub use target::{Config as TargetConfig, Target};
 pub use target_info::TargetInfo;
 
 pub(crate) use instance::create_instance;

--- a/rust/mxl/src/fabrics/mod.rs
+++ b/rust/mxl/src/fabrics/mod.rs
@@ -18,16 +18,20 @@
 //! let target = fabrics_instance.create_target().unwrap();
 //! let initiator = fabrics_instance.create_initiator().unwrap();
 //! ````
-mod config;
+mod capabilities;
+mod endpoint_address;
 pub mod initiator;
 mod instance;
+mod interface;
 mod provider;
 pub mod target;
 mod target_info;
 
-pub use config::EndpointAddress;
+pub use capabilities::Capabilities;
+pub use endpoint_address::EndpointAddress;
 pub use instance::FabricsInstance;
-pub use provider::Provider;
+pub use interface::config::InterfaceConfig;
+pub use provider::{Provider, ProviderType};
 pub use target_info::TargetInfo;
 
 pub(crate) use instance::create_instance;

--- a/rust/mxl/src/fabrics/mod.rs
+++ b/rust/mxl/src/fabrics/mod.rs
@@ -8,7 +8,7 @@
 //! # Details
 //! - To get a FabricsInstance, you must create it from MXL instance and a loaded Fabrics API.
 //! ```
-//! let mxl_api = mxl::load_api(mxl::config::get_mxl_so_path()) .unwrap();
+//! let mxl_api = mxl::load_api(mxl::config::get_mxl_so_path()).unwrap();
 //! let instance = mxl::MxlInstance::new(mxl_api, "/dev/shm","").unwrap();
 //!
 //! let mxl_fabrics_api = mxl::load_fabrics_api(mxl::config::get_mxl_fabrics_ofi_so_path());
@@ -17,7 +17,7 @@
 //! // You can now create Targets and Initiators from the fabrics_instance
 //! let target = fabrics_instance.create_target().unwrap();
 //! let initiator = fabrics_instance.create_initiator().unwrap();
-//! ````
+//! ```
 mod capabilities;
 mod endpoint_address;
 pub mod initiator;

--- a/rust/mxl/src/fabrics/provider.rs
+++ b/rust/mxl/src/fabrics/provider.rs
@@ -1,0 +1,105 @@
+use mxl_sys::fabrics::FabricsProvider;
+
+use crate::error::{Error, Result};
+use std::{ffi::CString, rc::Rc};
+
+use crate::fabrics::instance::FabricsInstanceContext;
+
+/// The provider corresponds to the transport used for transfers. This is created from a
+/// [FabricsInstance](crate::fabrics::FabricsInstance).
+#[derive(Clone)]
+pub struct Provider {
+    inner: ProviderType,
+    ctx: Rc<FabricsInstanceContext>,
+}
+
+/// The available transports
+#[derive(Clone)]
+enum ProviderType {
+    Auto,
+    Tcp,
+    Verbs,
+    Efa,
+    Shm,
+}
+
+impl From<mxl_sys::fabrics::FabricsProvider> for ProviderType {
+    fn from(value: mxl_sys::fabrics::FabricsProvider) -> Self {
+        match value {
+            mxl_sys::fabrics::MXL_FABRICS_PROVIDER_AUTO => ProviderType::Auto,
+            mxl_sys::fabrics::MXL_FABRICS_PROVIDER_TCP => ProviderType::Tcp,
+            mxl_sys::fabrics::MXL_FABRICS_PROVIDER_VERBS => ProviderType::Verbs,
+            mxl_sys::fabrics::MXL_FABRICS_PROVIDER_EFA => ProviderType::Efa,
+            mxl_sys::fabrics::MXL_FABRICS_PROVIDER_SHM => ProviderType::Shm,
+            _ => panic!("Unknown FabricsProvider value"),
+        }
+    }
+}
+
+impl From<&ProviderType> for mxl_sys::fabrics::FabricsProvider {
+    fn from(value: &ProviderType) -> Self {
+        match value {
+            ProviderType::Auto => mxl_sys::fabrics::MXL_FABRICS_PROVIDER_AUTO,
+            ProviderType::Tcp => mxl_sys::fabrics::MXL_FABRICS_PROVIDER_TCP,
+            ProviderType::Verbs => mxl_sys::fabrics::MXL_FABRICS_PROVIDER_VERBS,
+            ProviderType::Efa => mxl_sys::fabrics::MXL_FABRICS_PROVIDER_EFA,
+            ProviderType::Shm => mxl_sys::fabrics::MXL_FABRICS_PROVIDER_SHM,
+        }
+    }
+}
+
+impl From<&Provider> for mxl_sys::fabrics::FabricsProvider {
+    fn from(value: &Provider) -> Self {
+        (&value.inner).into()
+    }
+}
+
+impl Provider {
+    fn new(ctx: Rc<FabricsInstanceContext>, inner: FabricsProvider) -> Self {
+        Self {
+            inner: inner.into(),
+            ctx,
+        }
+    }
+
+    /// Convert a string to a fabrics provider enum value.
+    /// Public visibility is set to crate only, because a `FabricsInstanceContext` is required.
+    /// See [FabricsInstance](crate::FabricsInstance).
+    pub(crate) fn from_str(ctx: Rc<FabricsInstanceContext>, s: &str) -> Result<Provider> {
+        let mut inner = FabricsProvider::default();
+
+        Error::from_status(unsafe {
+            ctx.api()
+                .fabrics_provider_from_string(CString::new(s)?.as_ptr(), &mut inner)
+        })?;
+
+        Ok(Self::new(ctx, inner))
+    }
+
+    /// Convert a fabrics provider enum value to a string.
+    pub fn to_string(&self) -> Result<String> {
+        let mut size = 0;
+
+        let prov: mxl_sys::fabrics::FabricsProvider = (&self.inner).into();
+
+        Error::from_status(unsafe {
+            self.ctx
+                .api()
+                .fabrics_provider_to_string(prov, std::ptr::null_mut(), &mut size)
+        })?;
+
+        // fabrics_provider_to_string already includes space for null terminator. So we must remove it here, because CString includes it.
+        let out_string = unsafe { CString::from_vec_unchecked(vec![0; size - 1]) };
+
+        Error::from_status(unsafe {
+            self.ctx.api().fabrics_provider_to_string(
+                prov,
+                out_string.as_ptr() as *mut i8,
+                &mut size,
+            )
+        })?;
+        out_string
+            .into_string()
+            .map_err(|e| Error::Other(e.to_string()))
+    }
+}

--- a/rust/mxl/src/fabrics/provider.rs
+++ b/rust/mxl/src/fabrics/provider.rs
@@ -22,10 +22,15 @@ unsafe impl Sync for Provider {}
 /// The available transports
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ProviderType {
+    ///  Any provider. Currently useful as an input to `FabricsInstance::get_interfaces`
     Any,
+    /// Provider that use linux TCP sockets.
     Tcp,
+    /// Provider for userspace verbs (libibverbs and librdmacm)
     Verbs,
+    /// Provider for AWS Elastic Fabric Adapter
     Efa,
+    /// Provider used for moving data between 2 memory regions inside the same system.
     Shm,
 }
 
@@ -90,25 +95,25 @@ impl Provider {
     pub fn to_string(&self) -> Result<String> {
         let mut size = 0;
 
-        let prov: mxl_sys::fabrics::FabricsProvider = (&self.inner).into();
-
-        Error::from_status(unsafe {
-            self.ctx
-                .api()
-                .fabrics_provider_to_string(prov, std::ptr::null_mut(), &mut size)
-        })?;
-
-        // fabrics_provider_to_string already includes space for null terminator. So we must remove it here, because CString includes it.
-        let out_string = unsafe { CString::from_vec_unchecked(vec![0; size - 1]) };
-
         Error::from_status(unsafe {
             self.ctx.api().fabrics_provider_to_string(
-                prov,
-                out_string.as_ptr() as *mut i8,
+                (&self.inner).into(),
+                std::ptr::null_mut(),
                 &mut size,
             )
         })?;
-        out_string
+
+        let mut out_string = vec![0u8; size];
+        Error::from_status(unsafe {
+            self.ctx.api().fabrics_provider_to_string(
+                (&self.inner).into(),
+                out_string.as_mut_ptr() as *mut i8,
+                &mut size,
+            )
+        })?;
+
+        CString::from_vec_with_nul(out_string)
+            .map_err(|e| Error::Other(e.to_string()))?
             .into_string()
             .map_err(|e| Error::Other(e.to_string()))
     }

--- a/rust/mxl/src/fabrics/provider.rs
+++ b/rust/mxl/src/fabrics/provider.rs
@@ -20,9 +20,9 @@ unsafe impl Send for Provider {}
 unsafe impl Sync for Provider {}
 
 /// The available transports
-#[derive(Clone)]
-enum ProviderType {
-    Auto,
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ProviderType {
+    Any,
     Tcp,
     Verbs,
     Efa,
@@ -32,7 +32,7 @@ enum ProviderType {
 impl From<mxl_sys::fabrics::FabricsProvider> for ProviderType {
     fn from(value: mxl_sys::fabrics::FabricsProvider) -> Self {
         match value {
-            mxl_sys::fabrics::MXL_FABRICS_PROVIDER_AUTO => ProviderType::Auto,
+            mxl_sys::fabrics::MXL_FABRICS_PROVIDER_ANY => ProviderType::Any,
             mxl_sys::fabrics::MXL_FABRICS_PROVIDER_TCP => ProviderType::Tcp,
             mxl_sys::fabrics::MXL_FABRICS_PROVIDER_VERBS => ProviderType::Verbs,
             mxl_sys::fabrics::MXL_FABRICS_PROVIDER_EFA => ProviderType::Efa,
@@ -45,7 +45,7 @@ impl From<mxl_sys::fabrics::FabricsProvider> for ProviderType {
 impl From<&ProviderType> for mxl_sys::fabrics::FabricsProvider {
     fn from(value: &ProviderType) -> Self {
         match value {
-            ProviderType::Auto => mxl_sys::fabrics::MXL_FABRICS_PROVIDER_AUTO,
+            ProviderType::Any => mxl_sys::fabrics::MXL_FABRICS_PROVIDER_ANY,
             ProviderType::Tcp => mxl_sys::fabrics::MXL_FABRICS_PROVIDER_TCP,
             ProviderType::Verbs => mxl_sys::fabrics::MXL_FABRICS_PROVIDER_VERBS,
             ProviderType::Efa => mxl_sys::fabrics::MXL_FABRICS_PROVIDER_EFA,
@@ -66,6 +66,10 @@ impl Provider {
             inner: inner.into(),
             ctx,
         }
+    }
+
+    pub fn prov_type(&self) -> &ProviderType {
+        &self.inner
     }
 
     /// Convert a string to a fabrics provider enum value.

--- a/rust/mxl/src/fabrics/provider.rs
+++ b/rust/mxl/src/fabrics/provider.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: Apache-2.0
+
 use mxl_sys::fabrics::FabricsProvider;
 
 use crate::error::{Error, Result};

--- a/rust/mxl/src/fabrics/provider.rs
+++ b/rust/mxl/src/fabrics/provider.rs
@@ -1,7 +1,7 @@
 use mxl_sys::fabrics::FabricsProvider;
 
 use crate::error::{Error, Result};
-use std::{ffi::CString, rc::Rc};
+use std::{ffi::CString, sync::Arc};
 
 use crate::fabrics::instance::FabricsInstanceContext;
 
@@ -10,8 +10,11 @@ use crate::fabrics::instance::FabricsInstanceContext;
 #[derive(Clone)]
 pub struct Provider {
     inner: ProviderType,
-    ctx: Rc<FabricsInstanceContext>,
+    ctx: Arc<FabricsInstanceContext>,
 }
+unsafe impl Send for Provider {}
+/// SAFETY: Although the `FabricsInstanceContext` type as a whole is not thread-safe, the subset of functions that this `Provider type uses is thread-safe: `fabrics_provider_from_string` and `fabrics_provider_to_string`
+unsafe impl Sync for Provider {}
 
 /// The available transports
 #[derive(Clone)]
@@ -55,7 +58,7 @@ impl From<&Provider> for mxl_sys::fabrics::FabricsProvider {
 }
 
 impl Provider {
-    fn new(ctx: Rc<FabricsInstanceContext>, inner: FabricsProvider) -> Self {
+    fn new(ctx: Arc<FabricsInstanceContext>, inner: FabricsProvider) -> Self {
         Self {
             inner: inner.into(),
             ctx,
@@ -65,7 +68,7 @@ impl Provider {
     /// Convert a string to a fabrics provider enum value.
     /// Public visibility is set to crate only, because a `FabricsInstanceContext` is required.
     /// See [FabricsInstance](crate::FabricsInstance).
-    pub(crate) fn from_str(ctx: Rc<FabricsInstanceContext>, s: &str) -> Result<Provider> {
+    pub(crate) fn from_str(ctx: Arc<FabricsInstanceContext>, s: &str) -> Result<Provider> {
         let mut inner = FabricsProvider::default();
 
         Error::from_status(unsafe {

--- a/rust/mxl/src/fabrics/provider.rs
+++ b/rust/mxl/src/fabrics/provider.rs
@@ -1,7 +1,10 @@
 // SPDX-FileCopyrightText: 2026 Contributors to the Media eXchange Layer project.
 // SPDX-License-Identifier: Apache-2.0
 
-use mxl_sys::fabrics::FabricsProvider;
+use mxl_sys::types::{
+    FabricsProvider, MXL_FABRICS_PROVIDER_ANY, MXL_FABRICS_PROVIDER_EFA, MXL_FABRICS_PROVIDER_SHM,
+    MXL_FABRICS_PROVIDER_TCP, MXL_FABRICS_PROVIDER_VERBS,
+};
 
 use crate::error::{Error, Result};
 use std::{ffi::CString, sync::Arc};
@@ -34,33 +37,33 @@ pub enum ProviderType {
     Shm,
 }
 
-impl TryFrom<mxl_sys::fabrics::FabricsProvider> for ProviderType {
+impl TryFrom<FabricsProvider> for ProviderType {
     type Error = Error;
-    fn try_from(value: mxl_sys::fabrics::FabricsProvider) -> Result<Self> {
+    fn try_from(value: FabricsProvider) -> Result<Self> {
         match value {
-            mxl_sys::fabrics::MXL_FABRICS_PROVIDER_ANY => Ok(ProviderType::Any),
-            mxl_sys::fabrics::MXL_FABRICS_PROVIDER_TCP => Ok(ProviderType::Tcp),
-            mxl_sys::fabrics::MXL_FABRICS_PROVIDER_VERBS => Ok(ProviderType::Verbs),
-            mxl_sys::fabrics::MXL_FABRICS_PROVIDER_EFA => Ok(ProviderType::Efa),
-            mxl_sys::fabrics::MXL_FABRICS_PROVIDER_SHM => Ok(ProviderType::Shm),
+            MXL_FABRICS_PROVIDER_ANY => Ok(ProviderType::Any),
+            MXL_FABRICS_PROVIDER_TCP => Ok(ProviderType::Tcp),
+            MXL_FABRICS_PROVIDER_VERBS => Ok(ProviderType::Verbs),
+            MXL_FABRICS_PROVIDER_EFA => Ok(ProviderType::Efa),
+            MXL_FABRICS_PROVIDER_SHM => Ok(ProviderType::Shm),
             _ => Err(Error::Other("Unknown FabricsProvider value".into())),
         }
     }
 }
 
-impl From<&ProviderType> for mxl_sys::fabrics::FabricsProvider {
+impl From<&ProviderType> for FabricsProvider {
     fn from(value: &ProviderType) -> Self {
         match value {
-            ProviderType::Any => mxl_sys::fabrics::MXL_FABRICS_PROVIDER_ANY,
-            ProviderType::Tcp => mxl_sys::fabrics::MXL_FABRICS_PROVIDER_TCP,
-            ProviderType::Verbs => mxl_sys::fabrics::MXL_FABRICS_PROVIDER_VERBS,
-            ProviderType::Efa => mxl_sys::fabrics::MXL_FABRICS_PROVIDER_EFA,
-            ProviderType::Shm => mxl_sys::fabrics::MXL_FABRICS_PROVIDER_SHM,
+            ProviderType::Any => MXL_FABRICS_PROVIDER_ANY,
+            ProviderType::Tcp => MXL_FABRICS_PROVIDER_TCP,
+            ProviderType::Verbs => MXL_FABRICS_PROVIDER_VERBS,
+            ProviderType::Efa => MXL_FABRICS_PROVIDER_EFA,
+            ProviderType::Shm => MXL_FABRICS_PROVIDER_SHM,
         }
     }
 }
 
-impl From<&Provider> for mxl_sys::fabrics::FabricsProvider {
+impl From<&Provider> for FabricsProvider {
     fn from(value: &Provider) -> Self {
         (&value.inner).into()
     }

--- a/rust/mxl/src/fabrics/provider.rs
+++ b/rust/mxl/src/fabrics/provider.rs
@@ -34,15 +34,16 @@ pub enum ProviderType {
     Shm,
 }
 
-impl From<mxl_sys::fabrics::FabricsProvider> for ProviderType {
-    fn from(value: mxl_sys::fabrics::FabricsProvider) -> Self {
+impl TryFrom<mxl_sys::fabrics::FabricsProvider> for ProviderType {
+    type Error = Error;
+    fn try_from(value: mxl_sys::fabrics::FabricsProvider) -> Result<Self> {
         match value {
-            mxl_sys::fabrics::MXL_FABRICS_PROVIDER_ANY => ProviderType::Any,
-            mxl_sys::fabrics::MXL_FABRICS_PROVIDER_TCP => ProviderType::Tcp,
-            mxl_sys::fabrics::MXL_FABRICS_PROVIDER_VERBS => ProviderType::Verbs,
-            mxl_sys::fabrics::MXL_FABRICS_PROVIDER_EFA => ProviderType::Efa,
-            mxl_sys::fabrics::MXL_FABRICS_PROVIDER_SHM => ProviderType::Shm,
-            _ => panic!("Unknown FabricsProvider value"),
+            mxl_sys::fabrics::MXL_FABRICS_PROVIDER_ANY => Ok(ProviderType::Any),
+            mxl_sys::fabrics::MXL_FABRICS_PROVIDER_TCP => Ok(ProviderType::Tcp),
+            mxl_sys::fabrics::MXL_FABRICS_PROVIDER_VERBS => Ok(ProviderType::Verbs),
+            mxl_sys::fabrics::MXL_FABRICS_PROVIDER_EFA => Ok(ProviderType::Efa),
+            mxl_sys::fabrics::MXL_FABRICS_PROVIDER_SHM => Ok(ProviderType::Shm),
+            _ => Err(Error::Other("Unknown FabricsProvider value".into())),
         }
     }
 }
@@ -66,11 +67,11 @@ impl From<&Provider> for mxl_sys::fabrics::FabricsProvider {
 }
 
 impl Provider {
-    fn new(ctx: Arc<FabricsInstanceContext>, inner: FabricsProvider) -> Self {
-        Self {
-            inner: inner.into(),
+    fn new(ctx: Arc<FabricsInstanceContext>, inner: FabricsProvider) -> Result<Self> {
+        Ok(Self {
+            inner: inner.try_into()?,
             ctx,
-        }
+        })
     }
 
     pub fn prov_type(&self) -> &ProviderType {
@@ -88,7 +89,7 @@ impl Provider {
                 .fabrics_provider_from_string(CString::new(s)?.as_ptr(), &mut inner)
         })?;
 
-        Ok(Self::new(ctx, inner))
+        Self::new(ctx, inner)
     }
 
     /// Convert a fabrics provider enum value to a string.

--- a/rust/mxl/src/fabrics/target/config.rs
+++ b/rust/mxl/src/fabrics/target/config.rs
@@ -36,7 +36,7 @@ impl<'a> TryFrom<&Config<'a>> for mxl_sys::fabrics::FabricsTargetConfig {
             version: value.version,
             endpointAddress: (&value.endpoint_addr).try_into()?,
             provider: (&value.provider).into(),
-            // SAFETY: The type cast is necessary, because this FlowWriter is scoped in mxl_sys::fabrics::*, not mxl_sys::*
+            // SAFETY: The type cast is necessary, because this FlowWriter is scoped in mxl_sys::fabrics::*, not mxl_sys::*, but this is the same type.
             writer: unsafe {
                 std::mem::transmute::<mxl_sys::FlowWriter, mxl_sys::fabrics::FlowWriter>(
                     value.flow_writer.inner(),

--- a/rust/mxl/src/fabrics/target/config.rs
+++ b/rust/mxl/src/fabrics/target/config.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::FlowWriter;
 
 use crate::{

--- a/rust/mxl/src/fabrics/target/config.rs
+++ b/rust/mxl/src/fabrics/target/config.rs
@@ -4,13 +4,13 @@
 use crate::FlowWriter;
 
 use crate::Error;
-use crate::fabrics::InterfaceConfig;
+use crate::fabrics::{InterfaceConfig, interface::config::OwnedInterfaceConfig};
 
 /// Configuration object required to set up a target.
 pub struct Config<'a> {
     version: i32,
     interface: InterfaceConfig<'a>,
-    flow_writer: &'a FlowWriter,
+    pub(crate) flow_writer: &'a FlowWriter,
 }
 
 impl<'a> Config<'a> {
@@ -23,19 +23,27 @@ impl<'a> Config<'a> {
     }
 }
 
-impl<'a> TryFrom<&Config<'a>> for mxl_sys::fabrics::FabricsTargetConfig {
-    type Error = Error;
+pub(crate) struct OwnedTargetConfig {
+    inner: mxl_sys::fabrics::FabricsTargetConfig,
+    _interface: OwnedInterfaceConfig,
+}
 
-    fn try_from(value: &Config) -> Result<Self, Self::Error> {
+impl OwnedTargetConfig {
+    pub(crate) fn new(value: &Config<'_>) -> Result<Self, Error> {
+        let interface = OwnedInterfaceConfig::new(&value.interface)?;
+
         Ok(Self {
-            version: value.version,
-            interface: (&value.interface).try_into()?,
-            // SAFETY: The type cast is necessary, because this FlowWriter is scoped in mxl_sys::fabrics::*, not mxl_sys::*, but this is the same type.
-            writer: unsafe {
-                std::mem::transmute::<mxl_sys::FlowWriter, mxl_sys::fabrics::FlowWriter>(
-                    value.flow_writer.inner(),
-                )
+            inner: mxl_sys::fabrics::FabricsTargetConfig {
+                version: value.version,
+                interface: *interface.as_ffi(),
+                // SAFETY: Both types are equivalent opaque writer handles from different bindgen modules.
+                writer: value.flow_writer.inner().cast(),
             },
+            _interface: interface,
         })
+    }
+
+    pub(crate) fn as_ffi(&self) -> &mxl_sys::fabrics::FabricsTargetConfig {
+        &self.inner
     }
 }

--- a/rust/mxl/src/fabrics/target/config.rs
+++ b/rust/mxl/src/fabrics/target/config.rs
@@ -3,29 +3,21 @@
 
 use crate::FlowWriter;
 
-use crate::{
-    Error,
-    fabrics::{config::EndpointAddress, provider::Provider},
-};
+use crate::Error;
+use crate::fabrics::InterfaceConfig;
 
 /// Configuration object required to set up a target.
 pub struct Config<'a> {
     version: i32,
-    endpoint_addr: EndpointAddress<'a>,
-    provider: Provider,
+    interface: InterfaceConfig<'a>,
     flow_writer: &'a FlowWriter,
 }
 
 impl<'a> Config<'a> {
-    pub fn new(
-        endpoint_addr: EndpointAddress<'a>,
-        provider: Provider,
-        flow_writer: &'a FlowWriter,
-    ) -> Self {
+    pub fn new(interface: InterfaceConfig<'a>, flow_writer: &'a FlowWriter) -> Self {
         Self {
             version: 0,
-            endpoint_addr,
-            provider,
+            interface,
             flow_writer,
         }
     }
@@ -37,8 +29,7 @@ impl<'a> TryFrom<&Config<'a>> for mxl_sys::fabrics::FabricsTargetConfig {
     fn try_from(value: &Config) -> Result<Self, Self::Error> {
         Ok(Self {
             version: value.version,
-            endpointAddress: (&value.endpoint_addr).try_into()?,
-            provider: (&value.provider).into(),
+            interface: (&value.interface).try_into()?,
             // SAFETY: The type cast is necessary, because this FlowWriter is scoped in mxl_sys::fabrics::*, not mxl_sys::*, but this is the same type.
             writer: unsafe {
                 std::mem::transmute::<mxl_sys::FlowWriter, mxl_sys::fabrics::FlowWriter>(

--- a/rust/mxl/src/fabrics/target/config.rs
+++ b/rust/mxl/src/fabrics/target/config.rs
@@ -1,0 +1,47 @@
+use crate::FlowWriter;
+
+use crate::{
+    Error,
+    fabrics::{config::EndpointAddress, provider::Provider},
+};
+
+/// Configuration object required to set up a target.
+pub struct Config<'a> {
+    version: i32,
+    endpoint_addr: EndpointAddress<'a>,
+    provider: Provider,
+    flow_writer: &'a FlowWriter,
+}
+
+impl<'a> Config<'a> {
+    pub fn new(
+        endpoint_addr: EndpointAddress<'a>,
+        provider: Provider,
+        flow_writer: &'a FlowWriter,
+    ) -> Self {
+        Self {
+            version: 0,
+            endpoint_addr,
+            provider,
+            flow_writer,
+        }
+    }
+}
+
+impl<'a> TryFrom<&Config<'a>> for mxl_sys::fabrics::FabricsTargetConfig {
+    type Error = Error;
+
+    fn try_from(value: &Config) -> Result<Self, Self::Error> {
+        Ok(Self {
+            version: value.version,
+            endpointAddress: (&value.endpoint_addr).try_into()?,
+            provider: (&value.provider).into(),
+            // SAFETY: The type cast is necessary, because this FlowWriter is scoped in mxl_sys::fabrics::*, not mxl_sys::*
+            writer: unsafe {
+                std::mem::transmute::<mxl_sys::FlowWriter, mxl_sys::fabrics::FlowWriter>(
+                    value.flow_writer.inner(),
+                )
+            },
+        })
+    }
+}

--- a/rust/mxl/src/fabrics/target/config.rs
+++ b/rust/mxl/src/fabrics/target/config.rs
@@ -3,47 +3,33 @@
 
 use crate::FlowWriter;
 
-use crate::Error;
-use crate::fabrics::{InterfaceConfig, interface::config::OwnedInterfaceConfig};
+use crate::fabrics::InterfaceConfig;
 
 /// Configuration object required to set up a target.
 pub struct Config<'a> {
     version: i32,
-    interface: InterfaceConfig<'a>,
+    interface: InterfaceConfig,
     pub(crate) flow_writer: &'a FlowWriter,
 }
 
 impl<'a> Config<'a> {
-    pub fn new(interface: InterfaceConfig<'a>, flow_writer: &'a FlowWriter) -> Self {
+    pub fn new(interface: InterfaceConfig, flow_writer: &'a FlowWriter) -> Self {
         Self {
-            version: 0,
+            version: mxl_sys::fabrics::MXL_FABRICS_API_VERSION as i32,
             interface,
             flow_writer,
         }
     }
 }
+impl<'a> TryFrom<&Config<'a>> for mxl_sys::fabrics::FabricsTargetConfig {
+    type Error = crate::Error;
 
-pub(crate) struct OwnedTargetConfig {
-    inner: mxl_sys::fabrics::FabricsTargetConfig,
-    _interface: OwnedInterfaceConfig,
-}
-
-impl OwnedTargetConfig {
-    pub(crate) fn new(value: &Config<'_>) -> Result<Self, Error> {
-        let interface = OwnedInterfaceConfig::new(&value.interface)?;
-
+    fn try_from(value: &Config) -> Result<Self, Self::Error> {
         Ok(Self {
-            inner: mxl_sys::fabrics::FabricsTargetConfig {
-                version: value.version,
-                interface: *interface.as_ffi(),
-                // SAFETY: Both types are equivalent opaque writer handles from different bindgen modules.
-                writer: value.flow_writer.inner().cast(),
-            },
-            _interface: interface,
+            version: value.version,
+            interface: mxl_sys::fabrics::FabricsInterfaceConfig::try_from(&value.interface)?,
+            // SAFETY: Both types are equivalent opaque writer handles from different bindgen modules.
+            writer: value.flow_writer.inner().cast(),
         })
-    }
-
-    pub(crate) fn as_ffi(&self) -> &mxl_sys::fabrics::FabricsTargetConfig {
-        &self.inner
     }
 }

--- a/rust/mxl/src/fabrics/target/config.rs
+++ b/rust/mxl/src/fabrics/target/config.rs
@@ -4,6 +4,7 @@
 use crate::FlowWriter;
 
 use crate::fabrics::InterfaceConfig;
+use mxl_sys::types::{FabricsInterfaceConfig, FabricsTargetConfig, MXL_FABRICS_API_VERSION};
 
 /// Configuration object required to set up a target.
 pub struct Config<'a> {
@@ -15,21 +16,20 @@ pub struct Config<'a> {
 impl<'a> Config<'a> {
     pub fn new(interface: InterfaceConfig, flow_writer: &'a FlowWriter) -> Self {
         Self {
-            version: mxl_sys::fabrics::MXL_FABRICS_API_VERSION as i32,
+            version: MXL_FABRICS_API_VERSION as i32,
             interface,
             flow_writer,
         }
     }
 }
-impl<'a> TryFrom<&Config<'a>> for mxl_sys::fabrics::FabricsTargetConfig {
+impl<'a> TryFrom<&Config<'a>> for FabricsTargetConfig {
     type Error = crate::Error;
 
     fn try_from(value: &Config) -> Result<Self, Self::Error> {
         Ok(Self {
             version: value.version,
-            interface: mxl_sys::fabrics::FabricsInterfaceConfig::try_from(&value.interface)?,
-            // SAFETY: Both types are equivalent opaque writer handles from different bindgen modules.
-            writer: value.flow_writer.inner().cast(),
+            interface: FabricsInterfaceConfig::try_from(&value.interface)?,
+            writer: value.flow_writer.inner(),
         })
     }
 }

--- a/rust/mxl/src/fabrics/target/grain.rs
+++ b/rust/mxl/src/fabrics/target/grain.rs
@@ -5,7 +5,7 @@
 //
 use crate::{
     Error, Result,
-    fabrics::{target::Target, target::states::Grain},
+    fabrics::target::{Target, states::Grain},
 };
 use std::time::Duration;
 
@@ -21,7 +21,7 @@ impl Target<Grain> {
         Error::from_status(unsafe {
             self.instance.ctx.api().fabrics_target_read_grain(
                 self.instance.inner,
-                timeout.as_millis() as u16,
+                u16::try_from(timeout.as_millis()).map_err(|_| Error::InvalidArg)?,
                 &mut grain_index,
             )
         })?;

--- a/rust/mxl/src/fabrics/target/grain.rs
+++ b/rust/mxl/src/fabrics/target/grain.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: Apache-2.0
+
 // use std::time::Duration;
 //
 use crate::{

--- a/rust/mxl/src/fabrics/target/grain.rs
+++ b/rust/mxl/src/fabrics/target/grain.rs
@@ -12,7 +12,7 @@ pub struct GrainReadResult {
 }
 
 impl Target<Grain> {
-    ///Blocking accessor for a new grain.
+    /// Blocking accessor for a new grain.
     pub fn read(&self, timeout: Duration) -> Result<GrainReadResult> {
         let mut grain_index = 0;
         Error::from_status(unsafe {

--- a/rust/mxl/src/fabrics/target/grain.rs
+++ b/rust/mxl/src/fabrics/target/grain.rs
@@ -1,0 +1,39 @@
+// use std::time::Duration;
+//
+use crate::{
+    Error, Result,
+    fabrics::{target::Target, target::states::Grain},
+};
+use std::time::Duration;
+
+/// Returned value from calling read* methods.
+pub struct GrainReadResult {
+    pub grain_index: u64,
+}
+
+impl Target<Grain> {
+    ///Blocking accessor for a new grain.
+    pub fn read(&self, timeout: Duration) -> Result<GrainReadResult> {
+        let mut grain_index = 0;
+        Error::from_status(unsafe {
+            self.instance.ctx.api().fabrics_target_read_grain(
+                self.instance.inner,
+                timeout.as_millis() as u16,
+                &mut grain_index,
+            )
+        })?;
+        Ok(GrainReadResult { grain_index })
+    }
+
+    /// Non-blocking accessor for a new grain.
+    pub fn read_non_blocking(&self) -> Result<GrainReadResult> {
+        let mut grain_index = 0;
+        Error::from_status(unsafe {
+            self.instance
+                .ctx
+                .api()
+                .fabrics_target_read_grain_non_blocking(self.instance.inner, &mut grain_index)
+        })?;
+        Ok(GrainReadResult { grain_index })
+    }
+}

--- a/rust/mxl/src/fabrics/target/mod.rs
+++ b/rust/mxl/src/fabrics/target/mod.rs
@@ -10,7 +10,10 @@ use std::{marker::PhantomData, sync::Arc};
 use crate::{
     FlowConfigInfo,
     error::{Error, Result},
-    fabrics::{instance::FabricsInstanceContext, target_info::TargetInfo},
+    fabrics::{
+        instance::FabricsInstanceContext, target::config::OwnedTargetConfig,
+        target_info::TargetInfo,
+    },
 };
 pub use config::Config;
 
@@ -93,10 +96,11 @@ impl Target<Initializing> {
     /// setup(), but be deferred until the first call to mxlFabricsTargetTryNewGrain().
     pub fn setup(self, config: &Config) -> Result<(Target<Specializing>, TargetInfo)> {
         let mut info = mxl_sys::fabrics::FabricsTargetInfo::default();
+        let config = OwnedTargetConfig::new(config)?;
         Error::from_status(unsafe {
             self.instance.ctx.api().fabrics_target_setup(
                 self.instance.inner,
-                &config.try_into()?,
+                config.as_ffi(),
                 std::ptr::null(),
                 &mut info,
             )

--- a/rust/mxl/src/fabrics/target/mod.rs
+++ b/rust/mxl/src/fabrics/target/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: Apache-2.0
+
 mod config;
 mod grain;
 mod samples;

--- a/rust/mxl/src/fabrics/target/mod.rs
+++ b/rust/mxl/src/fabrics/target/mod.rs
@@ -2,7 +2,7 @@ mod config;
 mod grain;
 mod samples;
 
-use std::{marker::PhantomData, rc::Rc};
+use std::{marker::PhantomData, sync::Arc};
 
 use crate::{
     FlowConfigInfo,
@@ -42,9 +42,10 @@ pub mod states {
 /// Wrapper class that holds a reference count to the Fabrics Instance and the actual target
 /// instance.
 pub struct TargetInstance {
-    ctx: Rc<FabricsInstanceContext>,
+    ctx: Arc<FabricsInstanceContext>,
     inner: mxl_sys::fabrics::FabricsTarget,
 }
+unsafe impl Send for TargetInstance {}
 
 impl Drop for TargetInstance {
     fn drop(&mut self) {
@@ -62,6 +63,9 @@ pub struct Target<S: TargetState> {
     instance: TargetInstance,
     _marker: PhantomData<S>,
 }
+//SAFETY: A target is safe to be sent across threads, but it's not thread-safe to use its API functions.
+unsafe impl<S: TargetState> Send for Target<S> {}
+
 pub enum Either {
     Grain(Target<Grain>),
     Sample(Target<Sample>),
@@ -69,7 +73,7 @@ pub enum Either {
 
 impl Target<New> {
     pub(crate) fn new(
-        ctx: Rc<FabricsInstanceContext>,
+        ctx: Arc<FabricsInstanceContext>,
         target: mxl_sys::fabrics::FabricsTarget,
     ) -> Target<Initializing> {
         let instance = TargetInstance { ctx, inner: target };
@@ -126,7 +130,7 @@ impl Target<Specializing> {
 
 /// Create a new target.
 #[doc(hidden)]
-pub(crate) fn create_target(ctx: &Rc<FabricsInstanceContext>) -> Result<Target<Initializing>> {
+pub(crate) fn create_target(ctx: Arc<FabricsInstanceContext>) -> Result<Target<Initializing>> {
     let mut target = mxl_sys::fabrics::FabricsTarget::default();
     unsafe {
         Error::from_status(ctx.api().fabrics_create_target(ctx.inner, &mut target))?;

--- a/rust/mxl/src/fabrics/target/mod.rs
+++ b/rust/mxl/src/fabrics/target/mod.rs
@@ -1,0 +1,139 @@
+mod config;
+mod grain;
+mod samples;
+
+use std::{marker::PhantomData, rc::Rc};
+
+use crate::{
+    FlowConfigInfo,
+    error::{Error, Result},
+    fabrics::{instance::FabricsInstanceContext, target_info::TargetInfo},
+};
+pub use config::Config;
+
+use states::*;
+
+pub mod states {
+    /// Used to create a new target
+    pub struct New {}
+
+    /// Waiting for the target to be initialized with the setup function
+    pub struct Initializing {}
+
+    /// The setup function has been called, but the target has not yet been specialized into a
+    /// grain or samples target
+    pub struct Specializing {}
+
+    /// The target has been specialized into a grain target. It can only receive grains
+    pub struct Grain {}
+
+    /// The target has been specialized into a samples target. It can only receive samples
+    pub struct Sample {}
+
+    impl TargetState for New {}
+    impl TargetState for Initializing {}
+    impl TargetState for Specializing {}
+    impl TargetState for Grain {}
+    impl TargetState for Sample {}
+
+    pub trait TargetState {}
+}
+
+/// Wrapper class that holds a reference count to the Fabrics Instance and the actual target
+/// instance.
+pub struct TargetInstance {
+    ctx: Rc<FabricsInstanceContext>,
+    inner: mxl_sys::fabrics::FabricsTarget,
+}
+
+impl Drop for TargetInstance {
+    fn drop(&mut self) {
+        if !self.inner.is_null() {
+            unsafe {
+                self.ctx
+                    .api()
+                    .fabrics_destroy_target(self.ctx.inner, self.inner);
+            }
+        }
+    }
+}
+
+pub struct Target<S: TargetState> {
+    instance: TargetInstance,
+    _marker: PhantomData<S>,
+}
+pub enum Either {
+    Grain(Target<Grain>),
+    Sample(Target<Sample>),
+}
+
+impl Target<New> {
+    pub(crate) fn new(
+        ctx: Rc<FabricsInstanceContext>,
+        target: mxl_sys::fabrics::FabricsTarget,
+    ) -> Target<Initializing> {
+        let instance = TargetInstance { ctx, inner: target };
+        Target {
+            instance,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl Target<Initializing> {
+    /// Configure the target. After the target has been configured, it is ready to receive transfers from an initiator.
+    /// If additional connection setup is required by the underlying implementation it might not happen during the call to
+    /// setup(), but be deferred until the first call to mxlFabricsTargetTryNewGrain().
+    pub fn setup(self, config: &Config) -> Result<(Target<Specializing>, TargetInfo)> {
+        let mut info = mxl_sys::fabrics::FabricsTargetInfo::default();
+        Error::from_status(unsafe {
+            self.instance.ctx.api().fabrics_target_setup(
+                self.instance.inner,
+                &config.try_into()?,
+                std::ptr::null(),
+                &mut info,
+            )
+        })?;
+
+        let ctx = self.instance.ctx.clone();
+
+        Ok((
+            Target {
+                instance: self.instance,
+                _marker: PhantomData,
+            },
+            TargetInfo::new(ctx, info),
+        ))
+    }
+}
+
+impl Target<Specializing> {
+    /// Specialize the target into a concrete grain or samples target
+    pub fn specialize(self, flow_config: &FlowConfigInfo) -> Either {
+        if flow_config.is_discrete_flow() {
+            Either::Grain(Target {
+                instance: self.instance,
+                _marker: PhantomData,
+            })
+        } else {
+            Either::Sample(Target {
+                instance: self.instance,
+                _marker: PhantomData,
+            })
+        }
+    }
+}
+
+/// Create a new target.
+#[doc(hidden)]
+pub(crate) fn create_target(ctx: &Rc<FabricsInstanceContext>) -> Result<Target<Initializing>> {
+    let mut target = mxl_sys::fabrics::FabricsTarget::default();
+    unsafe {
+        Error::from_status(ctx.api().fabrics_create_target(ctx.inner, &mut target))?;
+    }
+    if target.is_null() {
+        return Err(Error::Other("Failed to create fabrics target.".to_string()));
+    }
+
+    Ok(Target::new(ctx.clone(), target))
+}

--- a/rust/mxl/src/fabrics/target/mod.rs
+++ b/rust/mxl/src/fabrics/target/mod.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 pub use config::Config;
 
-use mxl_sys::fabrics::FabricsTargetConfig;
+use mxl_sys::types::{FabricsTarget, FabricsTargetConfig, FabricsTargetInfo};
 use states::*;
 
 pub mod states {
@@ -42,7 +42,7 @@ pub mod states {
 /// instance.
 pub struct TargetInstance {
     ctx: Arc<FabricsInstanceContext>,
-    inner: mxl_sys::fabrics::FabricsTarget,
+    inner: FabricsTarget,
 }
 unsafe impl Send for TargetInstance {}
 
@@ -73,7 +73,7 @@ pub enum TargetFlavor {
 impl Target<New> {
     pub(crate) fn new(
         ctx: Arc<FabricsInstanceContext>,
-        target: mxl_sys::fabrics::FabricsTarget,
+        target: FabricsTarget,
     ) -> Target<Initializing> {
         let instance = TargetInstance { ctx, inner: target };
         Target {
@@ -92,7 +92,7 @@ impl Target<Initializing> {
         config: &Config,
         flow_config_info: &FlowConfigInfo,
     ) -> Result<(TargetFlavor, TargetInfo)> {
-        let mut info = mxl_sys::fabrics::FabricsTargetInfo::default();
+        let mut info = FabricsTargetInfo::default();
         let target_config = FabricsTargetConfig::try_from(config)?;
         Error::from_status(unsafe {
             self.instance.ctx.api().fabrics_target_setup(
@@ -129,7 +129,7 @@ impl Target<Initializing> {
 /// Create a new target.
 #[doc(hidden)]
 pub(crate) fn create_target(ctx: Arc<FabricsInstanceContext>) -> Result<Target<Initializing>> {
-    let mut target = mxl_sys::fabrics::FabricsTarget::default();
+    let mut target = FabricsTarget::default();
     unsafe {
         Error::from_status(ctx.api().fabrics_create_target(ctx.inner, &mut target))?;
     }

--- a/rust/mxl/src/fabrics/target/mod.rs
+++ b/rust/mxl/src/fabrics/target/mod.rs
@@ -10,13 +10,11 @@ use std::{marker::PhantomData, sync::Arc};
 use crate::{
     FlowConfigInfo,
     error::{Error, Result},
-    fabrics::{
-        instance::FabricsInstanceContext, target::config::OwnedTargetConfig,
-        target_info::TargetInfo,
-    },
+    fabrics::{instance::FabricsInstanceContext, target_info::TargetInfo},
 };
 pub use config::Config;
 
+use mxl_sys::fabrics::FabricsTargetConfig;
 use states::*;
 
 pub mod states {
@@ -26,21 +24,16 @@ pub mod states {
     /// Waiting for the target to be initialized with the setup function
     pub struct Initializing {}
 
-    /// The setup function has been called, but the target has not yet been specialized into a
-    /// grain or samples target
-    pub struct Specializing {}
-
     /// The target has been specialized into a grain target. It can only receive grains
     pub struct Grain {}
 
     /// The target has been specialized into a samples target. It can only receive samples
-    pub struct Sample {}
+    pub struct Samples {}
 
     impl TargetState for New {}
     impl TargetState for Initializing {}
-    impl TargetState for Specializing {}
     impl TargetState for Grain {}
-    impl TargetState for Sample {}
+    impl TargetState for Samples {}
 
     pub trait TargetState {}
 }
@@ -72,9 +65,9 @@ pub struct Target<S: TargetState> {
 //SAFETY: A target is safe to be sent across threads, but it's not thread-safe to use its API functions.
 unsafe impl<S: TargetState> Send for Target<S> {}
 
-pub enum Either {
+pub enum TargetFlavor {
     Grain(Target<Grain>),
-    Sample(Target<Sample>),
+    Sample(Target<Samples>),
 }
 
 impl Target<New> {
@@ -94,13 +87,18 @@ impl Target<Initializing> {
     /// Configure the target. After the target has been configured, it is ready to receive transfers from an initiator.
     /// If additional connection setup is required by the underlying implementation it might not happen during the call to
     /// setup(), but be deferred until the first call to mxlFabricsTargetTryNewGrain().
-    pub fn setup(self, config: &Config) -> Result<(Target<Specializing>, TargetInfo)> {
+    pub fn setup(
+        self,
+        config: &Config,
+        flow_config_info: &FlowConfigInfo,
+    ) -> Result<(TargetFlavor, TargetInfo)> {
         let mut info = mxl_sys::fabrics::FabricsTargetInfo::default();
-        let config = OwnedTargetConfig::new(config)?;
+        let target_config = FabricsTargetConfig::try_from(config)?;
         Error::from_status(unsafe {
             self.instance.ctx.api().fabrics_target_setup(
                 self.instance.inner,
-                config.as_ffi(),
+                // Pointer does not need to outlive the call, so we can safely pass a pointer to the stack variable.
+                &target_config as *const _,
                 std::ptr::null(),
                 &mut info,
             )
@@ -108,29 +106,22 @@ impl Target<Initializing> {
 
         let ctx = self.instance.ctx.clone();
 
-        Ok((
-            Target {
-                instance: self.instance,
-                _marker: PhantomData,
-            },
-            TargetInfo::new(ctx, info),
-        ))
-    }
-}
-
-impl Target<Specializing> {
-    /// Specialize the target into a concrete grain or samples target
-    pub fn specialize(self, flow_config: &FlowConfigInfo) -> Either {
-        if flow_config.is_discrete_flow() {
-            Either::Grain(Target {
-                instance: self.instance,
-                _marker: PhantomData,
-            })
+        if flow_config_info.is_discrete_flow() {
+            Ok((
+                TargetFlavor::Grain(Target {
+                    instance: self.instance,
+                    _marker: PhantomData,
+                }),
+                TargetInfo::new(ctx, info),
+            ))
         } else {
-            Either::Sample(Target {
-                instance: self.instance,
-                _marker: PhantomData,
-            })
+            Ok((
+                TargetFlavor::Sample(Target {
+                    instance: self.instance,
+                    _marker: PhantomData,
+                }),
+                TargetInfo::new(ctx, info),
+            ))
         }
     }
 }

--- a/rust/mxl/src/fabrics/target/mod.rs
+++ b/rust/mxl/src/fabrics/target/mod.rs
@@ -67,7 +67,7 @@ unsafe impl<S: TargetState> Send for Target<S> {}
 
 pub enum TargetFlavor {
     Grain(Target<Grain>),
-    Sample(Target<Samples>),
+    Samples(Target<Samples>),
 }
 
 impl Target<New> {
@@ -116,7 +116,7 @@ impl Target<Initializing> {
             ))
         } else {
             Ok((
-                TargetFlavor::Sample(Target {
+                TargetFlavor::Samples(Target {
                     instance: self.instance,
                     _marker: PhantomData,
                 }),

--- a/rust/mxl/src/fabrics/target/samples.rs
+++ b/rust/mxl/src/fabrics/target/samples.rs
@@ -22,7 +22,7 @@ impl Target<Sample> {
         Error::from_status(unsafe {
             self.instance.ctx.api().fabrics_target_read_samples(
                 self.instance.inner,
-                timeout.as_millis() as u16,
+                u16::try_from(timeout.as_millis()).map_err(|_| Error::InvalidArg)?,
                 &mut head_index,
                 &mut count,
             )

--- a/rust/mxl/src/fabrics/target/samples.rs
+++ b/rust/mxl/src/fabrics/target/samples.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::time::Duration;
 
 use crate::{

--- a/rust/mxl/src/fabrics/target/samples.rs
+++ b/rust/mxl/src/fabrics/target/samples.rs
@@ -1,0 +1,45 @@
+use std::time::Duration;
+
+use crate::{
+    Error,
+    error::Result,
+    fabrics::target::{Target, states::Sample},
+};
+
+pub struct SampleReadResult {
+    pub head_index: u64,
+    pub count: usize,
+}
+
+impl Target<Sample> {
+    ///Blocking accessor for a new grain.
+    pub fn read(&self, timeout: Duration) -> Result<SampleReadResult> {
+        let mut head_index = 0;
+        let mut count = 0;
+        Error::from_status(unsafe {
+            self.instance.ctx.api().fabrics_target_read_samples(
+                self.instance.inner,
+                timeout.as_millis() as u16,
+                &mut head_index,
+                &mut count,
+            )
+        })?;
+        Ok(SampleReadResult { head_index, count })
+    }
+    /// Non-blocking accessor for a new grain.
+    pub fn read_non_blocking(&self) -> Result<SampleReadResult> {
+        let mut head_index = 0;
+        let mut count = 0;
+        Error::from_status(unsafe {
+            self.instance
+                .ctx
+                .api()
+                .fabrics_target_read_samples_non_blocking(
+                    self.instance.inner,
+                    &mut head_index,
+                    &mut count,
+                )
+        })?;
+        Ok(SampleReadResult { head_index, count })
+    }
+}

--- a/rust/mxl/src/fabrics/target/samples.rs
+++ b/rust/mxl/src/fabrics/target/samples.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use crate::{
     Error,
     error::Result,
-    fabrics::target::{Target, states::Sample},
+    fabrics::target::{Target, states::Samples},
 };
 
 pub struct SampleReadResult {
@@ -14,8 +14,8 @@ pub struct SampleReadResult {
     pub count: usize,
 }
 
-impl Target<Sample> {
-    ///Blocking accessor for a new grain.
+impl Target<Samples> {
+    ///Blocking accessor for new samples.
     pub fn read(&self, timeout: Duration) -> Result<SampleReadResult> {
         let mut head_index = 0;
         let mut count = 0;
@@ -29,7 +29,7 @@ impl Target<Sample> {
         })?;
         Ok(SampleReadResult { head_index, count })
     }
-    /// Non-blocking accessor for a new grain.
+    /// Non-blocking accessor for new samples.
     pub fn read_non_blocking(&self) -> Result<SampleReadResult> {
         let mut head_index = 0;
         let mut count = 0;

--- a/rust/mxl/src/fabrics/target_info.rs
+++ b/rust/mxl/src/fabrics/target_info.rs
@@ -48,18 +48,17 @@ impl TargetInfo {
             )
         })?;
 
-        // The size returned by `fabrics_target_info_to_string` previous call already includes space for null terminator.
-        // Since CString ctor also includes the null terminated character, we must take the size minus 1.
-        let out_string = unsafe { CString::from_vec_unchecked(vec![0; size - 1]) };
-
+        let mut out_string = vec![0u8; size];
         Error::from_status(unsafe {
             self.ctx.api().fabrics_target_info_to_string(
                 self.inner,
-                out_string.as_ptr() as *mut i8,
+                out_string.as_mut_ptr() as *mut i8,
                 &mut size,
             )
         })?;
-        out_string
+
+        CString::from_vec_with_nul(out_string)
+            .map_err(|e| Error::Other(e.to_string()))?
             .into_string()
             .map_err(|e| Error::Other(e.to_string()))
     }

--- a/rust/mxl/src/fabrics/target_info.rs
+++ b/rust/mxl/src/fabrics/target_info.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::{ffi::CString, sync::Arc};
 
 use crate::error::{Error, Result};

--- a/rust/mxl/src/fabrics/target_info.rs
+++ b/rust/mxl/src/fabrics/target_info.rs
@@ -1,0 +1,68 @@
+use std::{ffi::CString, rc::Rc};
+
+use crate::error::{Error, Result};
+use mxl_sys::fabrics::FabricsTargetInfo;
+
+use crate::fabrics::instance::FabricsInstanceContext;
+
+/// The TargetInfo object holds the local fabric address, keys and memory region addresses for a target.
+/// It is returned after setting up a new target and must be passed to the initiator to connect it.
+pub struct TargetInfo {
+    ctx: Rc<FabricsInstanceContext>,
+    pub(crate) inner: FabricsTargetInfo,
+}
+
+impl TargetInfo {
+    pub(crate) fn new(ctx: Rc<FabricsInstanceContext>, inner: FabricsTargetInfo) -> Self {
+        Self { ctx, inner }
+    }
+
+    /// Parse a targetInfo object from its string representation.
+    /// Public visibility is set to crate only, because a `FabricsInstanceContext` is required.
+    /// See [FabricsInstance](crate::FabricsInstance).
+    pub(crate) fn from_str(ctx: Rc<FabricsInstanceContext>, s: &str) -> Result<Self> {
+        let mut inner = FabricsTargetInfo::default();
+
+        Error::from_status(unsafe {
+            ctx.api()
+                .fabrics_target_info_from_string(CString::new(s)?.as_ptr(), &mut inner)
+        })?;
+
+        Ok(Self::new(ctx, inner))
+    }
+
+    /// Serialize a target info object obtained from mxlFabricsTargetSetup() into a string representation.
+    pub fn to_string(&self) -> Result<String> {
+        let mut size = 0;
+        Error::from_status(unsafe {
+            self.ctx.api().fabrics_target_info_to_string(
+                self.inner,
+                std::ptr::null_mut(),
+                &mut size,
+            )
+        })?;
+
+        // The size returned by `fabrics_target_info_to_string` previous call already includes space for null terminator.
+        // Since CString ctor also includes the null terminated character, we must take the size minus 1.
+        let out_string = unsafe { CString::from_vec_unchecked(vec![0; size - 1]) };
+
+        Error::from_status(unsafe {
+            self.ctx.api().fabrics_target_info_to_string(
+                self.inner,
+                out_string.as_ptr() as *mut i8,
+                &mut size,
+            )
+        })?;
+        out_string
+            .into_string()
+            .map_err(|e| Error::Other(e.to_string()))
+    }
+}
+
+impl Drop for TargetInfo {
+    fn drop(&mut self) {
+        if !self.inner.is_null() {
+            unsafe { self.ctx.api().fabrics_free_target_info(self.inner) };
+        }
+    }
+}

--- a/rust/mxl/src/fabrics/target_info.rs
+++ b/rust/mxl/src/fabrics/target_info.rs
@@ -1,4 +1,4 @@
-use std::{ffi::CString, rc::Rc};
+use std::{ffi::CString, sync::Arc};
 
 use crate::error::{Error, Result};
 use mxl_sys::fabrics::FabricsTargetInfo;
@@ -8,19 +8,22 @@ use crate::fabrics::instance::FabricsInstanceContext;
 /// The TargetInfo object holds the local fabric address, keys and memory region addresses for a target.
 /// It is returned after setting up a new target and must be passed to the initiator to connect it.
 pub struct TargetInfo {
-    ctx: Rc<FabricsInstanceContext>,
+    ctx: Arc<FabricsInstanceContext>,
     pub(crate) inner: FabricsTargetInfo,
 }
+unsafe impl Send for TargetInfo {}
+/// SAFETY: Although the `FabricsInstanceContext` type as a whole is not thread-safe, the subset of functions that this `TargetInfo` type uses is thread-safe: `fabrics_target_info_from_string` and `fabrics_target_info_to_string`
+unsafe impl Sync for TargetInfo {}
 
 impl TargetInfo {
-    pub(crate) fn new(ctx: Rc<FabricsInstanceContext>, inner: FabricsTargetInfo) -> Self {
+    pub(crate) fn new(ctx: Arc<FabricsInstanceContext>, inner: FabricsTargetInfo) -> Self {
         Self { ctx, inner }
     }
 
     /// Parse a targetInfo object from its string representation.
     /// Public visibility is set to crate only, because a `FabricsInstanceContext` is required.
     /// See [FabricsInstance](crate::FabricsInstance).
-    pub(crate) fn from_str(ctx: Rc<FabricsInstanceContext>, s: &str) -> Result<Self> {
+    pub(crate) fn from_str(ctx: Arc<FabricsInstanceContext>, s: &str) -> Result<Self> {
         let mut inner = FabricsTargetInfo::default();
 
         Error::from_status(unsafe {

--- a/rust/mxl/src/fabrics/target_info.rs
+++ b/rust/mxl/src/fabrics/target_info.rs
@@ -4,7 +4,7 @@
 use std::{ffi::CString, sync::Arc};
 
 use crate::error::{Error, Result};
-use mxl_sys::fabrics::FabricsTargetInfo;
+use mxl_sys::types::FabricsTargetInfo;
 
 use crate::fabrics::instance::FabricsInstanceContext;
 

--- a/rust/mxl/src/flow/reader.rs
+++ b/rust/mxl/src/flow/reader.rs
@@ -71,6 +71,10 @@ impl FlowReader {
         Self { context, reader }
     }
 
+    pub(crate) fn inner(&self) -> mxl_sys::FlowReader {
+        self.reader
+    }
+
     pub fn get_info(&self) -> Result<FlowInfo> {
         get_flow_info(&self.context, self.reader)
     }

--- a/rust/mxl/src/flow/reader.rs
+++ b/rust/mxl/src/flow/reader.rs
@@ -71,6 +71,7 @@ impl FlowReader {
         Self { context, reader }
     }
 
+    #[allow(dead_code)]
     pub(crate) fn inner(&self) -> mxl_sys::FlowReader {
         self.reader
     }

--- a/rust/mxl/src/flow/reader.rs
+++ b/rust/mxl/src/flow/reader.rs
@@ -71,7 +71,7 @@ impl FlowReader {
         Self { context, reader }
     }
 
-    #[allow(dead_code)]
+    #[cfg(feature = "mxl-fabrics-ofi")]
     pub(crate) fn inner(&self) -> mxl_sys::FlowReader {
         self.reader
     }

--- a/rust/mxl/src/flow/writer.rs
+++ b/rust/mxl/src/flow/writer.rs
@@ -34,6 +34,10 @@ impl FlowWriter {
         }
     }
 
+    pub(crate) fn inner(&self) -> mxl_sys::FlowWriter {
+        self.writer
+    }
+
     pub fn to_grain_writer(mut self) -> Result<GrainWriter> {
         let flow_type = self.get_flow_type()?;
         if !is_discrete_data_format(flow_type) {

--- a/rust/mxl/src/flow/writer.rs
+++ b/rust/mxl/src/flow/writer.rs
@@ -34,6 +34,7 @@ impl FlowWriter {
         }
     }
 
+    #[allow(dead_code)]
     pub(crate) fn inner(&self) -> mxl_sys::FlowWriter {
         self.writer
     }

--- a/rust/mxl/src/flow/writer.rs
+++ b/rust/mxl/src/flow/writer.rs
@@ -34,7 +34,7 @@ impl FlowWriter {
         }
     }
 
-    #[allow(dead_code)]
+    #[cfg(feature = "mxl-fabrics-ofi")]
     pub(crate) fn inner(&self) -> mxl_sys::FlowWriter {
         self.writer
     }

--- a/rust/mxl/src/grain/data.rs
+++ b/rust/mxl/src/grain/data.rs
@@ -16,6 +16,10 @@ pub struct GrainData<'a> {
     /// index means `R` has not been produced yet, a newer one means the writer
     /// lapped the reader and `R` was evicted.
     pub index: u64,
+
+    /// The number of slices in the full grain. This is does not change depending on whether the
+    /// grain is partial or complete.
+    pub total_slices: u16,
 }
 
 impl<'a> GrainData<'a> {

--- a/rust/mxl/src/grain/reader.rs
+++ b/rust/mxl/src/grain/reader.rs
@@ -85,6 +85,7 @@ impl GrainReader {
             total_size: grain_info.grainSize as usize,
             flags: grain_info.flags,
             index: grain_info.index,
+            total_slices: grain_info.totalSlices,
         })
     }
 
@@ -119,6 +120,7 @@ impl GrainReader {
             total_size: grain_info.grainSize as usize,
             flags: grain_info.flags,
             index: grain_info.index,
+            total_slices: grain_info.totalSlices,
         })
     }
 

--- a/rust/mxl/src/grain/write_access.rs
+++ b/rust/mxl/src/grain/write_access.rs
@@ -50,6 +50,9 @@ impl<'a> GrainWriteAccess<'a> {
     pub fn total_slices(&self) -> u16 {
         self.grain_info.totalSlices
     }
+    pub fn valid_slices(&self) -> u16 {
+        self.grain_info.validSlices
+    }
 
     pub fn commit(mut self, valid_slices: u16) -> Result<()> {
         self.committed_or_canceled = true;

--- a/rust/mxl/src/instance.rs
+++ b/rust/mxl/src/instance.rs
@@ -3,6 +3,8 @@
 
 use std::{ffi::CString, sync::Arc};
 
+#[cfg(feature = "mxl-fabrics-ofi")]
+use crate::api::MxlFabricsAPiHandle;
 use crate::{Error, FlowConfigInfo, FlowReader, FlowWriter, Result, api::MxlApiHandle};
 
 /// This struct stores the context that is shared by all objects.
@@ -239,5 +241,15 @@ impl MxlInstance {
         let context = Arc::into_inner(self.context)
             .ok_or_else(|| Error::Other("Instance is still in use.".to_string()))?;
         context.destroy()
+    }
+
+    #[cfg(feature = "mxl-fabrics-ofi")]
+    pub fn create_fabrics_instance(
+        &self,
+        fabrics_api: &MxlFabricsAPiHandle,
+    ) -> Result<crate::fabrics::FabricsInstance> {
+        use crate::fabrics;
+
+        fabrics::create_instance(&self.context, fabrics_api)
     }
 }

--- a/rust/mxl/src/instance.rs
+++ b/rust/mxl/src/instance.rs
@@ -250,6 +250,6 @@ impl MxlInstance {
     ) -> Result<crate::fabrics::FabricsInstance> {
         use crate::fabrics;
 
-        fabrics::create_instance(&self.context, fabrics_api)
+        fabrics::create_instance(self.context.clone(), fabrics_api)
     }
 }

--- a/rust/mxl/src/instance.rs
+++ b/rust/mxl/src/instance.rs
@@ -4,7 +4,7 @@
 use std::{ffi::CString, sync::Arc};
 
 #[cfg(feature = "mxl-fabrics-ofi")]
-use crate::api::MxlFabricsAPiHandle;
+use crate::api::MxlFabricsApiHandle;
 use crate::{Error, FlowConfigInfo, FlowReader, FlowWriter, Result, api::MxlApiHandle};
 
 /// This struct stores the context that is shared by all objects.
@@ -246,7 +246,7 @@ impl MxlInstance {
     #[cfg(feature = "mxl-fabrics-ofi")]
     pub fn create_fabrics_instance(
         &self,
-        fabrics_api: &MxlFabricsAPiHandle,
+        fabrics_api: &MxlFabricsApiHandle,
     ) -> Result<crate::fabrics::FabricsInstance> {
         use crate::fabrics;
 

--- a/rust/mxl/src/lib.rs
+++ b/rust/mxl/src/lib.rs
@@ -22,3 +22,8 @@ pub use mxl_sys::Rational;
 pub use samples::{
     data::*, reader::SamplesReader, write_access::SamplesWriteAccess, writer::SamplesWriter,
 };
+
+#[cfg(feature = "mxl-fabrics-ofi")]
+pub mod fabrics;
+#[cfg(feature = "mxl-fabrics-ofi")]
+pub use api::{MxlFabricsApi, load_fabrics_api};

--- a/rust/mxl/tests/basic_tests.rs
+++ b/rust/mxl/tests/basic_tests.rs
@@ -5,83 +5,13 @@
 ///
 /// The tests now require an MXL library of a specific name to be present in the system. This should
 /// change in the future. For now, feel free to just edit the path to your library.
+mod common;
+
 use std::time::Duration;
 
-use mxl::{MxlInstance, OwnedGrainData, OwnedSamplesData, config::get_mxl_so_path};
+use common::{read_flow_def, setup_test};
+use mxl::{OwnedGrainData, OwnedSamplesData};
 use tracing::info;
-
-static LOG_ONCE: std::sync::Once = std::sync::Once::new();
-
-struct TestDomainGuard {
-    dir: std::path::PathBuf,
-}
-
-impl TestDomainGuard {
-    fn new(test: &str) -> Self {
-        let dir = std::path::PathBuf::from(format!(
-            "/dev/shm/mxl_rust_unit_tests_domain_{}_{}",
-            test,
-            uuid::Uuid::new_v4()
-        ));
-        std::fs::create_dir_all(dir.as_path()).unwrap_or_else(|_| {
-            panic!(
-                "Failed to create test domain directory \"{}\".",
-                dir.display()
-            )
-        });
-        Self { dir }
-    }
-
-    fn domain(&self) -> String {
-        self.dir.to_string_lossy().to_string()
-    }
-}
-
-impl Drop for TestDomainGuard {
-    fn drop(&mut self) {
-        std::fs::remove_dir_all(self.dir.as_path()).unwrap_or_else(|_| {
-            panic!(
-                "Failed to remove test domain directory \"{}\".",
-                self.dir.display()
-            )
-        });
-    }
-}
-
-fn setup_test(test: &str) -> (MxlInstance, TestDomainGuard) {
-    // Set up the logging to use the RUST_LOG environment variable and if not present, print INFO
-    // and higher.
-    LOG_ONCE.call_once(|| {
-        tracing_subscriber::fmt()
-            .with_env_filter(
-                tracing_subscriber::EnvFilter::builder()
-                    .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
-                    .from_env_lossy(),
-            )
-            .init();
-    });
-
-    let mxl_api = mxl::load_api(get_mxl_so_path()).unwrap();
-    let domain_guard = TestDomainGuard::new(test);
-    (
-        MxlInstance::new(mxl_api, domain_guard.domain().as_str(), "").unwrap(),
-        domain_guard,
-    )
-}
-
-fn read_flow_def<P: AsRef<std::path::Path>>(path: P) -> String {
-    let flow_config_file = mxl::config::get_mxl_repo_root().join(path);
-
-    std::fs::read_to_string(flow_config_file.as_path())
-        .map_err(|error| {
-            mxl::Error::Other(format!(
-                "Error while reading flow definition from \"{}\": {}",
-                flow_config_file.display(),
-                error
-            ))
-        })
-        .unwrap()
-}
 
 #[test]
 fn basic_mxl_grain_writing_reading() {

--- a/rust/mxl/tests/common/mod.rs
+++ b/rust/mxl/tests/common/mod.rs
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: Apache-2.0
+
+use mxl::{MxlInstance, config::get_mxl_so_path};
+
+#[cfg(feature = "mxl-fabrics-ofi")]
+use mxl::{MxlFabricsApi, config::get_mxl_fabrics_ofi_so_path};
+
+static LOG_ONCE: std::sync::Once = std::sync::Once::new();
+
+pub struct TestDomainGuard {
+    dir: std::path::PathBuf,
+}
+
+impl TestDomainGuard {
+    fn new(test: &str) -> Self {
+        let dir = std::path::PathBuf::from(format!(
+            "/dev/shm/mxl_rust_tests_domain_{}_{}",
+            test,
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(dir.as_path()).unwrap_or_else(|_| {
+            panic!(
+                "Failed to create test domain directory \"{}\".",
+                dir.display()
+            )
+        });
+        Self { dir }
+    }
+
+    fn domain(&self) -> String {
+        self.dir.to_string_lossy().to_string()
+    }
+}
+
+impl Drop for TestDomainGuard {
+    fn drop(&mut self) {
+        std::fs::remove_dir_all(self.dir.as_path()).unwrap_or_else(|_| {
+            panic!(
+                "Failed to remove test domain directory \"{}\".",
+                self.dir.display()
+            )
+        });
+    }
+}
+
+pub fn setup_test(test: &str) -> (MxlInstance, TestDomainGuard) {
+    LOG_ONCE.call_once(|| {
+        tracing_subscriber::fmt()
+            .with_env_filter(
+                tracing_subscriber::EnvFilter::builder()
+                    .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                    .from_env_lossy(),
+            )
+            .init();
+    });
+
+    let mxl_api = mxl::load_api(get_mxl_so_path()).unwrap();
+    let domain_guard = TestDomainGuard::new(test);
+    (
+        MxlInstance::new(mxl_api, domain_guard.domain().as_str(), "").unwrap(),
+        domain_guard,
+    )
+}
+
+#[cfg(feature = "mxl-fabrics-ofi")]
+#[allow(dead_code)]
+pub fn load_fabrics_test_api() -> std::sync::Arc<MxlFabricsApi> {
+    mxl::load_fabrics_api(get_mxl_fabrics_ofi_so_path()).unwrap()
+}
+
+pub fn read_flow_def<P: AsRef<std::path::Path>>(path: P) -> String {
+    let flow_config_file = mxl::config::get_mxl_repo_root().join(path);
+
+    std::fs::read_to_string(flow_config_file.as_path())
+        .map_err(|error| {
+            mxl::Error::Other(format!(
+                "Error while reading flow definition from \"{}\": {}",
+                flow_config_file.display(),
+                error
+            ))
+        })
+        .unwrap()
+}

--- a/rust/mxl/tests/fabrics_ofi_tests.rs
+++ b/rust/mxl/tests/fabrics_ofi_tests.rs
@@ -1,0 +1,525 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: Apache-2.0
+
+#![cfg(feature = "mxl-fabrics-ofi")]
+
+mod common;
+
+use std::time::{Duration, Instant};
+
+use common::{load_fabrics_test_api, read_flow_def, setup_test};
+use mxl::{
+    Error, FlowReader, FlowWriter, GrainReader, GrainWriter, OwnedGrainData, OwnedSamplesData,
+    SamplesReader, SamplesWriter,
+    fabrics::{
+        EndpointAddress,
+        initiator::{self, Initiator},
+        target::{self, Target},
+    },
+};
+
+const POLL_TIMEOUT: Duration = Duration::from_secs(5);
+const BLOCKING_WAIT: Duration = Duration::from_millis(20);
+const AUDIO_SAMPLE_COUNT: usize = 42;
+
+fn tcp_endpoint() -> EndpointAddress<'static> {
+    EndpointAddress {
+        node: Some("127.0.0.1"),
+        service: Some("0"),
+    }
+}
+
+fn poll_until_success<F>(mut step: F, timeout_message: &str)
+where
+    F: FnMut() -> bool,
+{
+    let deadline = Instant::now() + POLL_TIMEOUT;
+    while Instant::now() < deadline {
+        if step() {
+            return;
+        }
+    }
+
+    panic!("{timeout_message}");
+}
+
+fn wait_for_grain_connection(
+    target: &Target<target::states::Grain>,
+    initiator: &Initiator<initiator::states::Grain>,
+) {
+    poll_until_success(
+        || {
+            match target.read_non_blocking() {
+                Ok(_) | Err(Error::NotReady) => {}
+                Err(error) => panic!("unexpected target status while waiting for connection: {error}"),
+            }
+
+            match initiator.make_progress(BLOCKING_WAIT) {
+                Ok(()) => true,
+                Err(Error::NotReady) => false,
+                Err(error) => panic!(
+                    "unexpected initiator status while waiting for grain connection: {error}"
+                ),
+            }
+        },
+        "failed to connect grain initiator and target in 5 seconds",
+    );
+}
+
+fn wait_for_samples_connection(
+    target: &Target<target::states::Sample>,
+    initiator: &Initiator<initiator::states::Samples>,
+) {
+    poll_until_success(
+        || {
+            match target.read_non_blocking() {
+                Ok(_) | Err(Error::NotReady) => {}
+                Err(error) => {
+                    panic!("unexpected target status while waiting for sample connection: {error}")
+                }
+            }
+
+            match initiator.make_progress(BLOCKING_WAIT) {
+                Ok(()) => true,
+                Err(Error::NotReady) => false,
+                Err(error) => panic!(
+                    "unexpected initiator status while waiting for sample connection: {error}"
+                ),
+            }
+        },
+        "failed to connect sample initiator and target in 5 seconds",
+    );
+}
+
+fn wait_for_grain_transfer_start(
+    target: &Target<target::states::Grain>,
+    initiator: &Initiator<initiator::states::Grain>,
+    grain_index: u64,
+    end_slice: u16,
+) {
+    poll_until_success(
+        || {
+            match target.read_non_blocking() {
+                Ok(_) | Err(Error::NotReady) => {}
+                Err(error) => panic!("unexpected target status before grain transfer: {error}"),
+            }
+
+            match initiator.make_progress(BLOCKING_WAIT) {
+                Ok(()) | Err(Error::NotReady) => {}
+                Err(error) => panic!(
+                    "unexpected initiator status before grain transfer: {error}"
+                ),
+            }
+
+            match initiator.transfer(grain_index, 0, end_slice) {
+                Ok(()) => true,
+                Err(Error::NotReady) => false,
+                Err(error) => panic!("failed to start grain transfer: {error}"),
+            }
+        },
+        "failed to start grain transfer in 5 seconds",
+    );
+}
+
+fn wait_for_samples_transfer_start(
+    target: &Target<target::states::Sample>,
+    initiator: &Initiator<initiator::states::Samples>,
+    head_index: u64,
+    count: usize,
+) {
+    poll_until_success(
+        || {
+            match target.read_non_blocking() {
+                Ok(_) | Err(Error::NotReady) => {}
+                Err(error) => panic!("unexpected target status before sample transfer: {error}"),
+            }
+
+            match initiator.make_progress(BLOCKING_WAIT) {
+                Ok(()) | Err(Error::NotReady) => {}
+                Err(error) => panic!(
+                    "unexpected initiator status before sample transfer: {error}"
+                ),
+            }
+
+            match initiator.transfer(head_index, count) {
+                Ok(()) => true,
+                Err(Error::NotReady) => false,
+                Err(error) => panic!("failed to start samples transfer: {error}"),
+            }
+        },
+        "failed to start samples transfer in 5 seconds",
+    );
+}
+
+fn wait_for_grain_transfer_completion(
+    target: &Target<target::states::Grain>,
+    initiator: &Initiator<initiator::states::Grain>,
+    expected_grain_index: u64,
+) -> u64 {
+    let mut completed_index = None;
+    poll_until_success(
+        || {
+            match initiator.make_progress(BLOCKING_WAIT) {
+                Ok(()) | Err(Error::NotReady) => {}
+                Err(error) => panic!(
+                    "unexpected initiator status while completing grain transfer: {error}"
+                ),
+            }
+
+            match target.read(BLOCKING_WAIT) {
+                Ok(result) => {
+                    assert_eq!(result.grain_index, expected_grain_index);
+                    completed_index = Some(result.grain_index);
+                    true
+                }
+                Err(Error::NotReady) => false,
+                Err(Error::Interrupted) => panic!("grain target disconnected before transfer completed"),
+                Err(error) => panic!("unexpected grain completion status: {error}"),
+            }
+        },
+        "grain transfer did not complete in 5 seconds",
+    );
+    completed_index.unwrap()
+}
+
+fn wait_for_samples_transfer_completion(
+    target: &Target<target::states::Sample>,
+    initiator: &Initiator<initiator::states::Samples>,
+    expected_head_index: u64,
+    expected_count: usize,
+) -> (u64, usize) {
+    let mut completed = None;
+    poll_until_success(
+        || {
+            match initiator.make_progress(BLOCKING_WAIT) {
+                Ok(()) | Err(Error::NotReady) => {}
+                Err(error) => panic!(
+                    "unexpected initiator status while completing samples transfer: {error}"
+                ),
+            }
+
+            match target.read(BLOCKING_WAIT) {
+                Ok(result) => {
+                    assert_eq!(result.head_index, expected_head_index);
+                    assert_eq!(result.count, expected_count);
+                    completed = Some((result.head_index, result.count));
+                    true
+                }
+                Err(Error::NotReady) => false,
+                Err(Error::Interrupted) => {
+                    panic!("samples target disconnected before transfer completed")
+                }
+                Err(error) => panic!("unexpected samples completion status: {error}"),
+            }
+        },
+        "samples transfer did not complete in 5 seconds",
+    );
+    completed.unwrap()
+}
+
+fn wait_for_target_grain(
+    reader: &GrainReader,
+    grain_index: u64,
+) -> OwnedGrainData {
+    let mut result = None;
+    poll_until_success(
+        || match reader.get_grain_non_blocking(grain_index) {
+            Ok(grain) => {
+                result = Some(grain.into());
+                true
+            }
+            Err(Error::OutOfRangeTooEarly) | Err(Error::NotReady) => false,
+            Err(error) => panic!("unexpected target grain read status: {error}"),
+        },
+        "target grain did not become visible in 5 seconds",
+    );
+    result.unwrap()
+}
+
+fn wait_for_target_samples(
+    reader: &SamplesReader,
+    head_index: u64,
+    count: usize,
+) -> OwnedSamplesData {
+    let mut result = None;
+    poll_until_success(
+        || match reader.get_samples_non_blocking(head_index, count) {
+            Ok(samples) => {
+                result = Some(samples.into());
+                true
+            }
+            Err(Error::OutOfRangeTooEarly) | Err(Error::NotReady) => false,
+            Err(error) => panic!("unexpected target samples read status: {error}"),
+        },
+        "target samples did not become visible in 5 seconds",
+    );
+    result.unwrap()
+}
+
+fn create_video_flow(mxl_instance: &mxl::MxlInstance) -> (FlowWriter, FlowReader, mxl::FlowConfigInfo) {
+    create_flow_with_def(mxl_instance, read_flow_def("lib/tests/data/v210_flow.json"))
+}
+
+fn create_video_flow_with_unique_id(
+    mxl_instance: &mxl::MxlInstance,
+) -> (FlowWriter, FlowReader, mxl::FlowConfigInfo) {
+    create_flow_with_def(
+        mxl_instance,
+        flow_def_with_fresh_id(&read_flow_def("lib/tests/data/v210_flow.json")),
+    )
+}
+
+fn create_audio_flow(mxl_instance: &mxl::MxlInstance) -> (FlowWriter, FlowReader, mxl::FlowConfigInfo) {
+    create_flow_with_def(mxl_instance, read_flow_def("lib/tests/data/audio_flow.json"))
+}
+
+fn create_audio_flow_with_unique_id(
+    mxl_instance: &mxl::MxlInstance,
+) -> (FlowWriter, FlowReader, mxl::FlowConfigInfo) {
+    create_flow_with_def(
+        mxl_instance,
+        flow_def_with_fresh_id(&read_flow_def("lib/tests/data/audio_flow.json")),
+    )
+}
+
+fn flow_def_with_fresh_id(flow_def: &str) -> String {
+    let mut value: serde_json::Value = serde_json::from_str(flow_def).unwrap();
+    value["id"] = serde_json::Value::String(uuid::Uuid::new_v4().to_string());
+    serde_json::to_string(&value).unwrap()
+}
+
+fn create_flow_with_def(
+    mxl_instance: &mxl::MxlInstance,
+    flow_def: String,
+) -> (FlowWriter, FlowReader, mxl::FlowConfigInfo) {
+    let (flow_writer, flow_config, was_created) = mxl_instance
+        .create_flow_writer(flow_def.as_str(), None)
+        .unwrap();
+    assert!(was_created);
+
+    let flow_id = flow_config.common().id().to_string();
+    let flow_reader = mxl_instance.create_flow_reader(flow_id.as_str()).unwrap();
+
+    (flow_writer, flow_reader, flow_config)
+}
+
+fn fill_grain_payload(payload: &mut [u8]) {
+    for (index, byte) in payload.iter_mut().enumerate() {
+        *byte = (index % 251) as u8;
+    }
+}
+
+fn fill_samples_payload(writer: &mut mxl::SamplesWriteAccess<'_>) {
+    for channel in 0..writer.channels() {
+        let (first, second) = writer.channel_data_mut(channel).unwrap();
+        for (index, byte) in first.iter_mut().enumerate() {
+            *byte = (channel as u8).wrapping_mul(17).wrapping_add(index as u8);
+        }
+        for (index, byte) in second.iter_mut().enumerate() {
+            *byte = (channel as u8)
+                .wrapping_mul(29)
+                .wrapping_add(index as u8)
+                .wrapping_add(3);
+        }
+    }
+}
+
+#[test]
+fn provider_tcp_roundtrip() {
+    let (mxl_instance, _domain_guard) = setup_test("provider_tcp_roundtrip");
+
+    {
+        let fabrics_api = load_fabrics_test_api();
+        let fabrics_instance = mxl_instance.create_fabrics_instance(&fabrics_api).unwrap();
+        let provider = fabrics_instance.provider_from_str("tcp").unwrap();
+
+        assert_eq!(provider.to_string().unwrap(), "tcp");
+    }
+
+    mxl_instance.destroy().unwrap();
+}
+
+#[test]
+fn target_info_roundtrip() {
+    let (mxl_instance, _domain_guard) = setup_test("target_info_roundtrip");
+
+    {
+        let fabrics_api = load_fabrics_test_api();
+        let fabrics_instance = mxl_instance.create_fabrics_instance(&fabrics_api).unwrap();
+        let (flow_writer, _flow_reader, _flow_config) = create_video_flow(&mxl_instance);
+
+        let provider = fabrics_instance.provider_from_str("tcp").unwrap();
+        let target = fabrics_instance.create_target().unwrap();
+        let config = target::Config::new(tcp_endpoint(), provider, &flow_writer);
+        let (_target, target_info) = target.setup(&config).unwrap();
+
+        let serialized = target_info.to_string().unwrap();
+        let deserialized = fabrics_instance.target_info_from_str(&serialized).unwrap();
+
+        assert_eq!(serialized, deserialized.to_string().unwrap());
+    }
+
+    mxl_instance.destroy().unwrap();
+}
+
+#[test]
+fn tcp_grain_transfer_delivers_payload_to_target_flow() {
+    let (mxl_instance, _domain_guard) = setup_test("tcp_grain_transfer");
+
+    {
+        let fabrics_api = load_fabrics_test_api();
+        let fabrics_instance = mxl_instance.create_fabrics_instance(&fabrics_api).unwrap();
+
+        let (source_flow_writer, source_flow_reader, source_flow_config) =
+            create_video_flow(&mxl_instance);
+        let (target_flow_writer, target_flow_reader, _target_flow_config) =
+            create_video_flow_with_unique_id(&mxl_instance);
+
+        let source_grain_writer: GrainWriter = source_flow_writer.to_grain_writer().unwrap();
+        let source_grain_reader: GrainReader = source_flow_reader.to_grain_reader().unwrap();
+        let target_grain_reader: GrainReader = target_flow_reader.to_grain_reader().unwrap();
+
+        let (target, target_info) = {
+            let target_provider = fabrics_instance.provider_from_str("tcp").unwrap();
+            let target = fabrics_instance.create_target().unwrap();
+            let target_config =
+                target::Config::new(tcp_endpoint(), target_provider, &target_flow_writer);
+            target.setup(&target_config).unwrap()
+        };
+        let target_grain_writer: GrainWriter = target_flow_writer.to_grain_writer().unwrap();
+        let target = match target.specialize(&source_flow_config) {
+            target::Either::Grain(target) => target,
+            target::Either::Sample(_) => panic!("expected grain target for video flow"),
+        };
+
+        let initiator_flow_reader = mxl_instance
+            .create_flow_reader(source_flow_config.common().id().to_string().as_str())
+            .unwrap();
+        let initiator = {
+            let initiator_provider = fabrics_instance.provider_from_str("tcp").unwrap();
+            let initiator = fabrics_instance.create_initiator().unwrap();
+            let initiator_config = initiator::Config::new(
+                tcp_endpoint(),
+                initiator_provider,
+                &initiator_flow_reader,
+            );
+            initiator.setup(&initiator_config).unwrap()
+        };
+        let initiator = match initiator.specialize(&source_flow_config) {
+            initiator::Either::Grain(initiator) => initiator,
+            initiator::Either::Samples(_) => panic!("expected grain initiator for video flow"),
+        };
+
+        initiator.add_target(&target_info).unwrap();
+        wait_for_grain_connection(&target, &initiator);
+
+        let grain_index =
+            mxl_instance.get_current_index(&source_flow_config.common().grain_rate().unwrap());
+        let mut grain = source_grain_writer.open_grain(grain_index).unwrap();
+        fill_grain_payload(grain.payload_mut());
+        let total_slices = grain.total_slices();
+        grain.commit(total_slices).unwrap();
+
+        let expected: OwnedGrainData = source_grain_reader
+            .get_complete_grain(grain_index, POLL_TIMEOUT)
+            .unwrap()
+            .into();
+
+        wait_for_grain_transfer_start(&target, &initiator, grain_index, total_slices);
+        let completed_index = wait_for_grain_transfer_completion(&target, &initiator, grain_index);
+
+        let committed_grain = target_grain_writer.open_grain(completed_index).unwrap();
+        let committed_slices = committed_grain.valid_slices();
+        committed_grain.commit(committed_slices).unwrap();
+
+        let actual = wait_for_target_grain(&target_grain_reader, grain_index);
+        assert_eq!(actual.payload, expected.payload);
+
+        initiator.remove_target(&target_info).unwrap();
+    }
+
+    mxl_instance.destroy().unwrap();
+}
+
+#[test]
+fn tcp_samples_transfer_delivers_payload_to_target_flow() {
+    let (mxl_instance, _domain_guard) = setup_test("tcp_samples_transfer");
+
+    {
+        let fabrics_api = load_fabrics_test_api();
+        let fabrics_instance = mxl_instance.create_fabrics_instance(&fabrics_api).unwrap();
+
+        let (source_flow_writer, source_flow_reader, source_flow_config) =
+            create_audio_flow(&mxl_instance);
+        let (target_flow_writer, target_flow_reader, _target_flow_config) =
+            create_audio_flow_with_unique_id(&mxl_instance);
+
+        let source_samples_writer: SamplesWriter = source_flow_writer.to_samples_writer().unwrap();
+        let source_samples_reader: SamplesReader = source_flow_reader.to_samples_reader().unwrap();
+        let target_samples_reader: SamplesReader = target_flow_reader.to_samples_reader().unwrap();
+
+        let (target, target_info) = {
+            let target_provider = fabrics_instance.provider_from_str("tcp").unwrap();
+            let target = fabrics_instance.create_target().unwrap();
+            let target_config =
+                target::Config::new(tcp_endpoint(), target_provider, &target_flow_writer);
+            target.setup(&target_config).unwrap()
+        };
+        let target_samples_writer: SamplesWriter = target_flow_writer.to_samples_writer().unwrap();
+        let target = match target.specialize(&source_flow_config) {
+            target::Either::Sample(target) => target,
+            target::Either::Grain(_) => panic!("expected samples target for audio flow"),
+        };
+
+        let initiator_flow_reader = mxl_instance
+            .create_flow_reader(source_flow_config.common().id().to_string().as_str())
+            .unwrap();
+        let initiator = {
+            let initiator_provider = fabrics_instance.provider_from_str("tcp").unwrap();
+            let initiator = fabrics_instance.create_initiator().unwrap();
+            let initiator_config =
+                initiator::Config::new(tcp_endpoint(), initiator_provider, &initiator_flow_reader);
+            initiator.setup(&initiator_config).unwrap()
+        };
+        let initiator = match initiator.specialize(&source_flow_config) {
+            initiator::Either::Samples(initiator) => initiator,
+            initiator::Either::Grain(_) => panic!("expected samples initiator for audio flow"),
+        };
+
+        initiator.add_target(&target_info).unwrap();
+        wait_for_samples_connection(&target, &initiator);
+
+        let head_index =
+            mxl_instance.get_current_index(&source_flow_config.common().sample_rate().unwrap());
+        let mut samples = source_samples_writer
+            .open_samples(head_index, AUDIO_SAMPLE_COUNT)
+            .unwrap();
+        fill_samples_payload(&mut samples);
+        samples.commit().unwrap();
+
+        let expected: OwnedSamplesData = source_samples_reader
+            .get_samples(head_index, AUDIO_SAMPLE_COUNT, POLL_TIMEOUT)
+            .unwrap()
+            .into();
+
+        wait_for_samples_transfer_start(&target, &initiator, head_index, AUDIO_SAMPLE_COUNT);
+        let (completed_head_index, completed_count) = wait_for_samples_transfer_completion(
+            &target,
+            &initiator,
+            head_index,
+            AUDIO_SAMPLE_COUNT,
+        );
+
+        let committed_samples = target_samples_writer
+            .open_samples(completed_head_index, completed_count)
+            .unwrap();
+        committed_samples.commit().unwrap();
+
+        let actual = wait_for_target_samples(&target_samples_reader, head_index, AUDIO_SAMPLE_COUNT);
+        assert_eq!(actual.payload, expected.payload);
+
+        initiator.remove_target(&target_info).unwrap();
+    }
+
+    mxl_instance.destroy().unwrap();
+}

--- a/rust/mxl/tests/fabrics_ofi_tests.rs
+++ b/rust/mxl/tests/fabrics_ofi_tests.rs
@@ -408,10 +408,8 @@ fn tcp_grain_transfer_delivers_payload_to_target_flow() {
         let initiator = {
             let initiator_provider = fabrics_instance.provider_from_str("tcp").unwrap();
             let initiator = fabrics_instance.create_initiator().unwrap();
-            let initiator_config = initiator::Config::new(
-                tcp_interface(&initiator_provider),
-                &initiator_flow_reader,
-            );
+            let initiator_config =
+                initiator::Config::new(tcp_interface(&initiator_provider), &initiator_flow_reader);
             initiator.setup(&initiator_config).unwrap()
         };
         let initiator = match initiator.specialize(&source_flow_config) {
@@ -486,10 +484,8 @@ fn tcp_samples_transfer_delivers_payload_to_target_flow() {
         let initiator = {
             let initiator_provider = fabrics_instance.provider_from_str("tcp").unwrap();
             let initiator = fabrics_instance.create_initiator().unwrap();
-            let initiator_config = initiator::Config::new(
-                tcp_interface(&initiator_provider),
-                &initiator_flow_reader,
-            );
+            let initiator_config =
+                initiator::Config::new(tcp_interface(&initiator_provider), &initiator_flow_reader);
             initiator.setup(&initiator_config).unwrap()
         };
         let initiator = match initiator.specialize(&source_flow_config) {

--- a/rust/mxl/tests/fabrics_ofi_tests.rs
+++ b/rust/mxl/tests/fabrics_ofi_tests.rs
@@ -22,7 +22,7 @@ const POLL_TIMEOUT: Duration = Duration::from_secs(5);
 const BLOCKING_WAIT: Duration = Duration::from_millis(20);
 const AUDIO_SAMPLE_COUNT: usize = 42;
 
-fn tcp_endpoint() -> EndpointAddress<'static> {
+fn tcp_endpoint() -> EndpointAddress {
     EndpointAddress {
         node: Some("127.0.0.1"),
         service: Some("0"),
@@ -51,7 +51,9 @@ fn wait_for_grain_connection(
         || {
             match target.read_non_blocking() {
                 Ok(_) | Err(Error::NotReady) => {}
-                Err(error) => panic!("unexpected target status while waiting for connection: {error}"),
+                Err(error) => {
+                    panic!("unexpected target status while waiting for connection: {error}")
+                }
             }
 
             match initiator.make_progress(BLOCKING_WAIT) {
@@ -106,9 +108,7 @@ fn wait_for_grain_transfer_start(
 
             match initiator.make_progress(BLOCKING_WAIT) {
                 Ok(()) | Err(Error::NotReady) => {}
-                Err(error) => panic!(
-                    "unexpected initiator status before grain transfer: {error}"
-                ),
+                Err(error) => panic!("unexpected initiator status before grain transfer: {error}"),
             }
 
             match initiator.transfer(grain_index, 0, end_slice) {
@@ -136,9 +136,7 @@ fn wait_for_samples_transfer_start(
 
             match initiator.make_progress(BLOCKING_WAIT) {
                 Ok(()) | Err(Error::NotReady) => {}
-                Err(error) => panic!(
-                    "unexpected initiator status before sample transfer: {error}"
-                ),
+                Err(error) => panic!("unexpected initiator status before sample transfer: {error}"),
             }
 
             match initiator.transfer(head_index, count) {
@@ -161,9 +159,9 @@ fn wait_for_grain_transfer_completion(
         || {
             match initiator.make_progress(BLOCKING_WAIT) {
                 Ok(()) | Err(Error::NotReady) => {}
-                Err(error) => panic!(
-                    "unexpected initiator status while completing grain transfer: {error}"
-                ),
+                Err(error) => {
+                    panic!("unexpected initiator status while completing grain transfer: {error}")
+                }
             }
 
             match target.read(BLOCKING_WAIT) {
@@ -173,7 +171,9 @@ fn wait_for_grain_transfer_completion(
                     true
                 }
                 Err(Error::NotReady) => false,
-                Err(Error::Interrupted) => panic!("grain target disconnected before transfer completed"),
+                Err(Error::Interrupted) => {
+                    panic!("grain target disconnected before transfer completed")
+                }
                 Err(error) => panic!("unexpected grain completion status: {error}"),
             }
         },
@@ -193,9 +193,9 @@ fn wait_for_samples_transfer_completion(
         || {
             match initiator.make_progress(BLOCKING_WAIT) {
                 Ok(()) | Err(Error::NotReady) => {}
-                Err(error) => panic!(
-                    "unexpected initiator status while completing samples transfer: {error}"
-                ),
+                Err(error) => {
+                    panic!("unexpected initiator status while completing samples transfer: {error}")
+                }
             }
 
             match target.read(BLOCKING_WAIT) {
@@ -217,10 +217,7 @@ fn wait_for_samples_transfer_completion(
     completed.unwrap()
 }
 
-fn wait_for_target_grain(
-    reader: &GrainReader,
-    grain_index: u64,
-) -> OwnedGrainData {
+fn wait_for_target_grain(reader: &GrainReader, grain_index: u64) -> OwnedGrainData {
     let mut result = None;
     poll_until_success(
         || match reader.get_grain_non_blocking(grain_index) {
@@ -256,7 +253,9 @@ fn wait_for_target_samples(
     result.unwrap()
 }
 
-fn create_video_flow(mxl_instance: &mxl::MxlInstance) -> (FlowWriter, FlowReader, mxl::FlowConfigInfo) {
+fn create_video_flow(
+    mxl_instance: &mxl::MxlInstance,
+) -> (FlowWriter, FlowReader, mxl::FlowConfigInfo) {
     create_flow_with_def(mxl_instance, read_flow_def("lib/tests/data/v210_flow.json"))
 }
 
@@ -269,8 +268,13 @@ fn create_video_flow_with_unique_id(
     )
 }
 
-fn create_audio_flow(mxl_instance: &mxl::MxlInstance) -> (FlowWriter, FlowReader, mxl::FlowConfigInfo) {
-    create_flow_with_def(mxl_instance, read_flow_def("lib/tests/data/audio_flow.json"))
+fn create_audio_flow(
+    mxl_instance: &mxl::MxlInstance,
+) -> (FlowWriter, FlowReader, mxl::FlowConfigInfo) {
+    create_flow_with_def(
+        mxl_instance,
+        read_flow_def("lib/tests/data/audio_flow.json"),
+    )
 }
 
 fn create_audio_flow_with_unique_id(
@@ -398,11 +402,8 @@ fn tcp_grain_transfer_delivers_payload_to_target_flow() {
         let initiator = {
             let initiator_provider = fabrics_instance.provider_from_str("tcp").unwrap();
             let initiator = fabrics_instance.create_initiator().unwrap();
-            let initiator_config = initiator::Config::new(
-                tcp_endpoint(),
-                initiator_provider,
-                &initiator_flow_reader,
-            );
+            let initiator_config =
+                initiator::Config::new(tcp_endpoint(), initiator_provider, &initiator_flow_reader);
             initiator.setup(&initiator_config).unwrap()
         };
         let initiator = match initiator.specialize(&source_flow_config) {
@@ -515,7 +516,8 @@ fn tcp_samples_transfer_delivers_payload_to_target_flow() {
             .unwrap();
         committed_samples.commit().unwrap();
 
-        let actual = wait_for_target_samples(&target_samples_reader, head_index, AUDIO_SAMPLE_COUNT);
+        let actual =
+            wait_for_target_samples(&target_samples_reader, head_index, AUDIO_SAMPLE_COUNT);
         assert_eq!(actual.payload, expected.payload);
 
         initiator.remove_target(&target_info).unwrap();

--- a/rust/mxl/tests/fabrics_ofi_tests.rs
+++ b/rust/mxl/tests/fabrics_ofi_tests.rs
@@ -12,7 +12,7 @@ use mxl::{
     Error, FlowReader, FlowWriter, GrainReader, GrainWriter, OwnedGrainData, OwnedSamplesData,
     SamplesReader, SamplesWriter,
     fabrics::{
-        EndpointAddress,
+        EndpointAddress, InterfaceConfig, Provider,
         initiator::{self, Initiator},
         target::{self, Target},
     },
@@ -22,11 +22,17 @@ const POLL_TIMEOUT: Duration = Duration::from_secs(5);
 const BLOCKING_WAIT: Duration = Duration::from_millis(20);
 const AUDIO_SAMPLE_COUNT: usize = 42;
 
-fn tcp_endpoint() -> EndpointAddress {
+fn tcp_endpoint() -> EndpointAddress<'static> {
     EndpointAddress {
         node: Some("127.0.0.1"),
         service: Some("0"),
     }
+}
+
+fn tcp_interface(provider: &Provider) -> InterfaceConfig<'static> {
+    InterfaceConfig::builder(tcp_endpoint())
+        .provider(provider.prov_type().clone())
+        .build()
 }
 
 fn poll_until_success<F>(mut step: F, timeout_message: &str)
@@ -354,7 +360,7 @@ fn target_info_roundtrip() {
 
         let provider = fabrics_instance.provider_from_str("tcp").unwrap();
         let target = fabrics_instance.create_target().unwrap();
-        let config = target::Config::new(tcp_endpoint(), provider, &flow_writer);
+        let config = target::Config::new(tcp_interface(&provider), &flow_writer);
         let (_target, target_info) = target.setup(&config).unwrap();
 
         let serialized = target_info.to_string().unwrap();
@@ -387,7 +393,7 @@ fn tcp_grain_transfer_delivers_payload_to_target_flow() {
             let target_provider = fabrics_instance.provider_from_str("tcp").unwrap();
             let target = fabrics_instance.create_target().unwrap();
             let target_config =
-                target::Config::new(tcp_endpoint(), target_provider, &target_flow_writer);
+                target::Config::new(tcp_interface(&target_provider), &target_flow_writer);
             target.setup(&target_config).unwrap()
         };
         let target_grain_writer: GrainWriter = target_flow_writer.to_grain_writer().unwrap();
@@ -402,8 +408,10 @@ fn tcp_grain_transfer_delivers_payload_to_target_flow() {
         let initiator = {
             let initiator_provider = fabrics_instance.provider_from_str("tcp").unwrap();
             let initiator = fabrics_instance.create_initiator().unwrap();
-            let initiator_config =
-                initiator::Config::new(tcp_endpoint(), initiator_provider, &initiator_flow_reader);
+            let initiator_config = initiator::Config::new(
+                tcp_interface(&initiator_provider),
+                &initiator_flow_reader,
+            );
             initiator.setup(&initiator_config).unwrap()
         };
         let initiator = match initiator.specialize(&source_flow_config) {
@@ -463,7 +471,7 @@ fn tcp_samples_transfer_delivers_payload_to_target_flow() {
             let target_provider = fabrics_instance.provider_from_str("tcp").unwrap();
             let target = fabrics_instance.create_target().unwrap();
             let target_config =
-                target::Config::new(tcp_endpoint(), target_provider, &target_flow_writer);
+                target::Config::new(tcp_interface(&target_provider), &target_flow_writer);
             target.setup(&target_config).unwrap()
         };
         let target_samples_writer: SamplesWriter = target_flow_writer.to_samples_writer().unwrap();
@@ -478,8 +486,10 @@ fn tcp_samples_transfer_delivers_payload_to_target_flow() {
         let initiator = {
             let initiator_provider = fabrics_instance.provider_from_str("tcp").unwrap();
             let initiator = fabrics_instance.create_initiator().unwrap();
-            let initiator_config =
-                initiator::Config::new(tcp_endpoint(), initiator_provider, &initiator_flow_reader);
+            let initiator_config = initiator::Config::new(
+                tcp_interface(&initiator_provider),
+                &initiator_flow_reader,
+            );
             initiator.setup(&initiator_config).unwrap()
         };
         let initiator = match initiator.specialize(&source_flow_config) {

--- a/rust/mxl/tests/fabrics_ofi_tests.rs
+++ b/rust/mxl/tests/fabrics_ofi_tests.rs
@@ -398,7 +398,7 @@ fn tcp_grain_transfer_delivers_payload_to_target_flow() {
         let target_grain_writer: GrainWriter = target_flow_writer.to_grain_writer().unwrap();
         let target = match target {
             TargetFlavor::Grain(target) => target,
-            TargetFlavor::Sample(_) => panic!("expected grain target for video flow"),
+            TargetFlavor::Samples(_) => panic!("expected grain target for video flow"),
         };
 
         let initiator_flow_reader = mxl_instance
@@ -477,7 +477,7 @@ fn tcp_samples_transfer_delivers_payload_to_target_flow() {
         };
         let target_samples_writer: SamplesWriter = target_flow_writer.to_samples_writer().unwrap();
         let target = match target {
-            TargetFlavor::Sample(target) => target,
+            TargetFlavor::Samples(target) => target,
             TargetFlavor::Grain(_) => panic!("expected samples target for audio flow"),
         };
 

--- a/rust/mxl/tests/fabrics_ofi_tests.rs
+++ b/rust/mxl/tests/fabrics_ofi_tests.rs
@@ -13,8 +13,8 @@ use mxl::{
     SamplesReader, SamplesWriter,
     fabrics::{
         EndpointAddress, InterfaceConfig, Provider,
-        initiator::{self, Initiator},
-        target::{self, Target},
+        initiator::{self, Initiator, InitiatorFlavor},
+        target::{self, Target, TargetFlavor},
     },
 };
 
@@ -22,15 +22,12 @@ const POLL_TIMEOUT: Duration = Duration::from_secs(5);
 const BLOCKING_WAIT: Duration = Duration::from_millis(20);
 const AUDIO_SAMPLE_COUNT: usize = 42;
 
-fn tcp_endpoint() -> EndpointAddress<'static> {
-    EndpointAddress {
-        node: Some("127.0.0.1"),
-        service: Some("0"),
-    }
+fn tcp_endpoint() -> Result<EndpointAddress, Error> {
+    EndpointAddress::new(Some("127.0.0.1"), Some("0"))
 }
 
-fn tcp_interface(provider: &Provider) -> InterfaceConfig<'static> {
-    InterfaceConfig::builder(tcp_endpoint())
+fn tcp_interface(provider: &Provider) -> Result<InterfaceConfig, Error> {
+    InterfaceConfig::builder(tcp_endpoint()?)
         .provider(provider.prov_type().clone())
         .build()
 }
@@ -75,7 +72,7 @@ fn wait_for_grain_connection(
 }
 
 fn wait_for_samples_connection(
-    target: &Target<target::states::Sample>,
+    target: &Target<target::states::Samples>,
     initiator: &Initiator<initiator::states::Samples>,
 ) {
     poll_until_success(
@@ -128,7 +125,7 @@ fn wait_for_grain_transfer_start(
 }
 
 fn wait_for_samples_transfer_start(
-    target: &Target<target::states::Sample>,
+    target: &Target<target::states::Samples>,
     initiator: &Initiator<initiator::states::Samples>,
     head_index: u64,
     count: usize,
@@ -189,7 +186,7 @@ fn wait_for_grain_transfer_completion(
 }
 
 fn wait_for_samples_transfer_completion(
-    target: &Target<target::states::Sample>,
+    target: &Target<target::states::Samples>,
     initiator: &Initiator<initiator::states::Samples>,
     expected_head_index: u64,
     expected_count: usize,
@@ -356,12 +353,12 @@ fn target_info_roundtrip() {
     {
         let fabrics_api = load_fabrics_test_api();
         let fabrics_instance = mxl_instance.create_fabrics_instance(&fabrics_api).unwrap();
-        let (flow_writer, _flow_reader, _flow_config) = create_video_flow(&mxl_instance);
+        let (flow_writer, _flow_reader, flow_config) = create_video_flow(&mxl_instance);
 
         let provider = fabrics_instance.provider_from_str("tcp").unwrap();
         let target = fabrics_instance.create_target().unwrap();
-        let config = target::Config::new(tcp_interface(&provider), &flow_writer);
-        let (_target, target_info) = target.setup(&config).unwrap();
+        let config = target::Config::new(tcp_interface(&provider).unwrap(), &flow_writer);
+        let (_target, target_info) = target.setup(&config, &flow_config).unwrap();
 
         let serialized = target_info.to_string().unwrap();
         let deserialized = fabrics_instance.target_info_from_str(&serialized).unwrap();
@@ -382,7 +379,7 @@ fn tcp_grain_transfer_delivers_payload_to_target_flow() {
 
         let (source_flow_writer, source_flow_reader, source_flow_config) =
             create_video_flow(&mxl_instance);
-        let (target_flow_writer, target_flow_reader, _target_flow_config) =
+        let (target_flow_writer, target_flow_reader, target_flow_config) =
             create_video_flow_with_unique_id(&mxl_instance);
 
         let source_grain_writer: GrainWriter = source_flow_writer.to_grain_writer().unwrap();
@@ -392,14 +389,16 @@ fn tcp_grain_transfer_delivers_payload_to_target_flow() {
         let (target, target_info) = {
             let target_provider = fabrics_instance.provider_from_str("tcp").unwrap();
             let target = fabrics_instance.create_target().unwrap();
-            let target_config =
-                target::Config::new(tcp_interface(&target_provider), &target_flow_writer);
-            target.setup(&target_config).unwrap()
+            let target_config = target::Config::new(
+                tcp_interface(&target_provider).unwrap(),
+                &target_flow_writer,
+            );
+            target.setup(&target_config, &target_flow_config).unwrap()
         };
         let target_grain_writer: GrainWriter = target_flow_writer.to_grain_writer().unwrap();
-        let target = match target.specialize(&source_flow_config) {
-            target::Either::Grain(target) => target,
-            target::Either::Sample(_) => panic!("expected grain target for video flow"),
+        let target = match target {
+            TargetFlavor::Grain(target) => target,
+            TargetFlavor::Sample(_) => panic!("expected grain target for video flow"),
         };
 
         let initiator_flow_reader = mxl_instance
@@ -408,13 +407,15 @@ fn tcp_grain_transfer_delivers_payload_to_target_flow() {
         let initiator = {
             let initiator_provider = fabrics_instance.provider_from_str("tcp").unwrap();
             let initiator = fabrics_instance.create_initiator().unwrap();
-            let initiator_config =
-                initiator::Config::new(tcp_interface(&initiator_provider), &initiator_flow_reader);
+            let initiator_config = initiator::Config::new(
+                tcp_interface(&initiator_provider).unwrap(),
+                &initiator_flow_reader,
+            );
             initiator.setup(&initiator_config).unwrap()
         };
-        let initiator = match initiator.specialize(&source_flow_config) {
-            initiator::Either::Grain(initiator) => initiator,
-            initiator::Either::Samples(_) => panic!("expected grain initiator for video flow"),
+        let initiator = match initiator {
+            InitiatorFlavor::Grain(initiator) => initiator,
+            InitiatorFlavor::Samples(_) => panic!("expected grain initiator for video flow"),
         };
 
         initiator.add_target(&target_info).unwrap();
@@ -458,7 +459,7 @@ fn tcp_samples_transfer_delivers_payload_to_target_flow() {
 
         let (source_flow_writer, source_flow_reader, source_flow_config) =
             create_audio_flow(&mxl_instance);
-        let (target_flow_writer, target_flow_reader, _target_flow_config) =
+        let (target_flow_writer, target_flow_reader, target_flow_config) =
             create_audio_flow_with_unique_id(&mxl_instance);
 
         let source_samples_writer: SamplesWriter = source_flow_writer.to_samples_writer().unwrap();
@@ -468,14 +469,16 @@ fn tcp_samples_transfer_delivers_payload_to_target_flow() {
         let (target, target_info) = {
             let target_provider = fabrics_instance.provider_from_str("tcp").unwrap();
             let target = fabrics_instance.create_target().unwrap();
-            let target_config =
-                target::Config::new(tcp_interface(&target_provider), &target_flow_writer);
-            target.setup(&target_config).unwrap()
+            let target_config = target::Config::new(
+                tcp_interface(&target_provider).unwrap(),
+                &target_flow_writer,
+            );
+            target.setup(&target_config, &target_flow_config).unwrap()
         };
         let target_samples_writer: SamplesWriter = target_flow_writer.to_samples_writer().unwrap();
-        let target = match target.specialize(&source_flow_config) {
-            target::Either::Sample(target) => target,
-            target::Either::Grain(_) => panic!("expected samples target for audio flow"),
+        let target = match target {
+            TargetFlavor::Sample(target) => target,
+            TargetFlavor::Grain(_) => panic!("expected samples target for audio flow"),
         };
 
         let initiator_flow_reader = mxl_instance
@@ -484,13 +487,15 @@ fn tcp_samples_transfer_delivers_payload_to_target_flow() {
         let initiator = {
             let initiator_provider = fabrics_instance.provider_from_str("tcp").unwrap();
             let initiator = fabrics_instance.create_initiator().unwrap();
-            let initiator_config =
-                initiator::Config::new(tcp_interface(&initiator_provider), &initiator_flow_reader);
+            let initiator_config = initiator::Config::new(
+                tcp_interface(&initiator_provider).unwrap(),
+                &initiator_flow_reader,
+            );
             initiator.setup(&initiator_config).unwrap()
         };
-        let initiator = match initiator.specialize(&source_flow_config) {
-            initiator::Either::Samples(initiator) => initiator,
-            initiator::Either::Grain(_) => panic!("expected samples initiator for audio flow"),
+        let initiator = match initiator {
+            InitiatorFlavor::Samples(initiator) => initiator,
+            InitiatorFlavor::Grain(_) => panic!("expected samples initiator for audio flow"),
         };
 
         initiator.add_target(&target_info).unwrap();


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2026 Contributors to the Media eXchange Layer project. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- Before submitting a pull request, please check that:
- it has a suitably descriptive title
- it mentions any issue(s) that it addresses
- you have considered whether it should be backported (specify how far back below)
- any required regression tests have run successfully
- all commits are signed-off: see [here](https://github.com/dmf-mxl/mxl/blob/main/CONTRIBUTING.md#commit-sign-off) for more information
-->

# Details
As the title describes, this adds Rust Bindings to the new Fabrics API. It also includes a demo app written in Rust that behaves similarly to demo.cpp.

This PR will close https://github.com/dmf-mxl/mxl/issues/182.

# Backport requirements
v1.1