### PR TITLE
Change MXL_RELEASE_TYPE to rc1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ option(MXL_ENABLE_FABRICS_OFI "Enable building the fabrics library with libfabri
 
 # Build type. Used as a build suffix or in the operating system package file name.  Currently manually set but could be automated using branch names, etc.
 # One of : dev, beta, rc, "" (empty for final releases)
-set(MXL_BUILD_TYPE "beta-1")
+set(MXL_BUILD_TYPE "rc1")
 set(MXL_BUILD_SUFFIX "-${MXL_BUILD_TYPE}")
 
 set(mxl_VERSION 1.1.0)


### PR DESCRIPTION
Update MXL_BUILD_TYPE to rc1 in preparation for release.
No backport required.
