### PR TITLE
Fix FI_EINTR (interrupted) corrupting internal state for no reason

### DIFF
--- a/lib/fabrics/include/mxl/fabrics.h
+++ b/lib/fabrics/include/mxl/fabrics.h
@@ -227,7 +227,8 @@ extern "C"
      * \param in_target A valid fabrics target
      * \param out_grainIndex The index of the grain that was written, if any.
      * \param in_timeoutMs How long should we wait for the grain (in milliseconds)
-     * \return The result code. MXL_ERR_NOT_READY if no grain was available before the timeout. \see mxlStatus
+     * \return The result code. MXL_ERR_NOT_READY if no grain was available before the timeout. Some providers return MXL_ERR_INTERRUPTED when the
+     * blocking read is interrupted by a POSIX signal. \see mxlStatus
      */
     MXL_EXPORT
     mxlStatus mxlFabricsTargetReadGrain(mxlFabricsTarget in_target, uint16_t in_timeoutMs, uint64_t* out_entryIndex);
@@ -346,7 +347,7 @@ extern "C"
      * \param in_initiator The initiator that should make progress.
      * \param in_timeoutMs The maximum time to wait for progress to be made (in milliseconds).
      * \return The result code. Returns MXL_ERR_NOT_READY if there is still progress to be made and not all operations have completed before the
-     * timeout.
+     * timeout. Some providers return MXL_ERR_INTERRUPTED if the operation is interrupted by the arrival of a POSIX signal.
      */
     MXL_EXPORT
     mxlStatus mxlFabricsInitiatorMakeProgressBlocking(mxlFabricsInitiator in_initiator, uint16_t in_timeoutMs);

--- a/lib/fabrics/ofi/src/fabrics.cpp
+++ b/lib/fabrics/ofi/src/fabrics.cpp
@@ -23,6 +23,7 @@
 #include "internal/Target.hpp"
 #include "internal/TargetInfo.hpp"
 #include "mxl/platform.h"
+#include "VariantUtils.hpp"
 
 namespace ofi = mxl::lib::fabrics::ofi;
 
@@ -238,13 +239,24 @@ mxlStatus mxlFabricsTargetReadGrainNonBlocking(mxlFabricsTarget in_target, uint6
     return ofi::try_run(
         [&]()
         {
-            auto res = ofi::TargetWrapper::fromAPI(in_target)->readGrain();
-            if (!res)
+            auto const result = ofi::TargetWrapper::fromAPI(in_target)->read();
+            if (!result)
             {
                 return MXL_ERR_NOT_READY;
             }
 
-            *out_grainIndex = res->grainIndex;
+            if (std::holds_alternative<ofi::Target::Interrupted>(*result))
+            {
+                return MXL_ERR_INTERRUPTED;
+            }
+
+            auto const grainResult = std::get_if<ofi::Target::GrainReadResult>(&*result);
+            if (grainResult == nullptr)
+            {
+                return MXL_ERR_INVALID_STATE;
+            }
+
+            *out_grainIndex = grainResult->grainIndex;
             return MXL_STATUS_OK;
         },
         "Failed to try for new grain");
@@ -261,13 +273,24 @@ mxlStatus mxlFabricsTargetReadGrain(mxlFabricsTarget in_target, uint16_t in_time
     return ofi::try_run(
         [&]()
         {
-            auto res = ofi::TargetWrapper::fromAPI(in_target)->readGrainBlocking(std::chrono::milliseconds(in_timeoutMs));
-            if (!res)
+            auto const result = ofi::TargetWrapper::fromAPI(in_target)->readBlocking(std::chrono::milliseconds(in_timeoutMs));
+            if (!result)
             {
                 return MXL_ERR_NOT_READY;
             }
 
-            *out_grainIndex = res->grainIndex;
+            if (std::holds_alternative<ofi::Target::Interrupted>(*result))
+            {
+                return MXL_ERR_INTERRUPTED;
+            }
+
+            auto const grainResult = std::get_if<ofi::Target::GrainReadResult>(&*result);
+            if (grainResult == nullptr)
+            {
+                return MXL_ERR_INVALID_STATE;
+            }
+
+            *out_grainIndex = grainResult->grainIndex;
             return MXL_STATUS_OK;
         },
         "Failed to wait for new grain");
@@ -284,14 +307,25 @@ mxlStatus mxlFabricsTargetReadSamplesNonBlocking(mxlFabricsTarget in_target, uin
     return ofi::try_run(
         [&]()
         {
-            auto res = ofi::TargetWrapper::fromAPI(in_target)->readSamples();
-            if (!res)
+            auto const result = ofi::TargetWrapper::fromAPI(in_target)->read();
+            if (!result)
             {
                 return MXL_ERR_NOT_READY;
             }
 
-            *out_headIndex = res->headIndex;
-            *out_count = res->count;
+            if (std::holds_alternative<ofi::Target::Interrupted>(*result))
+            {
+                return MXL_ERR_INTERRUPTED;
+            }
+
+            auto const sampleResult = std::get_if<ofi::Target::SampleReadResult>(&*result);
+            if (sampleResult == nullptr)
+            {
+                return MXL_ERR_INVALID_STATE;
+            }
+
+            *out_headIndex = sampleResult->headIndex;
+            *out_count = sampleResult->count;
             return MXL_STATUS_OK;
         },
         "Failed to try for new samples");
@@ -308,14 +342,25 @@ mxlStatus mxlFabricsTargetReadSamples(mxlFabricsTarget in_target, uint16_t in_ti
     return ofi::try_run(
         [&]()
         {
-            auto res = ofi::TargetWrapper::fromAPI(in_target)->readSamplesBlocking(std::chrono::milliseconds(in_timeoutMs));
-            if (!res)
+            auto const result = ofi::TargetWrapper::fromAPI(in_target)->readBlocking(std::chrono::milliseconds(in_timeoutMs));
+            if (!result)
             {
                 return MXL_ERR_NOT_READY;
             }
 
-            *out_headIndex = res->headIndex;
-            *out_count = res->count;
+            if (std::holds_alternative<ofi::Target::Interrupted>(*result))
+            {
+                return MXL_ERR_INTERRUPTED;
+            }
+
+            auto const sampleResult = std::get_if<ofi::Target::SampleReadResult>(&*result);
+            if (sampleResult == nullptr)
+            {
+                return MXL_ERR_INVALID_STATE;
+            }
+
+            *out_headIndex = sampleResult->headIndex;
+            *out_count = sampleResult->count;
             return MXL_STATUS_OK;
         },
         "Failed to wait for new samples");
@@ -462,12 +507,14 @@ mxlStatus mxlFabricsInitiatorMakeProgressNonBlocking(mxlFabricsInitiator in_init
     return ofi::try_run(
         [&]()
         {
-            if (ofi::InitiatorWrapper::fromAPI(in_initiator)->makeProgress())
-            {
-                return MXL_ERR_NOT_READY;
-            }
-
-            return MXL_STATUS_OK;
+            auto const result = ofi::InitiatorWrapper::fromAPI(in_initiator)->makeProgress();
+            return std::visit(
+                ofi::overloaded{
+                    [](ofi::Initiator::Ready) { return MXL_STATUS_OK; },
+                    [](ofi::Initiator::NotReady) { return MXL_ERR_NOT_READY; },
+                    [](ofi::Initiator::Interrupted) { return MXL_ERR_INTERRUPTED; },
+                },
+                result);
         },
         "Failed to make progress in the initiator");
 }
@@ -483,12 +530,14 @@ mxlStatus mxlFabricsInitiatorMakeProgressBlocking(mxlFabricsInitiator in_initiat
     return ofi::try_run(
         [&]()
         {
-            if (ofi::InitiatorWrapper::fromAPI(in_initiator)->makeProgressBlocking(std::chrono::milliseconds(in_timeoutMs)))
-            {
-                return MXL_ERR_NOT_READY;
-            }
-
-            return MXL_STATUS_OK;
+            auto const result = ofi::InitiatorWrapper::fromAPI(in_initiator)->makeProgressBlocking(std::chrono::milliseconds(in_timeoutMs));
+            return std::visit(
+                ofi::overloaded{
+                    [](ofi::Initiator::Ready) { return MXL_STATUS_OK; },
+                    [](ofi::Initiator::NotReady) { return MXL_ERR_NOT_READY; },
+                    [](ofi::Initiator::Interrupted) { return MXL_ERR_INTERRUPTED; },
+                },
+                result);
         },
         "Failed to make progress in the initiator");
 }

--- a/lib/fabrics/ofi/src/internal/Exception.cpp
+++ b/lib/fabrics/ofi/src/internal/Exception.cpp
@@ -33,6 +33,11 @@ namespace mxl::lib::fabrics::ofi
         return _fiErrno;
     }
 
+    bool FabricException::isInterrupted() const noexcept
+    {
+        return _fiErrno == -FI_EINTR;
+    }
+
     mxlStatus mxlStatusFromFiErrno(int fiErrno)
     {
         switch (fiErrno)

--- a/lib/fabrics/ofi/src/internal/Exception.hpp
+++ b/lib/fabrics/ofi/src/internal/Exception.hpp
@@ -138,6 +138,9 @@ namespace mxl::lib::fabrics::ofi
         [[nodiscard]]
         int fiErrno() const noexcept;
 
+        [[nodiscard]]
+        bool isInterrupted() const noexcept;
+
     private:
         int _fiErrno;
     };

--- a/lib/fabrics/ofi/src/internal/Initiator.cpp
+++ b/lib/fabrics/ofi/src/internal/Initiator.cpp
@@ -89,7 +89,7 @@ namespace mxl::lib::fabrics::ofi
         _inner->transferSamples(headIndex, count);
     }
 
-    bool InitiatorWrapper::makeProgress()
+    Initiator::MakeProgressResult InitiatorWrapper::makeProgress()
     {
         if (!_inner)
         {
@@ -99,7 +99,7 @@ namespace mxl::lib::fabrics::ofi
         return _inner->makeProgress();
     }
 
-    bool InitiatorWrapper::makeProgressBlocking(std::chrono::steady_clock::duration timeout)
+    Initiator::MakeProgressResult InitiatorWrapper::makeProgressBlocking(std::chrono::steady_clock::duration timeout)
     {
         if (!_inner)
         {

--- a/lib/fabrics/ofi/src/internal/Initiator.hpp
+++ b/lib/fabrics/ofi/src/internal/Initiator.hpp
@@ -16,6 +16,18 @@ namespace mxl::lib::fabrics::ofi
     class Initiator
     {
     public:
+        struct Ready
+        {};
+
+        struct NotReady
+        {};
+
+        struct Interrupted
+        {};
+
+        using MakeProgressResult = std::variant<Ready, NotReady, Interrupted>;
+
+    public:
         virtual ~Initiator() = default;
 
         /** \brief Add a target to the initiator.
@@ -69,13 +81,13 @@ namespace mxl::lib::fabrics::ofi
          *
          * This is the non-blocking version of the progress function.
          */
-        virtual bool makeProgress() = 0;
+        virtual MakeProgressResult makeProgress() = 0;
 
         /** \brief Attempts to progress execution, including connection management and data operations.
          *
          * This is the blocking version of the progress function.
          */
-        virtual bool makeProgressBlocking(std::chrono::steady_clock::duration) = 0;
+        virtual MakeProgressResult makeProgressBlocking(std::chrono::steady_clock::duration) = 0;
 
         /** \brief Shut down the initiator gracefully.
          *
@@ -141,11 +153,11 @@ namespace mxl::lib::fabrics::ofi
 
         /** \copydoc Initiator::makeProgress()
          */
-        bool makeProgress();
+        Initiator::MakeProgressResult makeProgress();
 
         /** \copydoc Initiator::makeProgressBlocking()
          */
-        bool makeProgressBlocking(std::chrono::steady_clock::duration);
+        Initiator::MakeProgressResult makeProgressBlocking(std::chrono::steady_clock::duration);
 
     private:
         std::unique_ptr<Initiator> _inner; /**< The underlying initiator implementation. */

--- a/lib/fabrics/ofi/src/internal/RCInitiator.cpp
+++ b/lib/fabrics/ofi/src/internal/RCInitiator.cpp
@@ -358,18 +358,18 @@ namespace mxl::lib::fabrics::ofi
         }
     }
 
-    bool RCInitiator::hasPendingWork() const noexcept
+    Initiator::MakeProgressResult RCInitiator::afterProgressResult() const noexcept
     {
         // Check if any of the targets have pending work.
         for (auto& [_, target] : _targets)
         {
             if (target.hasPendingWork())
             {
-                return true;
+                return Initiator::NotReady{};
             }
         }
 
-        return false;
+        return Initiator::Ready{};
     }
 
     bool RCInitiator::hasTarget() const noexcept
@@ -392,7 +392,7 @@ namespace mxl::lib::fabrics::ofi
         std::erase_if(_targets, [](auto const& item) { return item.second.canEvict(); });
     }
 
-    void RCInitiator::blockOnCQ(std::chrono::steady_clock::duration timeout)
+    Initiator::MakeProgressResult RCInitiator::blockOnCQ(std::chrono::steady_clock::duration timeout)
     {
         // A zero timeout would cause the queue to block indefinetly, which
         // is not our documented behaviour.
@@ -400,30 +400,45 @@ namespace mxl::lib::fabrics::ofi
         {
             // So just behave exactly like the non-blocking variant.
             makeProgress();
-            return;
+            return afterProgressResult();
         }
 
         for (;;)
         {
-            auto completion = _cq->readBlocking(timeout);
-            if (!completion)
+            try
             {
-                // No completion available, if we were flushing any endpoint, transition their state to done.
-                for (auto& [_, target] : _targets)
+                auto completion = _cq->readBlocking(timeout);
+                if (!completion)
                 {
-                    target.terminate();
+                    // No completion available, if we were flushing any endpoint, transition their state to done.
+                    for (auto& [_, target] : _targets)
+                    {
+                        target.terminate();
+                    }
+
+                    return afterProgressResult();
                 }
-                return;
-            }
 
-            // Find the endpoint that this completion was generated from
-            auto ep = _targets.find(Endpoint::idFromToken(completion->token()));
-            if (ep == _targets.end())
+                // Find the endpoint that this completion was generated from
+                auto ep = _targets.find(Endpoint::idFromToken(completion->token()));
+                if (ep == _targets.end())
+                {
+                    MXL_WARN("Received completion for an unknown endpoint");
+                }
+
+                ep->second.consume(*completion);
+
+                return afterProgressResult();
+            }
+            catch (FabricException const& ex)
             {
-                MXL_WARN("Received completion for an unknown endpoint");
-            }
+                if (ex.isInterrupted())
+                {
+                    return Initiator::Interrupted{};
+                }
 
-            return ep->second.consume(*completion);
+                throw;
+            }
         }
     }
 
@@ -478,7 +493,7 @@ namespace mxl::lib::fabrics::ofi
         }
     }
 
-    bool RCInitiator::makeProgress()
+    Initiator::MakeProgressResult RCInitiator::makeProgress()
     {
         if (!hasTarget())
         {
@@ -495,18 +510,17 @@ namespace mxl::lib::fabrics::ofi
         // Evict any peers that are dead and no longer will make progress.
         evictDeadEndpoints();
 
-        return hasPendingWork();
+        return afterProgressResult();
     }
 
-    bool RCInitiator::makeProgressBlocking(std::chrono::steady_clock::duration timeout)
+    Initiator::MakeProgressResult RCInitiator::makeProgressBlocking(std::chrono::steady_clock::duration timeout)
     {
         // If the timeout is less than our maintainance interval, just check all the queues once, execute all maintainance tasks once
         // and block on the completion queue for the rest of the time.
         if (timeout < EQPollInterval)
         {
             makeProgress();
-            blockOnCQ(timeout);
-            return hasPendingWork();
+            return blockOnCQ(timeout);
         }
 
         auto deadline = std::chrono::steady_clock::now() + timeout;
@@ -514,9 +528,9 @@ namespace mxl::lib::fabrics::ofi
         for (;;)
         {
             // Poll all queues, execute all maintainance actions
-            if (!makeProgress())
+            if (std::holds_alternative<Initiator::Ready>(makeProgress()))
             {
-                return false;
+                return Initiator::Ready{};
             }
 
             // Calculate the remaining time until the user wants the blocking function to return. If there is no time left
@@ -524,14 +538,18 @@ namespace mxl::lib::fabrics::ofi
             auto timeUntilDeadline = std::chrono::duration_cast<std::chrono::milliseconds>(deadline - std::chrono::steady_clock::now());
             if (timeUntilDeadline <= decltype(timeUntilDeadline){0})
             {
-                return hasPendingWork();
+                return afterProgressResult();
             }
 
             // Block on the completion queue until a completion arrives, or the interval timeout occurs.
-            blockOnCQ(std::min(EQPollInterval, timeUntilDeadline));
-        }
+            auto const res = blockOnCQ(std::min(EQPollInterval, timeUntilDeadline));
+            if (std::holds_alternative<Initiator::NotReady>(res))
+            {
+                continue;
+            }
 
-        return hasPendingWork();
+            return res;
+        }
     }
 
     void RCInitiator::shutdown()

--- a/lib/fabrics/ofi/src/internal/RCInitiator.hpp
+++ b/lib/fabrics/ofi/src/internal/RCInitiator.hpp
@@ -195,11 +195,11 @@ namespace mxl::lib::fabrics::ofi
 
         /** \copydoc Initiator::makeProgress()
          */
-        virtual bool makeProgress() final;
+        virtual Initiator::MakeProgressResult makeProgress() final;
 
         /** \copydoc Initiator::makeProgressBlocking()
          */
-        virtual bool makeProgressBlocking(std::chrono::steady_clock::duration) final;
+        virtual Initiator::MakeProgressResult makeProgressBlocking(std::chrono::steady_clock::duration) final;
 
         virtual void shutdown() final;
 
@@ -207,7 +207,7 @@ namespace mxl::lib::fabrics::ofi
         /** \brief Returns true if any of the endpoints contained in this initiator have pending work.
          */
         [[nodiscard]]
-        bool hasPendingWork() const noexcept;
+        Initiator::MakeProgressResult afterProgressResult() const noexcept;
 
         /** \brief Returns true if the initiator has at least 1 target added no matter what the state is.
          */
@@ -229,7 +229,8 @@ namespace mxl::lib::fabrics::ofi
 
         /** \brief Block on the completion queue with a timeout.
          */
-        void blockOnCQ(std::chrono::steady_clock::duration timeout);
+        [[nodiscard]]
+        Initiator::MakeProgressResult blockOnCQ(std::chrono::steady_clock::duration timeout);
 
         /** \brief Poll the completion queue and process the events until the queue is empty.
          */

--- a/lib/fabrics/ofi/src/internal/RCTarget.cpp
+++ b/lib/fabrics/ofi/src/internal/RCTarget.cpp
@@ -63,60 +63,14 @@ namespace mxl::lib::fabrics::ofi
         , _state(WaitForConnectionRequest{std::move(pep)})
     {}
 
-    std::optional<Target::GrainReadResult> RCTarget::readGrain()
+    std::optional<Target::ReadResult> RCTarget::read()
     {
-        if (!_proto->canReadGrains())
-        {
-            throw Exception::unsupportedOperation("The current protocol does not support reading grains.");
-        }
-
-        if (auto res = readNext<QueueReadMode::NonBlocking>(std::chrono::steady_clock::duration::zero()); res)
-        {
-            return std::get<Target::GrainReadResult>(*res);
-        }
-        return std::nullopt;
+        return readNext<QueueReadMode::NonBlocking>(std::chrono::steady_clock::duration::zero());
     }
 
-    std::optional<Target::GrainReadResult> RCTarget::readGrainBlocking(std::chrono::steady_clock::duration timeout)
+    std::optional<Target::ReadResult> RCTarget::readBlocking(std::chrono::steady_clock::duration timeout)
     {
-        if (!_proto->canReadGrains())
-        {
-            throw Exception::unsupportedOperation("The current protocol does not support reading grains.");
-        }
-
-        if (auto res = readNext<QueueReadMode::Blocking>(timeout); res)
-        {
-            return std::get<Target::GrainReadResult>(*res);
-        }
-        return std::nullopt;
-    }
-
-    std::optional<Target::SampleReadResult> RCTarget::readSamples()
-    {
-        if (!_proto->canReadSamples())
-        {
-            throw Exception::unsupportedOperation("The current protocol does not support reading samples.");
-        }
-
-        if (auto res = readNext<QueueReadMode::NonBlocking>(std::chrono::steady_clock::duration::zero()); res)
-        {
-            return std::get<Target::SampleReadResult>(*res);
-        }
-        return std::nullopt;
-    }
-
-    std::optional<Target::SampleReadResult> RCTarget::readSamplesBlocking(std::chrono::steady_clock::duration timeout)
-    {
-        if (!_proto->canReadSamples())
-        {
-            throw Exception::unsupportedOperation("The current protocol does not support reading samples.");
-        }
-
-        if (auto res = readNext<QueueReadMode::Blocking>(timeout); res)
-        {
-            return std::get<Target::SampleReadResult>(*res);
-        }
-        return std::nullopt;
+        return readNext<QueueReadMode::Blocking>(timeout);
     }
 
     void RCTarget::shutdown()
@@ -131,67 +85,106 @@ namespace mxl::lib::fabrics::ofi
             overloaded{[](std::monostate) -> State { throw Exception::invalidState("Target is in an invalid state an can no longer make progress"); },
                 [&](WaitForConnectionRequest state) -> State
                 {
-                    auto event = readEventQueue<queueReadMode>(*state.pep.eventQueue(), timeout);
-
-                    // Check if the entry is available and is a connection request
-                    if (event && event->isConnReq())
+                    try
                     {
-                        auto remoteAddr = FabricAddress::fromDestination(event->connReq().info());
-                        MXL_INFO("Accept connection from: {}", remoteAddr.toString());
+                        auto event = readEventQueue<queueReadMode>(*state.pep.eventQueue(), timeout);
 
-                        auto cqAttr = CompletionQueue::Attributes::defaults();
-                        cqAttr.size = _setupOptions.cqDepth.value_or(CompletionQueue::Attributes::DEFAULT_SIZE);
-                        auto cq = CompletionQueue::open(_domain, cqAttr);
-                        auto endpoint = Endpoint::create(_domain, state.pep.id(), event->connReq().info());
-                        endpoint.bind(cq, FI_RECV);
+                        // Check if the entry is available and is a connection request
+                        if (event && event->isConnReq())
+                        {
+                            auto remoteAddr = FabricAddress::fromDestination(event->connReq().info());
+                            MXL_INFO("Accept connection from: {}", remoteAddr.toString());
 
-                        auto eq = EventQueue::open(_domain->fabric(), EventQueue::Attributes::defaults());
-                        endpoint.bind(eq);
+                            auto cqAttr = CompletionQueue::Attributes::defaults();
+                            cqAttr.size = _setupOptions.cqDepth.value_or(CompletionQueue::Attributes::DEFAULT_SIZE);
+                            auto cq = CompletionQueue::open(_domain, cqAttr);
+                            auto endpoint = Endpoint::create(_domain, state.pep.id(), event->connReq().info());
+                            endpoint.bind(cq, FI_RECV);
 
-                        // we are now ready to accept the connection
-                        endpoint.accept();
-                        MXL_DEBUG("Accepted the connection waiting for connected event notification.");
+                            auto eq = EventQueue::open(_domain->fabric(), EventQueue::Attributes::defaults());
+                            endpoint.bind(eq);
 
-                        // Return the new state as the variant type
-                        return RCTarget::WaitForConnection{std::move(endpoint)};
+                            // we are now ready to accept the connection
+                            endpoint.accept();
+                            MXL_DEBUG("Accepted the connection waiting for connected event notification.");
+
+                            // Return the new state as the variant type
+                            return RCTarget::WaitForConnection{std::move(endpoint)};
+                        }
+
+                        return WaitForConnectionRequest{.pep = std::move(state.pep)};
                     }
+                    catch (FabricException const& ex)
+                    {
+                        if (ex.isInterrupted())
+                        {
+                            result = std::make_optional<Target::Interrupted>();
+                            return WaitForConnectionRequest{.pep = std::move(state.pep)};
+                        }
 
-                    return WaitForConnectionRequest{.pep = std::move(state.pep)};
+                        throw;
+                    }
                 },
                 [&](WaitForConnection state) -> State
                 {
-                    auto event = readEventQueue<queueReadMode>(*state.ep.eventQueue(), timeout);
-
-                    if (event && event->isConnected())
+                    try
                     {
-                        MXL_INFO("Received connected event notification, now connected.");
+                        auto event = readEventQueue<queueReadMode>(*state.ep.eventQueue(), timeout);
 
-                        // We have a connected event, so we can transition to the connected state
-                        auto connected = Connected{.ep = std::move(state.ep)};
+                        if (event && event->isConnected())
+                        {
+                            MXL_INFO("Received connected event notification, now connected.");
 
-                        // The endpoint is now ready, initialize the protocol.
-                        _proto->start(connected.ep);
+                            // We have a connected event, so we can transition to the connected state
+                            auto connected = Connected{.ep = std::move(state.ep)};
 
-                        return connected;
+                            // The endpoint is now ready, initialize the protocol.
+                            _proto->start(connected.ep);
+
+                            return connected;
+                        }
+
+                        return WaitForConnection{std::move(state.ep)};
                     }
+                    catch (FabricException const& ex)
+                    {
+                        if (ex.isInterrupted())
+                        {
+                            result = std::make_optional<Target::Interrupted>();
+                            return WaitForConnection{.ep = std::move(state.ep)};
+                        }
 
-                    return WaitForConnection{std::move(state.ep)};
+                        throw;
+                    }
                 },
                 [&](RCTarget::Connected state) -> State
                 {
-                    auto [completion, event] = readEndpointQueues<queueReadMode>(state.ep, timeout);
-                    if (event && event.value().isShutdown())
+                    try
                     {
-                        MXL_INFO("Remote endpoint has shutdown the connection. Transitioning to listening to new connection.");
-                        return WaitForConnectionRequest{.pep = makeListener(state.ep.domain()->fabric())};
-                    }
+                        auto [completion, event] = readEndpointQueues<queueReadMode>(state.ep, timeout);
+                        if (event && event.value().isShutdown())
+                        {
+                            MXL_INFO("Remote endpoint has shutdown the connection. Transitioning to listening to new connection.");
+                            return WaitForConnectionRequest{.pep = makeListener(state.ep.domain()->fabric())};
+                        }
 
-                    if (completion)
+                        if (completion)
+                        {
+                            result = _proto->read(state.ep, *completion);
+                        }
+
+                        return Connected{.ep = std::move(state.ep)};
+                    }
+                    catch (FabricException const& ex)
                     {
-                        result = _proto->read(state.ep, *completion);
-                    }
+                        if (ex.isInterrupted())
+                        {
+                            result = std::make_optional<Target::Interrupted>();
+                            return Connected{.ep = std::move(state.ep)};
+                        }
 
-                    return Connected{.ep = std::move(state.ep)};
+                        throw;
+                    }
                 }},
             std::move(_state));
 

--- a/lib/fabrics/ofi/src/internal/RCTarget.hpp
+++ b/lib/fabrics/ofi/src/internal/RCTarget.hpp
@@ -33,21 +33,8 @@ namespace mxl::lib::fabrics::ofi
         static std::pair<std::unique_ptr<RCTarget>, std::unique_ptr<TargetInfo>> setup(mxlFabricsTargetConfig const& config, FabricInfoView info,
             TargetSetupOptions const& options = {});
 
-        /** \copydoc Target::readGrain()
-         */
-        virtual std::optional<Target::GrainReadResult> readGrain() final;
-
-        /** \copydoc Target::readGrainBlocking()
-         */
-        virtual std::optional<Target::GrainReadResult> readGrainBlocking(std::chrono::steady_clock::duration timeout) final;
-
-        /** \copydoc Target::readSamples()
-         */
-        virtual std::optional<Target::SampleReadResult> readSamples() final;
-
-        /** copydoc Target::readSamplesBlocking()
-         */
-        virtual std::optional<Target::SampleReadResult> readSamplesBlocking(std::chrono::steady_clock::duration timeout) final;
+        virtual std::optional<Target::ReadResult> read();
+        virtual std::optional<Target::ReadResult> readBlocking(std::chrono::steady_clock::duration timeout) final;
 
         /** \brief Shut down the target.
          */

--- a/lib/fabrics/ofi/src/internal/RDMInitiator.cpp
+++ b/lib/fabrics/ofi/src/internal/RDMInitiator.cpp
@@ -218,15 +218,15 @@ namespace mxl::lib::fabrics::ofi
     }
 
     // makeProgress
-    bool RDMInitiator::makeProgress()
+    Initiator::MakeProgressResult RDMInitiator::makeProgress()
     {
         activateIdleEndpoints();
         pollCQ();
-        return hasPendingWork();
+        return afterProgressResult();
     }
 
     // makeProgressBlocking
-    bool RDMInitiator::makeProgressBlocking(std::chrono::steady_clock::duration timeout)
+    Initiator::MakeProgressResult RDMInitiator::makeProgressBlocking(std::chrono::steady_clock::duration timeout)
     {
         auto now = std::chrono::steady_clock::now();
         activateIdleEndpoints();
@@ -235,14 +235,25 @@ namespace mxl::lib::fabrics::ofi
         auto remaining = timeout - elapsed;
         if (remaining.count() >= 0)
         {
-            blockOnCQ(remaining);
+            try
+            {
+                blockOnCQ(remaining);
+            }
+            catch (FabricException const& ex)
+            {
+                if (ex.isInterrupted())
+                {
+                    return Initiator::Interrupted{};
+                }
+                throw;
+            }
         }
         else
         {
             pollCQ();
         }
 
-        return hasPendingWork();
+        return afterProgressResult();
     }
 
     RDMInitiatorTarget& RDMInitiator::findRemoteByEndpoint(Endpoint::Id id)
@@ -267,17 +278,17 @@ namespace mxl::lib::fabrics::ofi
         return it->second;
     }
 
-    bool RDMInitiator::hasPendingWork() const noexcept
+    Initiator::MakeProgressResult RDMInitiator::afterProgressResult() const noexcept
     {
         for (auto const& [_, remote] : _targets)
         {
             if (remote.hasPendingWork())
             {
-                return true;
+                return Initiator::NotReady{};
             }
         }
 
-        return false;
+        return Initiator::Ready{};
     }
 
     void RDMInitiator::blockOnCQ(std::chrono::steady_clock::duration timeout)

--- a/lib/fabrics/ofi/src/internal/RDMInitiator.hpp
+++ b/lib/fabrics/ofi/src/internal/RDMInitiator.hpp
@@ -137,11 +137,11 @@ namespace mxl::lib::fabrics::ofi
 
         /** \copydoc Initiator::makeProgress()
          */
-        virtual bool makeProgress() final;
+        virtual Initiator::MakeProgressResult makeProgress() final;
 
         /** \copydoc Initiator::makeProgressBlocking()
          */
-        virtual bool makeProgressBlocking(std::chrono::steady_clock::duration timeout) final;
+        virtual Initiator::MakeProgressResult makeProgressBlocking(std::chrono::steady_clock::duration timeout) final;
 
     private:
         /** \brief Construct a new RDMInitiator object.
@@ -167,7 +167,7 @@ namespace mxl::lib::fabrics::ofi
         /** \brief Returns true if any of the endpoints contained in this initiator have pending work.
          */
         [[nodiscard]]
-        bool hasPendingWork() const noexcept;
+        Initiator::MakeProgressResult afterProgressResult() const noexcept;
 
         /** \brief Block on the completion queue with a timeout.
          */

--- a/lib/fabrics/ofi/src/internal/RDMTarget.cpp
+++ b/lib/fabrics/ofi/src/internal/RDMTarget.cpp
@@ -85,60 +85,14 @@ namespace mxl::lib::fabrics::ofi
         , _protocol(std::move(proto))
     {}
 
-    std::optional<Target::GrainReadResult> RDMTarget::readGrain()
+    std::optional<Target::ReadResult> RDMTarget::read()
     {
-        if (!_protocol->canReadGrains())
-        {
-            throw Exception::unsupportedOperation("The current protocol does not support reading grains.");
-        }
-
-        if (auto res = readNext<QueueReadMode::NonBlocking>({}); res)
-        {
-            return std::get<Target::GrainReadResult>(*res);
-        }
-        return std::nullopt;
+        return readNext<QueueReadMode::NonBlocking>({});
     }
 
-    std::optional<Target::GrainReadResult> RDMTarget::readGrainBlocking(std::chrono::steady_clock::duration timeout)
+    std::optional<Target::ReadResult> RDMTarget::readBlocking(std::chrono::steady_clock::duration timeout)
     {
-        if (!_protocol->canReadGrains())
-        {
-            throw Exception::unsupportedOperation("The current protocol does not support reading grains.");
-        }
-
-        if (auto res = readNext<QueueReadMode::Blocking>(timeout); res)
-        {
-            return std::get<Target::GrainReadResult>(*res);
-        }
-        return std::nullopt;
-    }
-
-    std::optional<Target::SampleReadResult> RDMTarget::readSamples()
-    {
-        if (!_protocol->canReadSamples())
-        {
-            throw Exception::unsupportedOperation("The current protocol does not support reading samples.");
-        }
-
-        if (auto res = readNext<QueueReadMode::NonBlocking>({}); res)
-        {
-            return std::get<Target::SampleReadResult>(*res);
-        }
-        return std::nullopt;
-    }
-
-    std::optional<Target::SampleReadResult> RDMTarget::readSamplesBlocking(std::chrono::steady_clock::duration timeout)
-    {
-        if (!_protocol->canReadSamples())
-        {
-            throw Exception::unsupportedOperation("The current protocol does not support reading samples.");
-        }
-
-        if (auto res = readNext<QueueReadMode::Blocking>(timeout); res)
-        {
-            return std::get<Target::SampleReadResult>(*res);
-        }
-        return std::nullopt;
+        return readNext<QueueReadMode::Blocking>(timeout);
     }
 
     void RDMTarget::shutdown()
@@ -147,10 +101,22 @@ namespace mxl::lib::fabrics::ofi
     template<QueueReadMode queueReadMode>
     std::optional<Target::ReadResult> RDMTarget::readNext(std::chrono::steady_clock::duration timeout)
     {
-        auto completion = readCompletionQueue<queueReadMode>(*_ep.completionQueue(), timeout);
-        if (completion)
+        try
         {
-            return _protocol->read(_ep, *completion);
+            auto completion = readCompletionQueue<queueReadMode>(*_ep.completionQueue(), timeout);
+            if (completion)
+            {
+                return _protocol->read(_ep, *completion);
+            }
+        }
+        catch (FabricException const& ex)
+        {
+            if (ex.isInterrupted())
+            {
+                return std::make_optional<Target::Interrupted>();
+            }
+
+            throw;
         }
 
         return {};

--- a/lib/fabrics/ofi/src/internal/RDMTarget.hpp
+++ b/lib/fabrics/ofi/src/internal/RDMTarget.hpp
@@ -29,19 +29,11 @@ namespace mxl::lib::fabrics::ofi
 
         /** \copydoc Target::read()
          */
-        virtual std::optional<Target::GrainReadResult> readGrain() final;
+        virtual std::optional<Target::ReadResult> read() final;
 
         /** \copydoc Target::readSamples()
          */
-        virtual std::optional<Target::SampleReadResult> readSamples() final;
-
-        /** \copydoc Target::readBlocking()
-         */
-        virtual std::optional<Target::GrainReadResult> readGrainBlocking(std::chrono::steady_clock::duration timeout) final;
-
-        /** \copydoc Target::readSamplesBlocking()
-         */
-        virtual std::optional<Target::SampleReadResult> readSamplesBlocking(std::chrono::steady_clock::duration timeout) final;
+        virtual std::optional<Target::ReadResult> readBlocking(std::chrono::steady_clock::duration timeout) final;
 
         /** \copydoc Target::shutdown()
          */

--- a/lib/fabrics/ofi/src/internal/Target.cpp
+++ b/lib/fabrics/ofi/src/internal/Target.cpp
@@ -36,44 +36,24 @@ namespace mxl::lib::fabrics::ofi
         return reinterpret_cast<mxlFabricsTarget>(this);
     }
 
-    std::optional<Target::GrainReadResult> TargetWrapper::readGrain()
+    std::optional<Target::ReadResult> TargetWrapper::read()
     {
         if (!_inner)
         {
             throw Exception::invalidState("Target is not set up.");
         }
 
-        return _inner->readGrain();
+        return _inner->read();
     }
 
-    std::optional<Target::GrainReadResult> TargetWrapper::readGrainBlocking(std::chrono::steady_clock::duration timeout)
+    std::optional<Target::ReadResult> TargetWrapper::readBlocking(std::chrono::steady_clock::duration timeout)
     {
         if (!_inner)
         {
             throw Exception::invalidState("Target is not set up.");
         }
 
-        return _inner->readGrainBlocking(timeout);
-    }
-
-    std::optional<Target::SampleReadResult> TargetWrapper::readSamples()
-    {
-        if (!_inner)
-        {
-            throw Exception::invalidState("Target is not set up.");
-        }
-
-        return _inner->readSamples();
-    }
-
-    std::optional<Target::SampleReadResult> TargetWrapper::readSamplesBlocking(std::chrono::steady_clock::duration timeout)
-    {
-        if (!_inner)
-        {
-            throw Exception::invalidState("Target is not set up.");
-        }
-
-        return _inner->readSamplesBlocking(timeout);
+        return _inner->readBlocking(timeout);
     }
 
     template<typename TargetT>

--- a/lib/fabrics/ofi/src/internal/Target.hpp
+++ b/lib/fabrics/ofi/src/internal/Target.hpp
@@ -47,7 +47,10 @@ namespace mxl::lib::fabrics::ofi
             std::size_t count;
         };
 
-        using ReadResult = std::variant<GrainReadResult, SampleReadResult>;
+        struct Interrupted
+        {};
+
+        using ReadResult = std::variant<GrainReadResult, SampleReadResult, Interrupted>;
 
     public:
         virtual ~Target() = default;
@@ -57,26 +60,13 @@ namespace mxl::lib::fabrics::ofi
          * A non-blocking operation that also drives the connection forward. Continuous invocation of this function is necessary for connection
          * establishment and ongoing progress.
          */
-        virtual std::optional<GrainReadResult> readGrain() = 0;
+        virtual std::optional<ReadResult> read() = 0;
 
         /** \brief Determine if new data can be consumed.
          *
          * A blocking version of readGrain. see readGrain().
          */
-        virtual std::optional<GrainReadResult> readGrainBlocking(std::chrono::steady_clock::duration timeout) = 0;
-
-        /** \brief Determine if new data can be consumed.
-         *
-         * A non-blocking operation that also drives the connection forward. Continuous invocation of this function is necessary for connection
-         * establishment and ongoing progress.
-         */
-        virtual std::optional<SampleReadResult> readSamples() = 0;
-
-        /** \brief Determine if new data can be consumed.
-         *
-         * A blocking version of readSamples. see readSamples().
-         */
-        virtual std::optional<SampleReadResult> readSamplesBlocking(std::chrono::steady_clock::duration timeout) = 0;
+        virtual std::optional<ReadResult> readBlocking(std::chrono::steady_clock::duration timeout) = 0;
 
         /** \brief Shut down the target gracefully.
          * Initiates a graceful shutdown of the target and blocks until the shutdown is complete.
@@ -125,19 +115,11 @@ namespace mxl::lib::fabrics::ofi
 
         /** \copydoc Target::readGrain()
          */
-        std::optional<Target::GrainReadResult> readGrain();
+        std::optional<Target::ReadResult> read();
 
         /** \copydoc Target::readGrainBlocking(std::chrono::steady_clock::duration)
          */
-        std::optional<Target::GrainReadResult> readGrainBlocking(std::chrono::steady_clock::duration timeout);
-
-        /** \copydoc Target::readSamples()
-         */
-        std::optional<Target::SampleReadResult> readSamples();
-
-        /** \copydoc Target::readSamplesBlocking(std::chrono::steady_clock::duration)
-         */
-        std::optional<Target::SampleReadResult> readSamplesBlocking(std::chrono::steady_clock::duration timeout);
+        std::optional<Target::ReadResult> readBlocking(std::chrono::steady_clock::duration timeout);
 
         /** \brief Set up the target with the specified configuration.
          *

--- a/tools/mxl-fabrics-demo/demo.cpp
+++ b/tools/mxl-fabrics-demo/demo.cpp
@@ -468,11 +468,6 @@ public:
                 status = makeProgress(std::chrono::milliseconds(10));
                 if (status == MXL_ERR_INTERRUPTED)
                 {
-                    if (g_exit_requested)
-                    {
-                        return MXL_STATUS_OK;
-                    }
-
                     continue;
                 }
 
@@ -566,11 +561,6 @@ public:
                 status = makeProgress(std::chrono::milliseconds(10));
                 if (status == MXL_ERR_INTERRUPTED)
                 {
-                    if (g_exit_requested)
-                    {
-                        return MXL_STATUS_OK;
-                    }
-
                     continue;
                 }
 
@@ -822,11 +812,6 @@ public:
             }
             else if (status == MXL_ERR_INTERRUPTED)
             {
-                if (g_exit_requested)
-                {
-                    return MXL_STATUS_OK;
-                }
-
                 continue;
             }
             else if (status != MXL_STATUS_OK)
@@ -887,11 +872,6 @@ public:
             }
             else if (status == MXL_ERR_INTERRUPTED)
             {
-                if (g_exit_requested)
-                {
-                    return MXL_STATUS_OK;
-                }
-
                 continue;
             }
             else if (status != MXL_STATUS_OK)

--- a/tools/mxl-fabrics-demo/demo.cpp
+++ b/tools/mxl-fabrics-demo/demo.cpp
@@ -51,9 +51,9 @@ struct Config
     InterfaceSelection interface;
 };
 
-void signal_handler(int)
+void signal_handler(int signal)
 {
-    g_exit_requested = 1;
+    g_exit_requested = signal;
 }
 
 struct TransferStats
@@ -359,7 +359,7 @@ public:
             status = makeProgress(std::chrono::milliseconds(250));
             if (status == MXL_ERR_INTERRUPTED)
             {
-                return MXL_STATUS_OK;
+                return status;
             }
 
             if (status != MXL_ERR_NOT_READY && status != MXL_STATUS_OK)
@@ -468,7 +468,7 @@ public:
                 status = makeProgress(std::chrono::milliseconds(10));
                 if (status == MXL_ERR_INTERRUPTED)
                 {
-                    return MXL_STATUS_OK;
+                    return status;
                 }
 
                 if (status != MXL_ERR_NOT_READY && status != MXL_STATUS_OK)
@@ -561,7 +561,7 @@ public:
                 status = makeProgress(std::chrono::milliseconds(10));
                 if (status == MXL_ERR_INTERRUPTED)
                 {
-                    return MXL_STATUS_OK;
+                    return status;
                 }
 
                 if (status != MXL_ERR_NOT_READY && status != MXL_STATUS_OK)
@@ -812,7 +812,7 @@ public:
             }
             else if (status == MXL_ERR_INTERRUPTED)
             {
-                return MXL_STATUS_OK;
+                return status;
             }
             else if (status != MXL_STATUS_OK)
             {
@@ -1060,6 +1060,11 @@ int main(int argc, char** argv)
 
         if (status = app.run(); status != MXL_STATUS_OK)
         {
+            if (status == MXL_ERR_INTERRUPTED)
+            {
+                return 128 + g_exit_requested;
+            }
+
             MXL_ERROR("Failed to run initiator with status '{}'", static_cast<int>(status));
             return status;
         }
@@ -1114,6 +1119,11 @@ int main(int argc, char** argv)
 
         if (status = app.run(); status != MXL_STATUS_OK)
         {
+            if (status == MXL_ERR_INTERRUPTED)
+            {
+                return 128 + g_exit_requested;
+            }
+
             MXL_ERROR("Failed to run target with status '{}'", static_cast<int>(status));
             return status;
         }

--- a/tools/mxl-fabrics-demo/demo.cpp
+++ b/tools/mxl-fabrics-demo/demo.cpp
@@ -51,9 +51,9 @@ struct Config
     InterfaceSelection interface;
 };
 
-void signal_handler(int signal)
+void signal_handler(int)
 {
-    g_exit_requested = signal;
+    g_exit_requested = 1;
 }
 
 struct TransferStats
@@ -468,7 +468,12 @@ public:
                 status = makeProgress(std::chrono::milliseconds(10));
                 if (status == MXL_ERR_INTERRUPTED)
                 {
-                    return status;
+                    if (g_exit_requested)
+                    {
+                        return MXL_STATUS_OK;
+                    }
+
+                    continue;
                 }
 
                 if (status != MXL_ERR_NOT_READY && status != MXL_STATUS_OK)
@@ -561,7 +566,12 @@ public:
                 status = makeProgress(std::chrono::milliseconds(10));
                 if (status == MXL_ERR_INTERRUPTED)
                 {
-                    return status;
+                    if (g_exit_requested)
+                    {
+                        return MXL_STATUS_OK;
+                    }
+
+                    continue;
                 }
 
                 if (status != MXL_ERR_NOT_READY && status != MXL_STATUS_OK)
@@ -812,7 +822,12 @@ public:
             }
             else if (status == MXL_ERR_INTERRUPTED)
             {
-                return status;
+                if (g_exit_requested)
+                {
+                    return MXL_STATUS_OK;
+                }
+
+                continue;
             }
             else if (status != MXL_STATUS_OK)
             {
@@ -872,7 +887,12 @@ public:
             }
             else if (status == MXL_ERR_INTERRUPTED)
             {
-                return MXL_STATUS_OK;
+                if (g_exit_requested)
+                {
+                    return MXL_STATUS_OK;
+                }
+
+                continue;
             }
             else if (status != MXL_STATUS_OK)
             {
@@ -1060,11 +1080,6 @@ int main(int argc, char** argv)
 
         if (status = app.run(); status != MXL_STATUS_OK)
         {
-            if (status == MXL_ERR_INTERRUPTED)
-            {
-                return 128 + g_exit_requested;
-            }
-
             MXL_ERROR("Failed to run initiator with status '{}'", static_cast<int>(status));
             return status;
         }
@@ -1119,11 +1134,6 @@ int main(int argc, char** argv)
 
         if (status = app.run(); status != MXL_STATUS_OK)
         {
-            if (status == MXL_ERR_INTERRUPTED)
-            {
-                return 128 + g_exit_requested;
-            }
-
             MXL_ERROR("Failed to run target with status '{}'", static_cast<int>(status));
             return status;
         }


### PR DESCRIPTION
Some providers return FI_EINTR from blocking completion or event queue reads. This was (almost correctly) forwarded to the user through an exception, but leave our internal state variant in `valueless_by_exception`.
FI_EINTR is a recoverable error, so the user should be able to continue making progress it they choose to do so.
This PR fixes that by catching FI_EINTR early and returning it as a valid result.

Fixes #624 