### PR TITLE
Remove one more reference to _currentIndex in PosixContinuousFlowWriter signaling code

### DIFF
--- a/lib/internal/src/PosixContinuousFlowWriter.cpp
+++ b/lib/internal/src/PosixContinuousFlowWriter.cpp
@@ -146,7 +146,7 @@ namespace mxl::lib
         if (currentSyncSampleBatch == _lastSyncSampleBatch)
         {
             // Signal now before overshooting the maximum the next time around
-            if ((_currentIndex % _syncBatchSize) > _earlySyncThreshold)
+            if ((flow->info.runtime.headIndex % _syncBatchSize) > _earlySyncThreshold)
             {
                 _lastSyncSampleBatch = currentSyncSampleBatch + 1U;
             }


### PR DESCRIPTION
Missed this one in #643 
