### PR TITLE
Close previously leaked `access` file fd in PosixDiscreteFlowReader

### DIFF
--- a/lib/internal/src/PosixDiscreteFlowReader.cpp
+++ b/lib/internal/src/PosixDiscreteFlowReader.cpp
@@ -50,6 +50,19 @@ namespace mxl::lib
         // Ignore failures.
     }
 
+    PosixDiscreteFlowReader::~PosixDiscreteFlowReader()
+    {
+        if (_accessFileFd != -1)
+        {
+            if (::close(_accessFileFd) != 0)
+            {
+                auto const error = errno;
+                MXL_ERROR("Failed to close access file fd: {}", ::strerror(error));
+            }
+            _accessFileFd = -1;
+        }
+    }
+
     FlowData const& PosixDiscreteFlowReader::getFlowData() const
     {
         if (_flowData)

--- a/lib/internal/src/PosixDiscreteFlowReader.hpp
+++ b/lib/internal/src/PosixDiscreteFlowReader.hpp
@@ -27,6 +27,11 @@ namespace mxl::lib
          */
         PosixDiscreteFlowReader(FlowManager const& manager, uuids::uuid const& flowId, std::unique_ptr<DiscreteFlowData>&& data);
 
+        /**
+         * Close the access file fd.
+         */
+        virtual ~PosixDiscreteFlowReader();
+
         /** \see FlowReader::getFlowData */
         [[nodiscard]]
         virtual FlowData const& getFlowData() const override;


### PR DESCRIPTION
Fixes #644 