### PR TITLE
Fix INSTALL_RPATH target for mxl-fabrics-demo

### DIFF
--- a/tools/mxl-fabrics-demo/CMakeLists.txt
+++ b/tools/mxl-fabrics-demo/CMakeLists.txt
@@ -25,7 +25,7 @@ target_link_libraries(mxl-fabrics-demo
             CLI11::CLI11
             spdlog::spdlog
     )
-set_target_properties(mxl-data-probe
+set_target_properties(mxl-fabrics-demo
         PROPERTIES
             INSTALL_RPATH "${MXL_TOOLS_INSTALL_RPATH}"
     )


### PR DESCRIPTION
Correct a copy-paste error introduced in ecd877e0 that applied the mxl-fabrics-demo INSTALL_RPATH to mxl-data-probe instead.
