### PR TITLE
Add fabrics FI_HMEM support for CUDA grain payloads

### DIFF
--- a/examples/payload-options/cuda-payload-options.json
+++ b/examples/payload-options/cuda-payload-options.json
@@ -1,0 +1,7 @@
+{
+  "payload": {
+    "location": "device",
+    "deviceIndex": 0,
+    "backend": "cuda-linear"
+  }
+}

--- a/lib/fabrics/include/mxl/fabrics.h
+++ b/lib/fabrics/include/mxl/fabrics.h
@@ -78,6 +78,11 @@ extern "C"
         MXL_FABRICS_IFACE_CAP_BLOCKING_OPERATIONS = MXL_FABRICS_FLAG(0), /**< The interface supports blocking operations. */
         MXL_FABRICS_IFACE_CAP_REMOTE_WRITE = MXL_FABRICS_FLAG(1),        /**< The interface supports remote-write (RDMA) operations. */
         MXL_FABRICS_IFACE_CAP_SEND_RECEIVE = MXL_FABRICS_FLAG(2),        /**< The interface supports send/receive message operations. */
+        /**
+         * The interface supports heterogeneous memory (libfabric FI_HMEM), including CUDA device
+         * buffers via FI_HMEM_CUDA. Required when MXL grain payloads live in device memory.
+         */
+        MXL_FABRICS_IFACE_CAP_HMEM = MXL_FABRICS_FLAG(3),
     } mxlFabricsInterfaceCapFlags;
 
     /** Capabilities of an interface. Returned as informational output by mxlFabricsGetInterfaces().

--- a/lib/fabrics/ofi/CMakeLists.txt
+++ b/lib/fabrics/ofi/CMakeLists.txt
@@ -72,6 +72,21 @@ target_link_libraries(mxl-fabrics-objects
             mxl-fabrics-headers
             PkgConfig::libfabric
 )
+if (MXL_BUILT_WITH_CUDA)
+    find_package(CUDAToolkit REQUIRED)
+    target_compile_definitions(mxl-fabrics-objects
+            PRIVATE
+                MXL_HAS_CUDA=1
+        )
+    target_include_directories(mxl-fabrics-objects
+            PRIVATE
+                ${CUDAToolkit_INCLUDE_DIRS}
+        )
+    target_link_libraries(mxl-fabrics-objects
+            PRIVATE
+                CUDA::cudart
+        )
+endif()
 set_target_properties(mxl-fabrics-objects
         PROPERTIES
             POSITION_INDEPENDENT_CODE ${MXL_POSITION_INDEPENDENT_CODE}
@@ -115,6 +130,12 @@ target_link_libraries(mxl-fabrics
             spdlog::spdlog
             fmt::fmt
       )
+if (MXL_BUILT_WITH_CUDA)
+    target_link_libraries(mxl-fabrics
+            PRIVATE
+                CUDA::cudart
+        )
+endif()
 
 # Add common linker options
 mxl_add_common_target_link_options(mxl-fabrics PRIVATE)

--- a/lib/fabrics/ofi/src/internal/FabricInterfaceDescription.cpp
+++ b/lib/fabrics/ofi/src/internal/FabricInterfaceDescription.cpp
@@ -138,6 +138,10 @@ namespace mxl::lib::fabrics::ofi
         {
             caps |= MXL_FABRICS_IFACE_CAP_REMOTE_WRITE;
         }
+        if ((info->caps & FI_HMEM) != 0)
+        {
+            caps |= MXL_FABRICS_IFACE_CAP_HMEM;
+        }
         if ((*provider != Provider::EFA) || (CompletionQueue::isWaitObjectSupportedForEFA()))
         {
             caps |= MXL_FABRICS_IFACE_CAP_BLOCKING_OPERATIONS;

--- a/lib/fabrics/ofi/src/internal/FabricInterfaceProbe.cpp
+++ b/lib/fabrics/ofi/src/internal/FabricInterfaceProbe.cpp
@@ -180,6 +180,9 @@ namespace mxl::lib::fabrics::ofi
         {
             throw Exception::noFabric("Unsupported provider constraints: Only REMOTE_WRITE supported at this time.");
         }
+        // RMA endpoints only bind a transmit CQ today. Drop SEND_RECEIVE so fi_getinfo does not
+        // advertise FI_RECV (which would require a receive CQ at fi_connect / fi_listen).
+        caps.interfaceCaps &= ~static_cast<std::uint64_t>(MXL_FABRICS_IFACE_CAP_SEND_RECEIVE);
         if (caps.maxMessageSize == 0)
         {
             MXL_WARN("maxMessageSize is not set. This field will be required in a future version.");
@@ -189,11 +192,38 @@ namespace mxl::lib::fabrics::ofi
             *provider, optStringFromCStr(interfaceConfig.address.node), optStringFromCStr(interfaceConfig.address.service));
 
         auto sourceInterfaces = FabricInfoList::getSourceInterfaces(providerConfig, fabricAddress);
-        if (std::ranges::distance(sourceInterfaces) == 0)
+        auto first = sourceInterfaces.begin();
+        auto const end = sourceInterfaces.end();
+        if (first == end)
         {
+            if ((caps.interfaceCaps & MXL_FABRICS_IFACE_CAP_HMEM) != 0)
+            {
+                throw Exception::noFabric(
+                    "no HMEM-capable interface found for provider '{}'. Device grain payloads require a provider/domain with FI_HMEM "
+                    "(e.g. verbs with nvidia_peermem loaded)",
+                    providerConfig.getProviderName());
+            }
             throw Exception::noFabric("no supported interfaces found");
         }
 
-        return {*sourceInterfaces.begin(), std::move(providerConfig)};
+        // Prefer an info entry that passes provider filters (important for HMEM selection).
+        for (auto info = first; info != end; ++info)
+        {
+            if (providerConfig.isSupportedFabricInfo(*info))
+            {
+                return {FabricInfo{*info}, std::move(providerConfig)};
+            }
+        }
+
+        if ((caps.interfaceCaps & MXL_FABRICS_IFACE_CAP_HMEM) != 0)
+        {
+            throw Exception::noFabric(
+                "no HMEM-capable interface found for provider '{}'. Device grain payloads require a provider/domain with FI_HMEM "
+                "(e.g. verbs with nvidia_peermem loaded)",
+                providerConfig.getProviderName());
+        }
+
+        // Host path: preserve historical behavior and accept the first fi_getinfo match.
+        return {FabricInfo{*first}, std::move(providerConfig)};
     }
 }

--- a/lib/fabrics/ofi/src/internal/FabricInterfaceProbe.hpp
+++ b/lib/fabrics/ofi/src/internal/FabricInterfaceProbe.hpp
@@ -20,9 +20,10 @@ namespace mxl::lib::fabrics::ofi
 
     /**
      * Setup path: select a single source interface for target or initiator setup.
-     * Capabilities from \p interfaceConfig are treated as requirements if no transfer capability
-     * (REMOTE_WRITE or SEND_RECEIVE) is set, REMOTE_WRITE is applied with a warning. Returns the
-     * matched fabric info and its resolved provider configuration.
+     * Capabilities from \p interfaceConfig are treated as requirements. At least one transfer
+     * capability (REMOTE_WRITE or SEND_RECEIVE) must be set; currently only REMOTE_WRITE is
+     * implemented. When \c MXL_FABRICS_IFACE_CAP_HMEM is set, only FI_HMEM-capable domains are
+     * accepted (required for CUDA device grain payloads).
      * \param isTarget true for target (FI_REMOTE_WRITE), false for initiator (FI_WRITE).
      * \throws Exception::noFabric if no matching interface is found or capabilities are unsupported.
      */

--- a/lib/fabrics/ofi/src/internal/Format.cpp
+++ b/lib/fabrics/ofi/src/internal/Format.cpp
@@ -24,6 +24,10 @@ namespace mxl::lib::fabrics::ofi
         {
             resultLength += capStrings.emplace_back("SEND_RECEIVE").size();
         }
+        if ((caps & MXL_FABRICS_IFACE_CAP_HMEM) != 0)
+        {
+            resultLength += capStrings.emplace_back("HMEM").size();
+        }
         if (capStrings.empty())
         {
             resultLength += capStrings.emplace_back("<none>").size();

--- a/lib/fabrics/ofi/src/internal/Initiator.cpp
+++ b/lib/fabrics/ofi/src/internal/Initiator.cpp
@@ -3,14 +3,29 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "Initiator.hpp"
+#include <mxl-internal/Logging.hpp>
 #include "mxl/fabrics.h"
 #include "Exception.hpp"
+#include "FabricInfoHelpers.hpp"
 #include "FabricInterfaceProbe.hpp"
 #include "RCInitiator.hpp"
 #include "RDMInitiator.hpp"
+#include "Region.hpp"
 
 namespace mxl::lib::fabrics::ofi
 {
+    namespace
+    {
+        ::mxlFabricsInterfaceConfig interfaceConfigWithHmemIfNeeded(::mxlFabricsInterfaceConfig interfaceConfig, bool needsHmem)
+        {
+            if (needsHmem)
+            {
+                interfaceConfig.caps.flags |= MXL_FABRICS_IFACE_CAP_HMEM;
+                MXL_INFO("Device grain payloads detected; requiring FI_HMEM-capable fabric interface");
+            }
+            return interfaceConfig;
+        }
+    }
 
     InitiatorWrapper* InitiatorWrapper::fromAPI(mxlFabricsInitiator api) noexcept
     {
@@ -29,7 +44,16 @@ namespace mxl::lib::fabrics::ofi
             _inner.reset();
         }
 
-        auto const [info, provierConfig] = selectSourceInterface(config.interface, /* target */ false);
+        auto const needsHmem = regionsNeedHmem(MxlRegions::forReader(config.reader).regions());
+        auto interfaceConfig = interfaceConfigWithHmemIfNeeded(config.interface, needsHmem);
+        auto const [info, providerConfig] = selectSourceInterface(interfaceConfig, /* target */ false);
+        (void)providerConfig;
+
+        if (needsHmem)
+        {
+            requireCapability(info.view(), FI_HMEM, "Selected fabric interface does not support FI_HMEM required by device grain payloads");
+        }
+
         switch (info.view().endpointType())
         {
             case FI_EP_MSG: _inner = RCInitiator::setup(config, info.view()); break;

--- a/lib/fabrics/ofi/src/internal/MemoryRegion.cpp
+++ b/lib/fabrics/ofi/src/internal/MemoryRegion.cpp
@@ -58,7 +58,8 @@ namespace mxl::lib::fabrics::ofi
         attr.auth_key = nullptr;
         attr.iface = region.loc.iface();
         attr.hmem_data = nullptr;
-        attr.page_size = 4096;  // not used'
+        // Leave page_size unset (0). Matching the zero-initialized libfabric default is safest across host and HMEM.
+        attr.page_size = 0;
         attr.base_mr = nullptr; // not used
         attr.sub_mr_cnt = 0;    // not used
 

--- a/lib/fabrics/ofi/src/internal/Protocol.cpp
+++ b/lib/fabrics/ofi/src/internal/Protocol.cpp
@@ -10,11 +10,12 @@
 
 namespace mxl::lib::fabrics::ofi
 {
-    std::unique_ptr<IngressProtocol> selectIngressProtocol(DataLayout const& layout, std::vector<Region> regions, std::uint32_t maxSyncBatchSize)
+    std::unique_ptr<IngressProtocol> selectIngressProtocol(DataLayout const& layout, std::vector<Region> regions, std::uint32_t maxSyncBatchSize,
+        std::size_t regionsPerGrain)
     {
         if (layout.isDiscrete())
         {
-            return std::make_unique<RMAGrainIngressProtocol>(std::move(regions));
+            return std::make_unique<RMAGrainIngressProtocol>(std::move(regions), regionsPerGrain);
         }
         else if (layout.isContinuous())
         {
@@ -30,11 +31,11 @@ namespace mxl::lib::fabrics::ofi
         }
     }
 
-    std::unique_ptr<EgressProtocolTemplate> selectEgressProtocol(DataLayout const& layout, std::vector<Region> regions)
+    std::unique_ptr<EgressProtocolTemplate> selectEgressProtocol(DataLayout const& layout, std::vector<Region> regions, std::size_t regionsPerGrain)
     {
         if (layout.isDiscrete())
         {
-            return std::make_unique<RMAGrainEgressProtocolTemplate>(layout.asDiscrete(), std::move(regions));
+            return std::make_unique<RMAGrainEgressProtocolTemplate>(layout.asDiscrete(), std::move(regions), regionsPerGrain);
         }
         else if (layout.isContinuous())
         {

--- a/lib/fabrics/ofi/src/internal/Protocol.hpp
+++ b/lib/fabrics/ofi/src/internal/Protocol.hpp
@@ -134,16 +134,19 @@ namespace mxl::lib::fabrics::ofi
      * \param layout The data layout.
      * \param regions The regions involved.
      * \param maxSyncBatchSize The maximum batch size for transfers.
+     * \param regionsPerGrain Number of registered regions per discrete grain (1 = contiguous header+payload, 2 = split).
      * \return A unique pointer to the selected ingress protocol.
      */
     [[nodiscard]]
-    std::unique_ptr<IngressProtocol> selectIngressProtocol(DataLayout const& layout, std::vector<Region> regions, std::uint32_t maxSyncBatchSize);
+    std::unique_ptr<IngressProtocol> selectIngressProtocol(DataLayout const& layout, std::vector<Region> regions, std::uint32_t maxSyncBatchSize,
+        std::size_t regionsPerGrain = 1);
 
     /** \brief Select an appropriate egress protocol based on the data layout
      * \param layout The data layout.
      * \param regions The regions involved.
+     * \param regionsPerGrain Number of registered regions per discrete grain (1 = contiguous header+payload, 2 = split).
      * \return A unique pointer to the selected egress protocol.
      */
     [[nodiscard]]
-    std::unique_ptr<EgressProtocolTemplate> selectEgressProtocol(DataLayout const& layout, std::vector<Region> regions);
+    std::unique_ptr<EgressProtocolTemplate> selectEgressProtocol(DataLayout const& layout, std::vector<Region> regions, std::size_t regionsPerGrain = 1);
 }

--- a/lib/fabrics/ofi/src/internal/ProtocolEgressRMA.cpp
+++ b/lib/fabrics/ofi/src/internal/ProtocolEgressRMA.cpp
@@ -8,16 +8,23 @@
 #include "Exception.hpp"
 #include "ImmData.hpp"
 #include "LocalRegion.hpp"
+#include <mxl-internal/Logging.hpp>
+
+#if defined(MXL_HAS_CUDA) && MXL_HAS_CUDA
+#  include <cuda_runtime.h>
+#endif
 
 namespace mxl::lib::fabrics::ofi
 {
 
     RMAGrainEgressProtocol::RMAGrainEgressProtocol(Completion::Token token, TargetInfo info, DataLayout::Discrete layout,
-        std::vector<LocalRegion> localRegions)
+        std::vector<LocalRegion> localRegions, std::vector<Region> sourceRegions, std::size_t regionsPerGrain)
         : _token{token}
         , _remoteInfo{std::move(info)}
         , _layout{layout}
         , _localRegions{std::move(localRegions)}
+        , _sourceRegions{std::move(sourceRegions)}
+        , _regionsPerGrain{regionsPerGrain}
     {}
 
     void RMAGrainEgressProtocol::registerMemory(std::shared_ptr<Domain>)
@@ -28,16 +35,84 @@ namespace mxl::lib::fabrics::ofi
     void RMAGrainEgressProtocol::transferGrain(Endpoint const& ep, std::uint64_t localIndex, std::uint64_t remoteIndex, std::uint32_t payloadOffset,
         SliceRange const& sliceRange, ::fi_addr_t destAddr)
     {
-        auto const localSize = sliceRange.transferSize(payloadOffset, _layout.sliceSizes[0]);
-        auto const localOffset = sliceRange.transferOffset(payloadOffset, _layout.sliceSizes[0]);
-        auto const remoteSize = sliceRange.transferSize(payloadOffset, _layout.sliceSizes[0]);
-        auto const remoteOffset = sliceRange.transferOffset(payloadOffset, _layout.sliceSizes[0]);
+        if ((_regionsPerGrain == 0) || ((_localRegions.size() % _regionsPerGrain) != 0) ||
+            ((_remoteInfo.remoteRegions.size() % _regionsPerGrain) != 0))
+        {
+            throw Exception::invalidState("Invalid regionsPerGrain {} for local/remote region counts {}/{}",
+                _regionsPerGrain,
+                _localRegions.size(),
+                _remoteInfo.remoteRegions.size());
+        }
 
-        auto const localRegion = _localRegions[localIndex % _localRegions.size()].sub(localOffset, localSize);
-        auto const remoteRegion = _remoteInfo.remoteRegions[remoteIndex % _remoteInfo.remoteRegions.size()].sub(remoteOffset, remoteSize);
-        auto const remoteSlot = remoteIndex % _remoteInfo.remoteRegions.size();
+        auto const localGrainCount = _localRegions.size() / _regionsPerGrain;
+        auto const remoteGrainCount = _remoteInfo.remoteRegions.size() / _regionsPerGrain;
+        auto const localSlot = localIndex % localGrainCount;
+        auto const remoteSlot = remoteIndex % remoteGrainCount;
+        auto const immData = ImmDataGrain{remoteSlot, sliceRange.end()}.data();
 
-        _pending += ep.write(_token, localRegion, remoteRegion, destAddr, ImmDataGrain{remoteSlot, sliceRange.end()}.data());
+        if (_regionsPerGrain == 1)
+        {
+            // Contiguous host mapping: [GrainHeader | payload]
+            auto const localSize = sliceRange.transferSize(payloadOffset, _layout.sliceSizes[0]);
+            auto const localOffset = sliceRange.transferOffset(payloadOffset, _layout.sliceSizes[0]);
+            auto const remoteSize = sliceRange.transferSize(payloadOffset, _layout.sliceSizes[0]);
+            auto const remoteOffset = sliceRange.transferOffset(payloadOffset, _layout.sliceSizes[0]);
+
+            auto const localRegion = _localRegions[localSlot].sub(localOffset, localSize);
+            auto const remoteRegion = _remoteInfo.remoteRegions[remoteSlot].sub(remoteOffset, remoteSize);
+
+            _pending += ep.write(_token, localRegion, remoteRegion, destAddr, immData);
+            return;
+        }
+
+        // Split header (host) + payload (e.g. CUDA): interleaved [H0,P0,H1,P1,...]
+        // payloadOffset is only meaningful for the contiguous host layout above.
+        (void)payloadOffset;
+
+        auto const headerLocal = _localRegions[localSlot * _regionsPerGrain];
+        auto const payloadLocal = _localRegions[localSlot * _regionsPerGrain + 1];
+        auto const headerRemote = _remoteInfo.remoteRegions[remoteSlot * _regionsPerGrain];
+        auto const payloadRemote = _remoteInfo.remoteRegions[remoteSlot * _regionsPerGrain + 1];
+
+        auto const includeHeader = (sliceRange.start() == 0);
+        auto const payloadByteOffset = static_cast<std::uint64_t>(sliceRange.start()) * _layout.sliceSizes[0];
+        auto const payloadByteSize = static_cast<std::size_t>(sliceRange.end() - sliceRange.start()) * _layout.sliceSizes[0];
+
+        if (includeHeader && (payloadByteSize == 0))
+        {
+            // Header-only transfer (e.g. invalid grain).
+            _pending += ep.write(_token, headerLocal, headerRemote, destAddr, immData);
+            return;
+        }
+
+        if (includeHeader)
+        {
+            _pending += ep.write(_token, headerLocal, headerRemote, destAddr, std::nullopt);
+        }
+
+        if (payloadByteSize > 0)
+        {
+#if defined(MXL_HAS_CUDA) && MXL_HAS_CUDA
+            // Refresh bounce buffer from the flow's device pointer (may be CUDA IPC) before RDMA.
+            auto const& sourcePayload = _sourceRegions[localSlot * _regionsPerGrain + 1];
+            if (!sourcePayload.loc.isHost() && (sourcePayload.base != payloadLocal.addr))
+            {
+                if (auto const err = ::cudaSetDevice(static_cast<int>(sourcePayload.loc.id())); err != cudaSuccess)
+                {
+                    throw Exception::make(MXL_ERR_UNKNOWN, "cudaSetDevice failed before egress bounce copy: {}", cudaGetErrorString(err));
+                }
+                auto const* src = reinterpret_cast<void const*>(sourcePayload.base + payloadByteOffset);
+                auto* dst = reinterpret_cast<void*>(payloadLocal.addr + payloadByteOffset);
+                if (auto const err = ::cudaMemcpy(dst, src, payloadByteSize, cudaMemcpyDeviceToDevice); err != cudaSuccess)
+                {
+                    throw Exception::make(MXL_ERR_UNKNOWN, "cudaMemcpy to egress bounce buffer failed: {}", cudaGetErrorString(err));
+                }
+            }
+#endif
+            auto const localPayload = payloadLocal.sub(payloadByteOffset, payloadByteSize);
+            auto const remotePayload = payloadRemote.sub(payloadByteOffset, payloadByteSize);
+            _pending += ep.write(_token, localPayload, remotePayload, destAddr, immData);
+        }
     }
 
     void RMAGrainEgressProtocol::transferSamples(Endpoint const&, std::uint64_t, std::size_t, ::fi_addr_t)
@@ -60,10 +135,91 @@ namespace mxl::lib::fabrics::ofi
         return std::exchange(_pending, 0);
     }
 
-    RMAGrainEgressProtocolTemplate::RMAGrainEgressProtocolTemplate(DataLayout::Discrete layout, std::vector<Region> regions)
+    RMAGrainEgressProtocolTemplate::RMAGrainEgressProtocolTemplate(DataLayout::Discrete layout, std::vector<Region> regions, std::size_t regionsPerGrain)
         : _layout{layout}
+        , _sourceRegions{regions}
         , _regions{std::move(regions)}
+        , _regionsPerGrain{regionsPerGrain}
     {}
+
+    RMAGrainEgressProtocolTemplate::~RMAGrainEgressProtocolTemplate()
+    {
+#if defined(MXL_HAS_CUDA) && MXL_HAS_CUDA
+        for (auto* ptr : _cudaBounceBuffers)
+        {
+            if (ptr != nullptr)
+            {
+                (void)::cudaFree(ptr);
+            }
+        }
+#endif
+        _cudaBounceBuffers.clear();
+    }
+
+    void RMAGrainEgressProtocolTemplate::prepareRegisterableCudaRegions()
+    {
+#if defined(MXL_HAS_CUDA) && MXL_HAS_CUDA
+        auto needsBounce = false;
+        for (auto const& region : _regions)
+        {
+            if (!region.loc.isHost())
+            {
+                needsBounce = true;
+                break;
+            }
+        }
+        if (!needsBounce)
+        {
+            return;
+        }
+
+        MXL_INFO("Preparing process-local CUDA bounce buffers for fabrics egress registration "
+                 "(CUDA IPC imports are not registerable with nvidia_peermem)");
+
+        auto registerable = std::vector<Region>{};
+        registerable.reserve(_regions.size());
+
+        for (auto const& region : _regions)
+        {
+            if (region.loc.isHost())
+            {
+                registerable.push_back(region);
+                continue;
+            }
+
+            if (auto const err = ::cudaSetDevice(static_cast<int>(region.loc.id())); err != cudaSuccess)
+            {
+                throw Exception::make(MXL_ERR_UNKNOWN, "cudaSetDevice({}) failed while preparing egress bounce buffers: {}",
+                    region.loc.id(),
+                    cudaGetErrorString(err));
+            }
+
+            void* bounce = nullptr;
+            if (auto const err = ::cudaMalloc(&bounce, region.size); err != cudaSuccess)
+            {
+                throw Exception::make(MXL_ERR_UNKNOWN, "cudaMalloc({} bytes) for egress bounce buffer failed: {}", region.size, cudaGetErrorString(err));
+            }
+            _cudaBounceBuffers.push_back(bounce);
+
+            registerable.emplace_back(reinterpret_cast<std::uintptr_t>(bounce),
+                region.size,
+                region.grainIndexPtr,
+                region.validSlicesPtr,
+                region.loc);
+        }
+
+        _regions = std::move(registerable);
+#else
+        for (auto const& region : _regions)
+        {
+            if (!region.loc.isHost())
+            {
+                throw Exception::make(MXL_ERR_UNSUPPORTED_OPERATION,
+                    "CUDA grain payloads require MXL built with CUDA to register fabrics egress buffers");
+            }
+        }
+#endif
+    }
 
     void RMAGrainEgressProtocolTemplate::registerMemory(std::shared_ptr<Domain> domain)
     {
@@ -72,6 +228,7 @@ namespace mxl::lib::fabrics::ofi
             throw Exception::invalidState("Memory already registered.");
         }
 
+        prepareRegisterableCudaRegions();
         domain->registerRegions(_regions, FI_WRITE);
         _localRegions = domain->localRegions();
     }
@@ -83,14 +240,22 @@ namespace mxl::lib::fabrics::ofi
             throw Exception::invalidState("Cannot create protocol before memory is registered.");
         }
 
+        if (remoteInfo.remoteRegions.size() != _localRegions->size())
+        {
+            throw Exception::invalidArgument("Remote region count {} does not match local region count {}",
+                remoteInfo.remoteRegions.size(),
+                _localRegions->size());
+        }
+
         struct MakeUniqueEnabler : RMAGrainEgressProtocol
         {
-            MakeUniqueEnabler(Completion::Token token, TargetInfo info, DataLayout::Discrete layout, std::vector<LocalRegion> localRegion)
-                : RMAGrainEgressProtocol{token, std::move(info), layout, std::move(localRegion)}
+            MakeUniqueEnabler(Completion::Token token, TargetInfo info, DataLayout::Discrete layout, std::vector<LocalRegion> localRegion,
+                std::vector<Region> sourceRegions, std::size_t regionsPerGrain)
+                : RMAGrainEgressProtocol{token, std::move(info), layout, std::move(localRegion), std::move(sourceRegions), regionsPerGrain}
             {}
         };
 
-        return std::make_unique<MakeUniqueEnabler>(token, std::move(remoteInfo), _layout, *_localRegions);
+        return std::make_unique<MakeUniqueEnabler>(token, std::move(remoteInfo), _layout, *_localRegions, _sourceRegions, _regionsPerGrain);
     }
 
     RMASampleEgressProtocol::RMASampleEgressProtocol(Completion::Token token, TargetInfo info, DataLayout::Continuous layout, LocalRegion localRegion,

--- a/lib/fabrics/ofi/src/internal/ProtocolEgressRMA.hpp
+++ b/lib/fabrics/ofi/src/internal/ProtocolEgressRMA.hpp
@@ -47,13 +47,16 @@ namespace mxl::lib::fabrics::ofi
     private:
         friend class RMAGrainEgressProtocolTemplate;
 
-        RMAGrainEgressProtocol(Completion::Token token, TargetInfo info, DataLayout::Discrete dataLayout, std::vector<LocalRegion> _localRegions);
+        RMAGrainEgressProtocol(Completion::Token token, TargetInfo info, DataLayout::Discrete dataLayout, std::vector<LocalRegion> localRegions,
+            std::vector<Region> sourceRegions, std::size_t regionsPerGrain);
 
     private:
         Completion::Token _token;
         TargetInfo _remoteInfo;
         DataLayout::Discrete _layout;
         std::vector<LocalRegion> _localRegions;
+        std::vector<Region> _sourceRegions;
+        std::size_t _regionsPerGrain{1};
         std::size_t _pending = 0;
     };
 
@@ -63,14 +66,27 @@ namespace mxl::lib::fabrics::ofi
     class RMAGrainEgressProtocolTemplate final : public EgressProtocolTemplate
     {
     public:
-        RMAGrainEgressProtocolTemplate(DataLayout::Discrete layout, std::vector<Region> regions);
+        RMAGrainEgressProtocolTemplate(DataLayout::Discrete layout, std::vector<Region> regions, std::size_t regionsPerGrain);
+        ~RMAGrainEgressProtocolTemplate() override;
 
         virtual void registerMemory(std::shared_ptr<Domain> domain) override;
         virtual std::unique_ptr<EgressProtocol> createInstance(Completion::Token, TargetInfo remoteInfo) override;
 
     private:
+        /** \brief For CUDA payloads, allocate process-local cudaMalloc buffers for peermem registration.
+         *
+         * CUDA IPC-imported pointers (reader / non-owning process) cannot be registered with nvidia_peermem.
+         * Egress therefore registers owned bounce buffers and device-to-device copies from the source
+         * pointers before each RDMA write.
+         */
+        void prepareRegisterableCudaRegions();
+
+    private:
         DataLayout::Discrete _layout;
+        std::vector<Region> _sourceRegions;
         std::vector<Region> _regions;
+        std::vector<void*> _cudaBounceBuffers;
+        std::size_t _regionsPerGrain{1};
         std::optional<std::vector<LocalRegion>> _localRegions{};
     };
 

--- a/lib/fabrics/ofi/src/internal/ProtocolIngressRMA.cpp
+++ b/lib/fabrics/ofi/src/internal/ProtocolIngressRMA.cpp
@@ -14,8 +14,9 @@ namespace mxl::lib::fabrics::ofi
 {
     //
     // RMAGrainIngressProtocol implementations below
-    RMAGrainIngressProtocol::RMAGrainIngressProtocol(std::vector<Region> regions)
+    RMAGrainIngressProtocol::RMAGrainIngressProtocol(std::vector<Region> regions, std::size_t regionsPerGrain)
         : _regions{std::move(regions)}
+        , _regionsPerGrain{regionsPerGrain}
     {}
 
     std::vector<RemoteRegion> RMAGrainIngressProtocol::registerMemory(std::shared_ptr<Domain> domain)
@@ -67,10 +68,10 @@ namespace mxl::lib::fabrics::ofi
 
         // Set the number of valid slices in the grain header. This information is received through the immediate data and must be updated
         // in the local shared memory in the case of partial writes.
-        setValidSlicesForGrain(_regions, slot, slice);
+        setValidSlicesForGrain(_regions, slot, slice, _regionsPerGrain);
 
         // Get the actual grain index from the grain header in share memory. This was written in the first RMA write.
-        auto grainIndex = getGrainIndexInRingSlot(_regions, slot);
+        auto grainIndex = getGrainIndexInRingSlot(_regions, slot, _regionsPerGrain);
 
         return std::make_optional<Target::GrainReadResult>(grainIndex);
     }

--- a/lib/fabrics/ofi/src/internal/ProtocolIngressRMA.hpp
+++ b/lib/fabrics/ofi/src/internal/ProtocolIngressRMA.hpp
@@ -17,7 +17,7 @@ namespace mxl::lib::fabrics::ofi
     class RMAGrainIngressProtocol final : public IngressProtocol
     {
     public:
-        RMAGrainIngressProtocol(std::vector<Region> regions);
+        RMAGrainIngressProtocol(std::vector<Region> regions, std::size_t regionsPerGrain = 1);
 
         /** \copydoc IngressProtocol::registerMemory()
          */
@@ -58,6 +58,7 @@ namespace mxl::lib::fabrics::ofi
 
     private:
         std::vector<Region> _regions;
+        std::size_t _regionsPerGrain{1};
         bool _isMemoryRegistered{false};
         std::optional<Target::ImmediateDataLocation> _immDataBuffer{};
     };

--- a/lib/fabrics/ofi/src/internal/ProviderConfig.cpp
+++ b/lib/fabrics/ofi/src/internal/ProviderConfig.cpp
@@ -1,5 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Contributors to the Media eXchange Layer project.
 // SPDX-License-Identifier: Apache-2.0
+#include <algorithm>
+
 #include "ProviderConfig.hpp"
 #include "Exception.hpp"
 
@@ -10,6 +12,12 @@ namespace mxl::lib::fabrics::ofi
         namespace
         {
             constexpr auto const supportedMemoryRegistrationModes = std::uint64_t{FI_MR_VIRT_ADDR | FI_MR_LOCAL | FI_MR_ALLOCATED | FI_MR_PROV_KEY};
+        }
+
+        [[nodiscard]]
+        bool requiresHmem(std::optional<ProviderCapabilities> const& capabilities) noexcept
+        {
+            return capabilities && ((capabilities->interfaceCaps & MXL_FABRICS_IFACE_CAP_HMEM) != 0);
         }
 
         std::uint64_t libfabricCaps(std::optional<ProviderCapabilities> const& capabilities, bool isTarget)
@@ -27,6 +35,10 @@ namespace mxl::lib::fabrics::ofi
             {
                 result |= FI_SEND | FI_RECV;
             }
+            if ((capabilities->interfaceCaps & MXL_FABRICS_IFACE_CAP_HMEM) != 0)
+            {
+                result |= FI_HMEM;
+            }
             return result;
         }
 
@@ -41,7 +53,40 @@ namespace mxl::lib::fabrics::ofi
             {
                 result |= FI_RMA;
             }
+            if ((capabilities->interfaceCaps & MXL_FABRICS_IFACE_CAP_HMEM) != 0)
+            {
+                result |= FI_HMEM;
+            }
             return result;
+        }
+
+        std::uint64_t memoryRegistrationModes(std::optional<ProviderCapabilities> const& capabilities) noexcept
+        {
+            auto modes = supportedMemoryRegistrationModes;
+            if (requiresHmem(capabilities))
+            {
+                modes |= FI_MR_HMEM;
+            }
+            return modes;
+        }
+
+        /**
+         * Host-only setups reject FI_HMEM domains so we keep the historical non-HMEM path.
+         * When HMEM is required (device grain payloads), keep FI_HMEM domains and require the cap.
+         * On the query path (no capabilities), do not filter FI_HMEM so callers can discover
+         * HMEM-capable interfaces via mxlFabricsGetInterfaces().
+         */
+        std::uint64_t filteredCapsForProvider(std::uint64_t baseFilteredCaps, std::optional<ProviderCapabilities> const& capabilities) noexcept
+        {
+            if (!capabilities)
+            {
+                return baseFilteredCaps;
+            }
+            if (requiresHmem(capabilities))
+            {
+                return baseFilteredCaps & ~static_cast<std::uint64_t>(FI_HMEM);
+            }
+            return baseFilteredCaps | FI_HMEM;
         }
     }
 
@@ -67,30 +112,39 @@ namespace mxl::lib::fabrics::ofi
 
     ProviderConfig ProviderConfig::tcp(bool isTarget, std::optional<ProviderCapabilities> capabilities)
     {
+        // TCP has no real HMEM path today; requesting HMEM will fail at fi_getinfo / requiredCaps.
+        // When concrete capabilities are supplied, include FI_MSG in hints so returned fi_info
+        // objects advertise FI_MSG (requiredCaps checks it). Leave discovery (nullopt) unchanged.
+        auto const msgCap = capabilities ? static_cast<std::uint64_t>(FI_MSG) : 0;
         auto values = ProviderConfigValues{
             .providerName = "tcp",
-            .memoryRegistrationModes = supportedMemoryRegistrationModes,
+            .memoryRegistrationModes = static_cast<int>(memoryRegistrationModes(capabilities)),
             .endpointType = FI_EP_MSG,
-            .caps = libfabricCaps(capabilities, isTarget),
+            .caps = libfabricCaps(capabilities, isTarget) | msgCap,
             .supportedAddressFormats = {FI_SOCKADDR_IN, FI_SOCKADDR_IN6},
             .supportedProtocols = {FI_PROTO_SOCK_TCP},
-            .requiredCaps = libfabricRequiredCaps(capabilities) | FI_MSG,
-            .filteredCaps = FI_TAGGED,
+            .requiredCaps = libfabricRequiredCaps(capabilities) | msgCap,
+            .filteredCaps = filteredCapsForProvider(FI_TAGGED, capabilities),
         };
         return ProviderConfig{std::move(values), capabilities};
     }
 
     ProviderConfig ProviderConfig::verbs(bool isTarget, std::optional<ProviderCapabilities> capabilities)
     {
+        // When concrete capabilities are supplied, include FI_MSG in hints so returned fi_info
+        // objects advertise FI_MSG (requiredCaps checks it). Without this, HMEM-capable domains
+        // can be returned without FI_MSG set and then rejected by isSupportedFabricInfo.
+        // Discovery (nullopt) keeps historical zero-cap hints.
+        auto const msgCap = capabilities ? static_cast<std::uint64_t>(FI_MSG) : 0;
         auto values = ProviderConfigValues{
             .providerName = "verbs",
-            .memoryRegistrationModes = supportedMemoryRegistrationModes,
+            .memoryRegistrationModes = static_cast<int>(memoryRegistrationModes(capabilities)),
             .endpointType = FI_EP_MSG,
-            .caps = libfabricCaps(capabilities, isTarget),
+            .caps = libfabricCaps(capabilities, isTarget) | msgCap,
             .supportedAddressFormats = {FI_SOCKADDR_IN, FI_SOCKADDR_IN6},
             .supportedProtocols = {FI_PROTO_RDMA_CM_IB_RC},
-            .requiredCaps = libfabricRequiredCaps(capabilities) | FI_MSG,
-            .filteredCaps = FI_HMEM,
+            .requiredCaps = libfabricRequiredCaps(capabilities) | msgCap,
+            .filteredCaps = filteredCapsForProvider(0, capabilities),
         };
         return ProviderConfig{std::move(values), capabilities};
     }
@@ -99,13 +153,13 @@ namespace mxl::lib::fabrics::ofi
     {
         auto values = ProviderConfigValues{
             .providerName = "shm",
-            .memoryRegistrationModes = supportedMemoryRegistrationModes,
+            .memoryRegistrationModes = static_cast<int>(memoryRegistrationModes(capabilities)),
             .endpointType = FI_EP_RDM,
             .caps = libfabricCaps(capabilities, isTarget),
             .supportedAddressFormats = {FI_ADDR_STR},
             .supportedProtocols = {FI_PROTO_SHM},
             .requiredCaps = libfabricRequiredCaps(capabilities),
-            .filteredCaps = FI_HMEM,
+            .filteredCaps = filteredCapsForProvider(0, capabilities),
         };
         return ProviderConfig{std::move(values), capabilities};
     }
@@ -114,13 +168,13 @@ namespace mxl::lib::fabrics::ofi
     {
         auto values = ProviderConfigValues{
             .providerName = "efa",
-            .memoryRegistrationModes = supportedMemoryRegistrationModes,
+            .memoryRegistrationModes = static_cast<int>(memoryRegistrationModes(capabilities)),
             .endpointType = FI_EP_RDM,
             .caps = libfabricCaps(capabilities, isTarget),
             .supportedAddressFormats = {FI_ADDR_EFA},
             .supportedProtocols = {FI_PROTO_EFA},
             .requiredCaps = libfabricRequiredCaps(capabilities),
-            .filteredCaps = FI_HMEM | FI_TAGGED,
+            .filteredCaps = filteredCapsForProvider(FI_TAGGED, capabilities),
         };
         return ProviderConfig{std::move(values), capabilities};
     }

--- a/lib/fabrics/ofi/src/internal/RCInitiator.cpp
+++ b/lib/fabrics/ofi/src/internal/RCInitiator.cpp
@@ -117,8 +117,10 @@ namespace mxl::lib::fabrics::ofi
                         std::chrono::duration_cast<std::chrono::milliseconds>(idleDuration).count());
 
                     // The endpoint in an idle target is always fresh and thus needs to be bound the the queues.
+                    // Bind FI_RECV as well: verbs often advertises FI_RECV on MSG endpoints even for RMA-only
+                    // setups (especially FI_HMEM domains), and fi_connect requires a recv CQ in that case.
                     state.ep.bind(eq);
-                    state.ep.bind(cq, FI_TRANSMIT);
+                    state.ep.bind(cq, FI_TRANSMIT | FI_RECV);
 
                     // Transition into the connecting state
                     auto const faddr = _info.fabricAddress.decode();
@@ -283,7 +285,7 @@ namespace mxl::lib::fabrics::ofi
         auto cq = CompletionQueue::open(domain);
 
         auto regions = MxlRegions::forReader(config.reader);
-        auto proto = selectEgressProtocol(regions.dataLayout(), regions.regions());
+        auto proto = selectEgressProtocol(regions.dataLayout(), regions.regions(), regions.regionsPerGrain());
         proto->registerMemory(domain);
 
         struct MakeUniqueEnabler : RCInitiator

--- a/lib/fabrics/ofi/src/internal/RCTarget.cpp
+++ b/lib/fabrics/ofi/src/internal/RCTarget.cpp
@@ -40,7 +40,7 @@ namespace mxl::lib::fabrics::ofi
         auto pep = makeListener(fabric);
 
         auto const mxlRegions = MxlRegions::forWriter(config.writer);
-        auto proto = selectIngressProtocol(mxlRegions.dataLayout(), mxlRegions.regions(), mxlRegions.maxSyncBatchSize());
+        auto proto = selectIngressProtocol(mxlRegions.dataLayout(), mxlRegions.regions(), mxlRegions.maxSyncBatchSize(), mxlRegions.regionsPerGrain());
         auto targetInfo = std::make_unique<TargetInfo>(
             pep.id(), pep.localAddress(), *provider, proto->registerMemory(domain), proto->bounceBufferInfo());
 
@@ -143,7 +143,8 @@ namespace mxl::lib::fabrics::ofi
                         cqAttr.size = _setupOptions.cqDepth.value_or(CompletionQueue::Attributes::DEFAULT_SIZE);
                         auto cq = CompletionQueue::open(_domain, cqAttr);
                         auto endpoint = Endpoint::create(_domain, state.pep.id(), event->connReq().info());
-                        endpoint.bind(cq, FI_RECV);
+                        // HMEM / RMA-capable MSG endpoints advertise transmit caps; bind both directions.
+                        endpoint.bind(cq, FI_RECV | FI_TRANSMIT);
 
                         auto eq = EventQueue::open(_domain->fabric(), EventQueue::Attributes::defaults());
                         endpoint.bind(eq);

--- a/lib/fabrics/ofi/src/internal/RDMInitiator.cpp
+++ b/lib/fabrics/ofi/src/internal/RDMInitiator.cpp
@@ -147,7 +147,7 @@ namespace mxl::lib::fabrics::ofi
         endpoint.enable();
 
         auto regions = MxlRegions::forReader(config.reader);
-        auto proto = selectEgressProtocol(regions.dataLayout(), regions.regions());
+        auto proto = selectEgressProtocol(regions.dataLayout(), regions.regions(), regions.regionsPerGrain());
 
         proto->registerMemory(domain);
 

--- a/lib/fabrics/ofi/src/internal/RDMTarget.cpp
+++ b/lib/fabrics/ofi/src/internal/RDMTarget.cpp
@@ -66,7 +66,7 @@ namespace mxl::lib::fabrics::ofi
         endpoint.enable();
 
         auto mxlRegions = MxlRegions::forWriter(config.writer);
-        auto protocol = selectIngressProtocol(mxlRegions.dataLayout(), mxlRegions.regions(), mxlRegions.maxSyncBatchSize());
+        auto protocol = selectIngressProtocol(mxlRegions.dataLayout(), mxlRegions.regions(), mxlRegions.maxSyncBatchSize(), mxlRegions.regionsPerGrain());
         auto targetInfo = std::make_unique<TargetInfo>(
             endpoint.id(), endpoint.localAddress(), *provider, protocol->registerMemory(domain), protocol->bounceBufferInfo());
 

--- a/lib/fabrics/ofi/src/internal/Region.cpp
+++ b/lib/fabrics/ofi/src/internal/Region.cpp
@@ -127,6 +127,11 @@ namespace mxl::lib::fabrics::ofi
         return _maxSyncBatchSize;
     }
 
+    std::size_t MxlRegions::regionsPerGrain() const noexcept
+    {
+        return _regionsPerGrain;
+    }
+
     MxlRegions mxlFabricsRegionsFromMutableFlow(FlowData& flow)
     {
         auto mxlRegions = mxlFabricsRegionsFromFlow(flow);
@@ -134,16 +139,22 @@ namespace mxl::lib::fabrics::ofi
         if (mxlIsDiscreteDataFormat(static_cast<int>(flow.flowInfo()->config.common.format)))
         {
             auto& discreteFlow = static_cast<DiscreteFlowData&>(flow);
+            auto const stride = mxlRegions.regionsPerGrain();
 
-            if (mxlRegions._regions.size() != discreteFlow.grainCount())
+            if ((stride == 0) || ((mxlRegions._regions.size() % stride) != 0) ||
+                ((mxlRegions._regions.size() / stride) != discreteFlow.grainCount()))
             {
-                throw Exception::invalidState("Unexpected number of grains in discrete flow");
+                throw Exception::invalidState("Unexpected number of regions in discrete flow (regions={}, grains={}, stride={})",
+                    mxlRegions._regions.size(),
+                    discreteFlow.grainCount(),
+                    stride);
             }
 
             for (std::size_t i = 0; i < discreteFlow.grainCount(); ++i)
             {
-                mxlRegions._regions[i].grainIndexPtr = &discreteFlow.grainAt(i)->header.info.index;
-                mxlRegions._regions[i].validSlicesPtr = &discreteFlow.grainAt(i)->header.info.validSlices;
+                auto& headerRegion = mxlRegions._regions[i * stride];
+                headerRegion.grainIndexPtr = &discreteFlow.grainAt(i)->header.info.index;
+                headerRegion.validSlicesPtr = &discreteFlow.grainAt(i)->header.info.validSlices;
             }
         }
 
@@ -156,34 +167,81 @@ namespace mxl::lib::fabrics::ofi
             "GrainHeader type size changed! The Fabrics API makes assumptions on the memory layout of a flow, please review the code below if the "
             "change is intended!");
 
-        if (flow.flowInfo()->config.common.payloadLocation != MXL_PAYLOAD_LOCATION_HOST_MEMORY)
-        {
-            throw Exception::make(MXL_ERR_UNKNOWN,
-                "GPU memory is not currently supported in the Flow API of MXL. Edit the code below when it is supported");
-        }
-
         if (mxlIsDiscreteDataFormat(static_cast<int>(flow.flowInfo()->config.common.format)))
         {
             auto const& discreteFlow = static_cast<DiscreteFlowData const&>(flow);
+            auto const payloadLocation = static_cast<mxlPayloadLocation>(flow.flowInfo()->config.common.payloadLocation);
             auto regions = std::vector<Region>{};
-            regions.reserve(discreteFlow.grainCount());
-            for (auto i = std::size_t{0}; i < discreteFlow.grainCount(); ++i)
+            auto regionsPerGrain = std::size_t{1};
+
+            if (payloadLocation == MXL_PAYLOAD_LOCATION_HOST_MEMORY)
             {
-                auto grain = discreteFlow.grainAt(i);
+                regions.reserve(discreteFlow.grainCount());
+                for (auto i = std::size_t{0}; i < discreteFlow.grainCount(); ++i)
+                {
+                    auto const* grain = discreteFlow.grainAt(i);
+                    auto const grainInfoBaseAddr = reinterpret_cast<std::uintptr_t>(grain);
+                    auto const grainInfoSize = sizeof(GrainHeader);
+                    auto const grainPayloadSize = grain->header.info.grainSize;
 
-                auto grainInfoBaseAddr = reinterpret_cast<std::uintptr_t>(discreteFlow.grainAt(i));
-                auto grainInfoSize = sizeof(GrainHeader);
-                auto grainPayloadSize = grain->header.info.grainSize;
+                    // Host-mapped payloads remain embedded after the grain header (single contiguous MR).
+                    regions.emplace_back(grainInfoBaseAddr, grainInfoSize + grainPayloadSize, nullptr, nullptr, Region::Location::host());
+                }
+            }
+            else if (payloadLocation == MXL_PAYLOAD_LOCATION_DEVICE_MEMORY)
+            {
+                regionsPerGrain = 2;
+                regions.reserve(discreteFlow.grainCount() * regionsPerGrain);
 
-                regions.emplace_back(grainInfoBaseAddr, grainInfoSize + grainPayloadSize, nullptr, nullptr, Region::Location::host());
+                for (auto i = std::size_t{0}; i < discreteFlow.grainCount(); ++i)
+                {
+                    auto const* grain = discreteFlow.grainAt(i);
+                    auto const headerBase = reinterpret_cast<std::uintptr_t>(grain);
+
+                    mxlPayloadView payloadView{};
+                    if (auto const status = discreteFlow.payloadViewAt(i, &payloadView); status != MXL_STATUS_OK)
+                    {
+                        throw Exception::make(status,
+                            "Failed to resolve device grain payload for fabrics registration at slot {} (status {})",
+                            i,
+                            static_cast<int>(status));
+                    }
+                    if (payloadView.kind != MXL_PAYLOAD_KIND_DEVICE_PTR)
+                    {
+                        throw Exception::make(MXL_ERR_UNSUPPORTED_OPERATION,
+                            "Fabrics discrete device flows currently require DEVICE_PTR payloads (got kind {})",
+                            payloadView.kind);
+                    }
+                    if (payloadView.u.devicePtr == 0)
+                    {
+                        throw Exception::invalidState("Device payload pointer is null at grain slot {}", i);
+                    }
+
+                    regions.emplace_back(headerBase, sizeof(GrainHeader), nullptr, nullptr, Region::Location::host());
+                    regions.emplace_back(static_cast<std::uintptr_t>(payloadView.u.devicePtr),
+                        payloadView.grainSize,
+                        nullptr,
+                        nullptr,
+                        Region::Location::cuda(payloadView.deviceIndex));
+                }
+            }
+            else
+            {
+                throw Exception::make(MXL_ERR_UNSUPPORTED_OPERATION, "Unsupported payload location {}", static_cast<int>(payloadLocation));
             }
 
             return {std::move(regions),
                 DataLayout::fromDiscrete(std::to_array(discreteFlow.flowInfo()->config.discrete.sliceSizes)),
-                discreteFlow.flowInfo()->config.common.maxSyncBatchSizeHint};
+                discreteFlow.flowInfo()->config.common.maxSyncBatchSizeHint,
+                regionsPerGrain};
         }
         else if (mxlIsContinuousDataFormat(static_cast<int>(flow.flowInfo()->config.common.format)))
         {
+            if (flow.flowInfo()->config.common.payloadLocation != MXL_PAYLOAD_LOCATION_HOST_MEMORY)
+            {
+                throw Exception::make(MXL_ERR_UNSUPPORTED_OPERATION, "Continuous flows with non-host payloads are not supported by fabrics");
+            }
+
             auto const& continuousFlow = static_cast<ContinuousFlowData const&>(flow);
             auto regions = std::vector<Region>{};
 
@@ -196,7 +254,8 @@ namespace mxl::lib::fabrics::ofi
 
             return {std::move(regions),
                 DataLayout::fromContinuous(continuousFlow.sampleWordSize(), continuousFlow.channelCount(), continuousFlow.channelBufferLength()),
-                continuousFlow.flowInfo()->config.common.maxSyncBatchSizeHint};
+                continuousFlow.flowInfo()->config.common.maxSyncBatchSizeHint,
+                1};
         }
         else
         {
@@ -204,23 +263,47 @@ namespace mxl::lib::fabrics::ofi
         }
     }
 
-    std::uint64_t getGrainIndexInRingSlot(std::vector<Region> const& regions, std::uint16_t slot)
+    namespace
     {
-        if (slot >= regions.size())
+        std::size_t headerRegionIndex(std::uint16_t slot, std::size_t regionsPerGrain, std::size_t regionCount)
         {
-            throw Exception::invalidArgument("Invalid ring buffer slot number: {}, ring buffer len: {}", slot, regions.size());
-        }
+            if ((regionsPerGrain == 0) || ((regionCount % regionsPerGrain) != 0))
+            {
+                throw Exception::invalidState("Invalid regionsPerGrain {} for region count {}", regionsPerGrain, regionCount);
+            }
 
-        return *regions[slot].grainIndexPtr;
+            auto const grainCount = regionCount / regionsPerGrain;
+            if (slot >= grainCount)
+            {
+                throw Exception::invalidArgument("Invalid ring buffer slot number: {}, grain count: {}", slot, grainCount);
+            }
+
+            return static_cast<std::size_t>(slot) * regionsPerGrain;
+        }
     }
 
-    void setValidSlicesForGrain(std::vector<Region> const& regions, std::uint16_t slot, std::uint16_t validSlices)
+    std::uint64_t getGrainIndexInRingSlot(std::vector<Region> const& regions, std::uint16_t slot, std::size_t regionsPerGrain)
     {
-        if (slot >= regions.size())
+        auto const index = headerRegionIndex(slot, regionsPerGrain, regions.size());
+        if (regions[index].grainIndexPtr == nullptr)
         {
-            throw Exception::invalidArgument("Invalid ring buffer slot number: {}, ring buffer len: {}", slot, regions.size());
+            throw Exception::invalidState("Grain index pointer is not set for ring slot {}", slot);
         }
+        return *regions[index].grainIndexPtr;
+    }
 
-        *regions[slot].validSlicesPtr = validSlices;
+    void setValidSlicesForGrain(std::vector<Region> const& regions, std::uint16_t slot, std::uint16_t validSlices, std::size_t regionsPerGrain)
+    {
+        auto const index = headerRegionIndex(slot, regionsPerGrain, regions.size());
+        if (regions[index].validSlicesPtr == nullptr)
+        {
+            throw Exception::invalidState("Valid slices pointer is not set for ring slot {}", slot);
+        }
+        *regions[index].validSlicesPtr = validSlices;
+    }
+
+    bool regionsNeedHmem(std::vector<Region> const& regions) noexcept
+    {
+        return std::ranges::any_of(regions, [](Region const& region) { return !region.loc.isHost(); });
     }
 }

--- a/lib/fabrics/ofi/src/internal/Region.hpp
+++ b/lib/fabrics/ofi/src/internal/Region.hpp
@@ -202,10 +202,16 @@ namespace mxl::lib::fabrics::ofi
     class MxlRegions
     {
     public:
-        MxlRegions(std::vector<Region> regions, DataLayout dataLayout, std::uint32_t maxSyncBatchSize = 0)
+        /**
+         * \param regionsPerGrain For discrete flows: 1 when header+payload are one contiguous host
+         *        mapping, 2 when header (host) and payload (e.g. CUDA) are registered separately
+         *        and interleaved as [header0, payload0, header1, payload1, ...].
+         */
+        MxlRegions(std::vector<Region> regions, DataLayout dataLayout, std::uint32_t maxSyncBatchSize = 0, std::size_t regionsPerGrain = 1)
             : _regions{std::move(regions)}
             , _layout{dataLayout}
             , _maxSyncBatchSize{maxSyncBatchSize}
+            , _regionsPerGrain{regionsPerGrain}
         {}
 
         static MxlRegions forReader(mxlFlowReader);
@@ -222,14 +228,22 @@ namespace mxl::lib::fabrics::ofi
         [[nodiscard]]
         std::uint32_t maxSyncBatchSize() const noexcept;
 
+        /**
+         * \brief Number of registered memory regions that belong to one discrete grain slot.
+         * Always 1 for continuous flows.
+         */
+        [[nodiscard]]
+        std::size_t regionsPerGrain() const noexcept;
+
     private:
-        friend MxlRegions mxlFabricsRegionsFromFlow(FlowData& flow);
+        friend MxlRegions mxlFabricsRegionsFromFlow(FlowData const& flow);
         friend MxlRegions mxlFabricsRegionsFromMutableFlow(FlowData& flow);
 
     private:
         std::vector<Region> _regions;
         DataLayout _layout;
         std::uint32_t _maxSyncBatchSize;
+        std::size_t _regionsPerGrain;
     };
 
     /** \brief Convert a FlowData's memory regions to MxlRegions.
@@ -244,11 +258,13 @@ namespace mxl::lib::fabrics::ofi
     [[nodiscard]]
     MxlRegions mxlFabricsRegionsFromMutableFlow(FlowData& flow);
 
-    /** \brief
-     */
-    std::uint64_t getGrainIndexInRingSlot(std::vector<Region> const& regions, std::uint16_t slotIndex);
+    /** \brief Read the grain index from the header region for ring slot \p slotIndex. */
+    std::uint64_t getGrainIndexInRingSlot(std::vector<Region> const& regions, std::uint16_t slotIndex, std::size_t regionsPerGrain = 1);
 
-    /** \brief
-     */
-    void setValidSlicesForGrain(std::vector<Region> const& regions, std::uint16_t slot, std::uint16_t validSlices);
+    /** \brief Update validSlices on the header region for ring slot \p slot. */
+    void setValidSlicesForGrain(std::vector<Region> const& regions, std::uint16_t slot, std::uint16_t validSlices, std::size_t regionsPerGrain = 1);
+
+    /** \brief True when any region is backed by non-host memory (e.g. CUDA) and needs FI_HMEM. */
+    [[nodiscard]]
+    bool regionsNeedHmem(std::vector<Region> const& regions) noexcept;
 }

--- a/lib/fabrics/ofi/src/internal/Target.cpp
+++ b/lib/fabrics/ofi/src/internal/Target.cpp
@@ -8,15 +8,31 @@
 #include <fmt/format.h>
 #include <rdma/fabric.h>
 #include <rdma/fi_errno.h>
+#include <mxl-internal/Logging.hpp>
 #include "mxl/fabrics.h"
 #include "Exception.hpp"
+#include "FabricInfoHelpers.hpp"
 #include "FabricInterfaceProbe.hpp"
 #include "LocalRegion.hpp"
 #include "RCTarget.hpp"
 #include "RDMTarget.hpp"
+#include "Region.hpp"
 
 namespace mxl::lib::fabrics::ofi
 {
+    namespace
+    {
+        ::mxlFabricsInterfaceConfig interfaceConfigWithHmemIfNeeded(::mxlFabricsInterfaceConfig interfaceConfig, bool needsHmem)
+        {
+            if (needsHmem)
+            {
+                interfaceConfig.caps.flags |= MXL_FABRICS_IFACE_CAP_HMEM;
+                MXL_INFO("Device grain payloads detected; requiring FI_HMEM-capable fabric interface");
+            }
+            return interfaceConfig;
+        }
+    }
+
     LocalRegion Target::ImmediateDataLocation::toLocalRegion() const noexcept
     {
         return LocalRegion{
@@ -91,7 +107,16 @@ namespace mxl::lib::fabrics::ofi
             _inner.reset();
         }
 
-        auto [info, providerConfig] = selectSourceInterface(config.interface, /* target */ true);
+        auto const needsHmem = regionsNeedHmem(MxlRegions::forWriter(config.writer).regions());
+        auto interfaceConfig = interfaceConfigWithHmemIfNeeded(config.interface, needsHmem);
+        auto [info, providerConfig] = selectSourceInterface(interfaceConfig, /* target */ true);
+        (void)providerConfig;
+
+        if (needsHmem)
+        {
+            requireCapability(info.view(), FI_HMEM, "Selected fabric interface does not support FI_HMEM required by device grain payloads");
+        }
+
         switch (info->ep_attr->type)
         {
             case FI_EP_MSG: return setup<RCTarget>(config, info.view(), options);

--- a/lib/include/mxl/flow.h
+++ b/lib/include/mxl/flow.h
@@ -298,6 +298,12 @@ extern "C"
     mxlStatus mxlFlowReaderGetGrain(mxlFlowReader reader, uint64_t index, uint64_t timeoutNs, mxlGrainInfo* grain, uint8_t** payload);
 
     /**
+     * Like \ref mxlFlowReaderGetGrain but returns an \ref mxlPayloadView.
+     */
+    MXL_EXPORT
+    mxlStatus mxlFlowReaderGetGrainEx(mxlFlowReader reader, uint64_t index, uint64_t timeoutNs, mxlGrainInfo* grain, mxlPayloadView* payload);
+
+    /**
      * Accessors for a flow grain at a specific index, with a minimum number of valid slices.
      *
      * \param[in] reader A valid discrete flow reader.
@@ -317,6 +323,13 @@ extern "C"
         uint8_t** payload);
 
     /**
+     * Like \ref mxlFlowReaderGetGrainSlice but returns an \ref mxlPayloadView.
+     */
+    MXL_EXPORT
+    mxlStatus mxlFlowReaderGetGrainSliceEx(mxlFlowReader reader, uint64_t index, uint16_t minValidSlices, uint64_t timeoutNs, mxlGrainInfo* grain,
+        mxlPayloadView* payload);
+
+    /**
      * Non-blocking accessor for a flow grain at a specific index
      *
      * \param[in] reader A valid flow reader
@@ -331,6 +344,12 @@ extern "C"
      */
     MXL_EXPORT
     mxlStatus mxlFlowReaderGetGrainNonBlocking(mxlFlowReader reader, uint64_t index, mxlGrainInfo* grain, uint8_t** payload);
+
+    /**
+     * Like \ref mxlFlowReaderGetGrainNonBlocking but returns an \ref mxlPayloadView.
+     */
+    MXL_EXPORT
+    mxlStatus mxlFlowReaderGetGrainNonBlockingEx(mxlFlowReader reader, uint64_t index, mxlGrainInfo* grain, mxlPayloadView* payload);
 
     /**
      * Non-blocking accessor for a flow grain at a specific index, with a minimum number of valid slices.
@@ -349,6 +368,13 @@ extern "C"
     MXL_EXPORT
     mxlStatus mxlFlowReaderGetGrainSliceNonBlocking(mxlFlowReader reader, uint64_t index, uint16_t minValidSlices, mxlGrainInfo* grain,
         uint8_t** payload);
+
+    /**
+     * Like \ref mxlFlowReaderGetGrainSliceNonBlocking but returns an \ref mxlPayloadView.
+     */
+    MXL_EXPORT
+    mxlStatus mxlFlowReaderGetGrainSliceNonBlockingEx(mxlFlowReader reader, uint64_t index, uint16_t minValidSlices, mxlGrainInfo* grain,
+        mxlPayloadView* payload);
 
     /**
      * Get grain info for a given index. This is used to inspect the grain info without opening the grain for mutation.
@@ -384,6 +410,19 @@ extern "C"
      */
     MXL_EXPORT
     mxlStatus mxlFlowWriterOpenGrain(mxlFlowWriter writer, uint64_t index, mxlGrainInfo* mxlGrainInfo, uint8_t** payload);
+
+    /**
+     * Open a grain for mutation and return an extended payload view.
+     *
+     * Prefer this over \ref mxlFlowWriterOpenGrain when the flow may use a non-host payload
+     * backing store. For host-mapped flows the returned view has kind \c MXL_PAYLOAD_KIND_HOST_PTR
+     * and \c u.hostPtr matches the pointer that \ref mxlFlowWriterOpenGrain would return.
+     *
+     * \return \c MXL_ERR_UNSUPPORTED_OPERATION when the flow records a device payload location but
+     *         no device allocator has been configured yet.
+     */
+    MXL_EXPORT
+    mxlStatus mxlFlowWriterOpenGrainEx(mxlFlowWriter writer, uint64_t index, mxlGrainInfo* mxlGrainInfo, mxlPayloadView* payload);
 
     /**
      *

--- a/lib/include/mxl/flowinfo.h
+++ b/lib/include/mxl/flowinfo.h
@@ -37,6 +37,54 @@ extern "C"
     } mxlPayloadLocation;
 
     /**
+     * How a grain payload can be addressed by a reader or writer.
+     *
+     * Host-mapped payloads (the default today) use \ref MXL_PAYLOAD_KIND_HOST_PTR and are also
+     * exposed through the classic \c uint8_t* grain accessors. Device and opaque backends use the
+     * extended \c mxlPayloadView accessors (\c mxlFlowWriterOpenGrainEx / \c mxlFlowReaderGetGrainEx).
+     */
+    typedef enum mxlPayloadKind
+    {
+        /** Linear payload in the calling process's address space. \c mxlPayloadView::u.hostPtr is valid. */
+        MXL_PAYLOAD_KIND_HOST_PTR = 0,
+        /** Linear device address (e.g. CUDA device pointer). \c mxlPayloadView::u.devicePtr is valid. */
+        MXL_PAYLOAD_KIND_DEVICE_PTR = 1,
+        /** Exported DMA-BUF file descriptor. \c mxlPayloadView::u.dmaBufFd is valid. */
+        MXL_PAYLOAD_KIND_DMABUF = 2,
+        /** Backend-specific opaque resource (e.g. CUDA array, Vulkan image). */
+        MXL_PAYLOAD_KIND_OPAQUE = 3,
+    } mxlPayloadKind;
+
+    /**
+     * Description of a grain payload backing store.
+     *
+     * Grain headers and flow synchronization always live in host shared memory. This structure
+     * describes only the payload bytes that follow (or are associated with) a grain header.
+     */
+    typedef struct mxlPayloadView
+    {
+        /** Payload addressing kind. \see mxlPayloadKind */
+        uint32_t kind;
+        /** Logical payload size in bytes (matches \c mxlGrainInfo::grainSize). */
+        uint32_t grainSize;
+        /** Device index when the payload lives in device memory; -1 for host memory. */
+        int32_t deviceIndex;
+        /** Reserved for future use; must be zero. */
+        uint32_t reserved;
+        union
+        {
+            /** Valid when kind == MXL_PAYLOAD_KIND_HOST_PTR. */
+            uint8_t* hostPtr;
+            /** Valid when kind == MXL_PAYLOAD_KIND_DEVICE_PTR. */
+            uint64_t devicePtr;
+            /** Valid when kind == MXL_PAYLOAD_KIND_DMABUF. */
+            int64_t dmaBufFd;
+            /** Valid when kind == MXL_PAYLOAD_KIND_OPAQUE. */
+            uint64_t opaqueHandle;
+        } u;
+    } mxlPayloadView;
+
+    /**
      * Immutable metadata about a media flow that is independent of the data
      * format of the flow and thus common to all flows handled by MXL.
      */

--- a/lib/internal/CMakeLists.txt
+++ b/lib/internal/CMakeLists.txt
@@ -71,6 +71,7 @@ target_sources(mxl-internal-objects
             src/FlowReader.cpp
             src/FlowSynchronizationGroup.cpp
             src/FlowWriter.cpp
+            src/GrainPayloadAllocator.cpp
             src/Instance.cpp
             src/Logging.cpp
             src/MediaUtils.cpp
@@ -86,6 +87,37 @@ target_sources(mxl-internal-objects
             src/Time.cpp
             src/Timing.cpp
     )
+
+option(MXL_ENABLE_CUDA "Enable CUDA linear grain payload allocator" ON)
+if (MXL_ENABLE_CUDA)
+    find_package(CUDAToolkit QUIET)
+    if (CUDAToolkit_FOUND)
+        message(STATUS "CUDA toolkit found: enabling CudaLinearPayloadAllocator")
+        target_sources(mxl-internal-objects
+                PRIVATE
+                    src/CudaLinearPayloadAllocator.cpp
+            )
+        target_compile_definitions(mxl-internal-objects
+                PRIVATE
+                    MXL_HAS_CUDA=1
+            )
+        target_include_directories(mxl-internal-objects
+                PRIVATE
+                    ${CUDAToolkit_INCLUDE_DIRS}
+            )
+        # PUBLIC so dependents that link mxl-internal-objects (libmxl) also link cudart.
+        target_link_libraries(mxl-internal-objects
+                PUBLIC
+                    CUDA::cudart
+            )
+        set(MXL_BUILT_WITH_CUDA ON CACHE INTERNAL "MXL was configured with CUDA payload support")
+    else()
+        message(STATUS "MXL_ENABLE_CUDA is ON but CUDAToolkit was not found; building without CUDA payload support")
+        set(MXL_BUILT_WITH_CUDA OFF CACHE INTERNAL "MXL was configured with CUDA payload support")
+    endif()
+else()
+    set(MXL_BUILT_WITH_CUDA OFF CACHE INTERNAL "MXL was configured with CUDA payload support")
+endif()
 
 if (NOT TARGET stduuid)
     find_package(stduuid CONFIG REQUIRED)

--- a/lib/internal/include/mxl-internal/CudaLinearPayloadAllocator.hpp
+++ b/lib/internal/include/mxl-internal/CudaLinearPayloadAllocator.hpp
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <vector>
+#include "GrainPayloadAllocator.hpp"
+
+namespace mxl::lib
+{
+#if defined(MXL_HAS_CUDA) && MXL_HAS_CUDA
+    /**
+     * Device payload allocator using cudaMalloc'd linear buffers, shared across processes via
+     * CUDA IPC memory handles published under \c payload/ in the flow directory.
+     */
+    class MXL_EXPORT CudaLinearPayloadAllocator final : public GrainPayloadAllocator
+    {
+    public:
+        explicit CudaLinearPayloadAllocator(int32_t deviceIndex);
+
+        ~CudaLinearPayloadAllocator() override;
+
+        CudaLinearPayloadAllocator(CudaLinearPayloadAllocator const&) = delete;
+        CudaLinearPayloadAllocator& operator=(CudaLinearPayloadAllocator const&) = delete;
+
+        [[nodiscard]]
+        mxlPayloadLocation location() const noexcept override;
+
+        [[nodiscard]]
+        int32_t deviceIndex() const noexcept override;
+
+        [[nodiscard]]
+        char const* backendName() const noexcept override;
+
+        [[nodiscard]]
+        std::size_t mappedPayloadBytes() const noexcept override;
+
+        void attach(GrainPayloadAttachContext const& context) override;
+
+        [[nodiscard]]
+        mxlStatus viewAt(std::size_t slotIndex, Grain const* grain, mxlPayloadView* outView) const noexcept override;
+
+    private:
+        void release() noexcept;
+        void createPayloads(GrainPayloadAttachContext const& context);
+        void openPayloads(GrainPayloadAttachContext const& context);
+        void writeDescriptor(GrainPayloadAttachContext const& context) const;
+
+    private:
+        int32_t _deviceIndex;
+        std::size_t _logicalPayloadSize{0};
+        bool _ownsDeviceMemory{false};
+        /** True when pointers came from the process-local registry (must not free/close). */
+        bool _borrowedFromLocalRegistry{false};
+        std::vector<void*> _devicePtrs;
+        std::vector<std::filesystem::path> _slotPaths;
+    };
+
+    [[nodiscard]]
+    bool isCudaRuntimeAvailable() noexcept;
+#else
+    [[nodiscard]]
+    inline bool isCudaRuntimeAvailable() noexcept
+    {
+        return false;
+    }
+#endif
+}

--- a/lib/internal/include/mxl-internal/DiscreteFlowData.hpp
+++ b/lib/internal/include/mxl-internal/DiscreteFlowData.hpp
@@ -3,15 +3,20 @@
 
 #pragma once
 
+#include <memory>
+#include <stdexcept>
 #include <vector>
 #include <fmt/format.h>
+#include <mxl/mxl.h>
 #include "Flow.hpp"
 #include "FlowData.hpp"
+#include "GrainPayloadAllocator.hpp"
 
 namespace mxl::lib
 {
     ///
-    /// Simple structure holding the shared memory resources of discrete flows.
+    /// Shared memory resources of a discrete flow: grain headers (always host-mapped) plus a
+    /// pluggable payload allocator that describes where grain payload bytes live.
     ///
     class DiscreteFlowData : public FlowData
     {
@@ -29,8 +34,19 @@ namespace mxl::lib
         mxlGrainInfo* grainInfoAt(std::size_t i) noexcept;
         mxlGrainInfo const* grainInfoAt(std::size_t i) const noexcept;
 
+        void setPayloadAllocator(std::unique_ptr<GrainPayloadAllocator> allocator) noexcept;
+        [[nodiscard]]
+        GrainPayloadAllocator const& payloadAllocator() const;
+
+        /**
+         * Resolve the payload view for ring slot \p i via the attached payload allocator.
+         */
+        [[nodiscard]]
+        mxlStatus payloadViewAt(std::size_t i, mxlPayloadView* outView) const noexcept;
+
     private:
         std::vector<SharedMemoryInstance<Grain>> _grains;
+        std::unique_ptr<GrainPayloadAllocator> _payloadAllocator;
     };
 
     /**************************************************************************/
@@ -40,6 +56,7 @@ namespace mxl::lib
     inline DiscreteFlowData::DiscreteFlowData(SharedMemoryInstance<Flow>&& flowSegement) noexcept
         : FlowData{std::move(flowSegement)}
         , _grains{}
+        , _payloadAllocator{}
     {
         _grains.reserve(flowInfo()->config.discrete.grainCount);
     }
@@ -47,6 +64,7 @@ namespace mxl::lib
     inline DiscreteFlowData::DiscreteFlowData(char const* flowFilePath, AccessMode mode, LockMode lockMode)
         : FlowData{flowFilePath, mode, lockMode}
         , _grains{}
+        , _payloadAllocator{}
     {
         _grains.reserve(flowInfo()->config.discrete.grainCount);
     }
@@ -100,5 +118,35 @@ namespace mxl::lib
             return &grain->header.info;
         }
         return nullptr;
+    }
+
+    inline void DiscreteFlowData::setPayloadAllocator(std::unique_ptr<GrainPayloadAllocator> allocator) noexcept
+    {
+        _payloadAllocator = std::move(allocator);
+    }
+
+    inline GrainPayloadAllocator const& DiscreteFlowData::payloadAllocator() const
+    {
+        if (!_payloadAllocator)
+        {
+            throw std::runtime_error{"Discrete flow has no payload allocator."};
+        }
+        return *_payloadAllocator;
+    }
+
+    inline mxlStatus DiscreteFlowData::payloadViewAt(std::size_t i, mxlPayloadView* outView) const noexcept
+    {
+        if ((outView == nullptr) || !_payloadAllocator)
+        {
+            return MXL_ERR_INVALID_ARG;
+        }
+
+        auto const grain = grainAt(i);
+        if (grain == nullptr)
+        {
+            return MXL_ERR_INVALID_ARG;
+        }
+
+        return _payloadAllocator->viewAt(i, grain, outView);
     }
 }

--- a/lib/internal/include/mxl-internal/DiscreteFlowReader.hpp
+++ b/lib/internal/include/mxl-internal/DiscreteFlowReader.hpp
@@ -48,6 +48,12 @@ namespace mxl::lib
             std::uint8_t** out_payload) = 0;
 
         /**
+         * Blocking accessor returning an extended payload view.
+         */
+        virtual mxlStatus getGrain(std::uint64_t in_index, std::uint16_t in_minValidSlices, Timepoint in_deadline, mxlGrainInfo* out_grainInfo,
+            mxlPayloadView* out_payload) = 0;
+
+        /**
          * Non-blocking accessor for a specific grain at a specific index.
          * The index must be greater than or equal to the current tail index of the flow.
          *
@@ -61,6 +67,12 @@ namespace mxl::lib
          */
         virtual mxlStatus getGrain(std::uint64_t in_index, std::uint16_t in_minValidSlices, mxlGrainInfo* out_grainInfo,
             std::uint8_t** out_payload) = 0;
+
+        /**
+         * Non-blocking accessor returning an extended payload view.
+         */
+        virtual mxlStatus getGrain(std::uint64_t in_index, std::uint16_t in_minValidSlices, mxlGrainInfo* out_grainInfo,
+            mxlPayloadView* out_payload) = 0;
 
     protected:
         using FlowReader::FlowReader;

--- a/lib/internal/include/mxl-internal/DiscreteFlowWriter.hpp
+++ b/lib/internal/include/mxl-internal/DiscreteFlowWriter.hpp
@@ -18,6 +18,11 @@ namespace mxl::lib
 
         virtual mxlStatus openGrain(std::uint64_t in_index, mxlGrainInfo* out_grainInfo, std::uint8_t** out_payload) = 0;
 
+        /**
+         * Open a grain and return an extended payload view (host pointer, device pointer, dmabuf, ...).
+         */
+        virtual mxlStatus openGrain(std::uint64_t in_index, mxlGrainInfo* out_grainInfo, mxlPayloadView* out_payload) = 0;
+
         virtual mxlStatus commit(mxlGrainInfo const& mxlGrainInfo) = 0;
 
         virtual mxlStatus cancel() = 0;

--- a/lib/internal/include/mxl-internal/FlowManager.hpp
+++ b/lib/internal/include/mxl-internal/FlowManager.hpp
@@ -57,18 +57,25 @@ namespace mxl::lib
         /// \param[in] flowFormat The flow data format. Must be one of the discrete formats.
         /// \param[in] grainCount How many individual grains to create.
         /// \param[in] grainRate The grain rate.
-        /// \param[in] grainPayloadSize Size of the grain in host memory.  0 if the grain payload lives in device memory.
+        /// \param[in] grainPayloadSize Logical size of the grain payload in bytes. When the payload lives in
+        /// host memory this is also the number of bytes embedded after each grain header. When the payload
+        /// lives in device memory, grain files are header-only (mapped payload size 0) and this value is still
+        /// stored in \c mxlGrainInfo::grainSize.
         /// \param[in] grainNumOfSlices Number of slices per grain.
         /// \param[in] grainSliceLengths Length of each slice in bytes.
         /// \param[in] maxSyncBatchSizeHintOpt Optional max sync batch size hint.
         /// \param[in] maxCommitBatchSizeHintOpt Optional max commit batch size hint
+        /// \param[in] payloadLocation Host or device payload location.
+        /// \param[in] deviceIndex Device index (-1 for host memory).
         /// \return (created, flowData) If the flow was created, the first returnd value is true. If the flow was opened instead, false will be
         /// returned. The second returned value is the flow data of the opened or created flow.
         ///
         std::pair<bool, std::unique_ptr<DiscreteFlowData>> createOrOpenDiscreteFlow(uuids::uuid const& flowId, std::string const& flowDef,
             mxlDataFormat flowFormat, std::size_t grainCount, mxlRational const& grainRate, std::size_t grainPayloadSize,
             std::size_t grainNumOfSlices, std::array<std::uint32_t, MXL_MAX_PLANES_PER_GRAIN> grainSliceLengths,
-            std::uint32_t maxSyncBatchSizeHintOpt = 1, std::uint32_t maxCommitBatchSizeHintOpt = 1);
+            std::uint32_t maxSyncBatchSizeHintOpt = 1, std::uint32_t maxCommitBatchSizeHintOpt = 1,
+            mxlPayloadLocation payloadLocation = MXL_PAYLOAD_LOCATION_HOST_MEMORY, int32_t deviceIndex = -1,
+            std::string const& payloadBackend = {});
 
         ///
         /// Create a new continuous flow together with its associated channel store and open it in read-write mode.
@@ -82,12 +89,15 @@ namespace mxl::lib
         /// \param[in] bufferLength The length of each channel buffer in samples.
         /// \param[in] maxSyncBatchSizeHintOpt Optional max sync batch size hint.
         /// \param[in] maxCommitBatchSizeHintOpt Optional max commit batch size hint
+        /// \param[in] payloadLocation Host or device payload location.
+        /// \param[in] deviceIndex Device index (-1 for host memory).
         /// \return (created, flowData) If the flow was created, the first returnd value is true. If the flow was opened instead, false will be
         /// returned. The second returned value is the flow data of the opened or created flow.
         ///
         std::pair<bool, std::unique_ptr<ContinuousFlowData>> createOrOpenContinuousFlow(uuids::uuid const& flowId, std::string const& flowDef,
             mxlDataFormat flowFormat, mxlRational const& sampleRate, std::size_t channelCount, std::size_t sampleWordSize, std::size_t bufferLength,
-            std::uint32_t maxSyncBatchSizeHintOpt = 1, std::uint32_t maxCommitBatchSizeHintOpt = 1);
+            std::uint32_t maxSyncBatchSizeHintOpt = 1, std::uint32_t maxCommitBatchSizeHintOpt = 1,
+            mxlPayloadLocation payloadLocation = MXL_PAYLOAD_LOCATION_HOST_MEMORY, int32_t deviceIndex = -1);
 
         /// Open an existing flow by id.
         ///

--- a/lib/internal/include/mxl-internal/FlowOptionsParser.hpp
+++ b/lib/internal/include/mxl-internal/FlowOptionsParser.hpp
@@ -7,6 +7,7 @@
 #include <optional>
 #include <string>
 #include <picojson/wrapper.h>
+#include <mxl/flowinfo.h>
 #include <mxl/platform.h>
 
 namespace mxl::lib
@@ -44,6 +45,29 @@ namespace mxl::lib
         std::optional<std::uint32_t> getMaxSyncBatchSizeHint() const;
 
         /**
+         * Payload location from options. Defaults to host memory when omitted.
+         *
+         * Accepted forms:
+         * - Nested: `{ "payload": { "location": "host"|"device", "deviceIndex": <int>, "backend": "cuda-linear" } }`
+         * - Flat:   `{ "payloadLocation": "host"|"device"|0|1, "deviceIndex": <int>, "payloadBackend": "cuda-linear" }`
+         */
+        [[nodiscard]]
+        mxlPayloadLocation getPayloadLocation() const noexcept;
+
+        /**
+         * Device index from options. Defaults to -1 for host, 0 for device when omitted.
+         */
+        [[nodiscard]]
+        int32_t getDeviceIndex() const noexcept;
+
+        /**
+         * Payload backend name from options (e.g. "host", "cuda-linear", "placeholder").
+         * Empty when the caller did not specify a backend (factory applies defaults).
+         */
+        [[nodiscard]]
+        std::string const& getPayloadBackend() const noexcept;
+
+        /**
          * Generic accessor for json fields.
          *
          * \param in_field The field name.
@@ -59,6 +83,9 @@ namespace mxl::lib
         std::optional<std::uint32_t> _maxSyncBatchSizeHint;
         /// \see mxlCommonFlowInfo::maxCommitBatchSizeHint
         std::optional<std::uint32_t> _maxCommitBatchSizeHint;
+        mxlPayloadLocation _payloadLocation{MXL_PAYLOAD_LOCATION_HOST_MEMORY};
+        int32_t _deviceIndex{-1};
+        std::string _payloadBackend;
         /** The parsed flow object. */
         picojson::object _root;
     };

--- a/lib/internal/include/mxl-internal/GrainPayloadAllocator.hpp
+++ b/lib/internal/include/mxl-internal/GrainPayloadAllocator.hpp
@@ -1,0 +1,173 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <mxl/flowinfo.h>
+#include <mxl/mxl.h>
+#include <mxl/platform.h>
+#include "Flow.hpp"
+#include "SharedMemory.hpp"
+
+namespace mxl::lib
+{
+    /** Well-known payload backend names used in flow options / payload.json. */
+    inline constexpr char const* PAYLOAD_BACKEND_HOST = "host";
+    inline constexpr char const* PAYLOAD_BACKEND_CUDA_LINEAR = "cuda-linear";
+    inline constexpr char const* PAYLOAD_BACKEND_PLACEHOLDER = "placeholder";
+
+    /**
+     * Context passed when an allocator is bound to a concrete flow directory.
+     */
+    struct GrainPayloadAttachContext
+    {
+        std::filesystem::path flowDir;
+        std::size_t grainCount{0};
+        std::size_t logicalPayloadSize{0};
+        AccessMode accessMode{AccessMode::READ_ONLY};
+    };
+
+    /**
+     * Strategy that owns (or will own) the payload bytes of a discrete-flow grain ring.
+     *
+     * Grain headers remain file-backed host shared memory. Implementations decide whether payload
+     * bytes are embedded in the same mapping (host) or live elsewhere (device).
+     */
+    class MXL_EXPORT GrainPayloadAllocator
+    {
+    public:
+        virtual ~GrainPayloadAllocator() = default;
+
+        /** Where payloads for this flow are located. */
+        [[nodiscard]]
+        virtual mxlPayloadLocation location() const noexcept = 0;
+
+        /** Device index for device payloads; -1 for host. */
+        [[nodiscard]]
+        virtual int32_t deviceIndex() const noexcept = 0;
+
+        /** Backend name written to / read from payload.json (e.g. "host", "cuda-linear"). */
+        [[nodiscard]]
+        virtual char const* backendName() const noexcept = 0;
+
+        /**
+         * Extra bytes to map together with each \c GrainHeader when creating grain files.
+         * Return 0 when the payload is not embedded in the grain mapping (device memory path).
+         */
+        [[nodiscard]]
+        virtual std::size_t mappedPayloadBytes() const noexcept = 0;
+
+        /**
+         * Bind this allocator to a flow directory.
+         *
+         * On create (\c AccessMode::CREATE_READ_WRITE): allocate payload resources and publish
+         * descriptors under the flow directory.
+         * On open: import previously published descriptors.
+         */
+        virtual void attach(GrainPayloadAttachContext const& context) = 0;
+
+        /**
+         * Build a payload view for ring slot \p slotIndex.
+         *
+         * \return MXL_STATUS_OK on success. MXL_ERR_UNSUPPORTED_OPERATION when the backing store
+         *         exists only as metadata (placeholder device allocator).
+         */
+        [[nodiscard]]
+        virtual mxlStatus viewAt(std::size_t slotIndex, Grain const* grain, mxlPayloadView* outView) const noexcept = 0;
+    };
+
+    /**
+     * Default allocator: payload bytes are embedded immediately after the grain header in the
+     * same host mmap (preserves today's on-disk layout).
+     */
+    class MXL_EXPORT HostMappedPayloadAllocator final : public GrainPayloadAllocator
+    {
+    public:
+        explicit HostMappedPayloadAllocator(std::size_t mappedPayloadBytes) noexcept;
+
+        [[nodiscard]]
+        mxlPayloadLocation location() const noexcept override;
+
+        [[nodiscard]]
+        int32_t deviceIndex() const noexcept override;
+
+        [[nodiscard]]
+        char const* backendName() const noexcept override;
+
+        [[nodiscard]]
+        std::size_t mappedPayloadBytes() const noexcept override;
+
+        void attach(GrainPayloadAttachContext const& context) override;
+
+        [[nodiscard]]
+        mxlStatus viewAt(std::size_t slotIndex, Grain const* grain, mxlPayloadView* outView) const noexcept override;
+
+    private:
+        std::size_t _mappedPayloadBytes;
+    };
+
+    /**
+     * Placeholder for device flows without a concrete device allocator.
+     * Creates header-only grain mappings; payload access returns unsupported.
+     */
+    class MXL_EXPORT DevicePayloadPlaceholderAllocator final : public GrainPayloadAllocator
+    {
+    public:
+        explicit DevicePayloadPlaceholderAllocator(int32_t deviceIndex) noexcept;
+
+        [[nodiscard]]
+        mxlPayloadLocation location() const noexcept override;
+
+        [[nodiscard]]
+        int32_t deviceIndex() const noexcept override;
+
+        [[nodiscard]]
+        char const* backendName() const noexcept override;
+
+        [[nodiscard]]
+        std::size_t mappedPayloadBytes() const noexcept override;
+
+        void attach(GrainPayloadAttachContext const& context) override;
+
+        [[nodiscard]]
+        mxlStatus viewAt(std::size_t slotIndex, Grain const* grain, mxlPayloadView* outView) const noexcept override;
+
+    private:
+        int32_t _deviceIndex;
+    };
+
+    /**
+     * Factory arguments for constructing a payload allocator.
+     */
+    struct GrainPayloadAllocatorSpec
+    {
+        mxlPayloadLocation location{MXL_PAYLOAD_LOCATION_HOST_MEMORY};
+        int32_t deviceIndex{-1};
+        std::size_t logicalPayloadSize{0};
+        /** Backend name: "host", "cuda-linear", "placeholder", or empty for defaults. */
+        std::string backend;
+    };
+
+    /**
+     * Select an allocator from flow options / stored flow metadata.
+     *
+     * For device location with backend "cuda-linear", requires the library to have been built
+     * with CUDA support. Otherwise falls back to the device placeholder (or throws if an
+     * explicit unsupported backend was requested).
+     */
+    [[nodiscard]]
+    MXL_EXPORT std::unique_ptr<GrainPayloadAllocator> makeGrainPayloadAllocator(GrainPayloadAllocatorSpec const& spec);
+
+    /**
+     * Read payload.json from an existing flow directory, if present, and build an allocator.
+     * When payload.json is missing, falls back to \p fallbackSpec (typically from flow config).
+     */
+    [[nodiscard]]
+    MXL_EXPORT std::unique_ptr<GrainPayloadAllocator> makeGrainPayloadAllocatorForFlow(std::filesystem::path const& flowDir,
+        GrainPayloadAllocatorSpec const& fallbackSpec);
+}

--- a/lib/internal/include/mxl-internal/PathUtils.hpp
+++ b/lib/internal/include/mxl-internal/PathUtils.hpp
@@ -15,6 +15,9 @@ namespace mxl::lib
     constexpr auto const GRAIN_DATA_FILE_NAME_STEM = "data";
     constexpr auto const CHANNEL_DATA_FILE_NAME = "channels";
     constexpr auto const DOMAIN_OPTIONS_FILE_NAME = "options.json";
+    constexpr auto const PAYLOAD_DIRECTORY_NAME = "payload";
+    constexpr auto const PAYLOAD_DESCRIPTOR_FILE_NAME = "payload.json";
+    constexpr auto const PAYLOAD_SLOT_FILE_NAME_STEM = "slot";
 
     std::filesystem::path makeFlowDirectoryName(std::filesystem::path const& domain, std::string const& uuid);
 
@@ -37,6 +40,10 @@ namespace mxl::lib
     std::filesystem::path makeChannelDataFilePath(std::filesystem::path const& domain, std::string const& uuid);
 
     std::filesystem::path makeDomainOptionsFilePath(std::filesystem::path const& domain);
+
+    std::filesystem::path makePayloadDirectoryName(std::filesystem::path const& flowDirectory);
+    std::filesystem::path makePayloadDescriptorFilePath(std::filesystem::path const& flowDirectory);
+    std::filesystem::path makePayloadSlotFilePath(std::filesystem::path const& flowDirectory, unsigned int index);
 
     /**************************************************************************/
     /* Inline implementation.                                                 */

--- a/lib/internal/src/CudaLinearPayloadAllocator.cpp
+++ b/lib/internal/src/CudaLinearPayloadAllocator.cpp
@@ -1,0 +1,361 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "mxl-internal/CudaLinearPayloadAllocator.hpp"
+
+#if defined(MXL_HAS_CUDA) && MXL_HAS_CUDA
+
+#   include <fstream>
+#   include <mutex>
+#   include <stdexcept>
+#   include <string>
+#   include <unordered_map>
+#   include <cuda_runtime_api.h>
+#   include <fmt/format.h>
+#   include <picojson/picojson.h>
+#   include <mxl/mxl.h>
+#   include "mxl-internal/Logging.hpp"
+#   include "mxl-internal/PathUtils.hpp"
+
+namespace mxl::lib
+{
+    namespace
+    {
+        [[noreturn]]
+        void throwCuda(char const* what, cudaError_t err)
+        {
+            throw std::runtime_error{fmt::format("{}: {} ({})", what, cudaGetErrorString(err), static_cast<int>(err))};
+        }
+
+        void checkCuda(char const* what, cudaError_t err)
+        {
+            if (err != cudaSuccess)
+            {
+                throwCuda(what, err);
+            }
+        }
+
+        void fillCommon(mxlPayloadView* outView, Grain const* grain, int32_t deviceIndex, std::uint64_t devicePtr) noexcept
+        {
+            *outView = {};
+            outView->kind = MXL_PAYLOAD_KIND_DEVICE_PTR;
+            outView->grainSize = grain->header.info.grainSize;
+            outView->deviceIndex = deviceIndex;
+            outView->reserved = 0;
+            outView->u.devicePtr = devicePtr;
+        }
+
+        /**
+         * CUDA IPC cannot open a handle inside the process that created it. Keep a process-local
+         * registry so multiple MXL instances in the same process can share creator-owned pointers.
+         */
+        class LocalCudaPayloadRegistry
+        {
+        public:
+            static LocalCudaPayloadRegistry& instance()
+            {
+                static LocalCudaPayloadRegistry registry;
+                return registry;
+            }
+
+            void publish(std::filesystem::path const& slotPath, void* devicePtr)
+            {
+                auto key = std::filesystem::weakly_canonical(slotPath).string();
+                auto lock = std::lock_guard{_mutex};
+                _entries[key] = devicePtr;
+            }
+
+            void* lookup(std::filesystem::path const& slotPath) const
+            {
+                auto key = std::filesystem::weakly_canonical(slotPath).string();
+                auto lock = std::lock_guard{_mutex};
+                if (auto it = _entries.find(key); it != _entries.end())
+                {
+                    return it->second;
+                }
+                return nullptr;
+            }
+
+            void unpublish(std::filesystem::path const& slotPath) noexcept
+            {
+                try
+                {
+                    auto key = std::filesystem::weakly_canonical(slotPath).string();
+                    auto lock = std::lock_guard{_mutex};
+                    _entries.erase(key);
+                }
+                catch (...)
+                {
+                }
+            }
+
+        private:
+            mutable std::mutex _mutex;
+            std::unordered_map<std::string, void*> _entries;
+        };
+    }
+
+    bool isCudaRuntimeAvailable() noexcept
+    {
+        int deviceCount = 0;
+        auto const err = cudaGetDeviceCount(&deviceCount);
+        return (err == cudaSuccess) && (deviceCount > 0);
+    }
+
+    CudaLinearPayloadAllocator::CudaLinearPayloadAllocator(int32_t deviceIndex)
+        : _deviceIndex{deviceIndex}
+    {
+        if (deviceIndex < 0)
+        {
+            throw std::invalid_argument{"CudaLinearPayloadAllocator requires deviceIndex >= 0."};
+        }
+    }
+
+    CudaLinearPayloadAllocator::~CudaLinearPayloadAllocator()
+    {
+        release();
+    }
+
+    mxlPayloadLocation CudaLinearPayloadAllocator::location() const noexcept
+    {
+        return MXL_PAYLOAD_LOCATION_DEVICE_MEMORY;
+    }
+
+    int32_t CudaLinearPayloadAllocator::deviceIndex() const noexcept
+    {
+        return _deviceIndex;
+    }
+
+    char const* CudaLinearPayloadAllocator::backendName() const noexcept
+    {
+        return PAYLOAD_BACKEND_CUDA_LINEAR;
+    }
+
+    std::size_t CudaLinearPayloadAllocator::mappedPayloadBytes() const noexcept
+    {
+        return 0U;
+    }
+
+    void CudaLinearPayloadAllocator::attach(GrainPayloadAttachContext const& context)
+    {
+        release();
+
+        if (context.grainCount == 0U)
+        {
+            return;
+        }
+        if (context.logicalPayloadSize == 0U)
+        {
+            throw std::invalid_argument{"CudaLinearPayloadAllocator requires a non-zero logical payload size."};
+        }
+
+        _logicalPayloadSize = context.logicalPayloadSize;
+        checkCuda("cudaSetDevice", cudaSetDevice(_deviceIndex));
+
+        if (context.accessMode == AccessMode::CREATE_READ_WRITE)
+        {
+            createPayloads(context);
+        }
+        else
+        {
+            openPayloads(context);
+        }
+    }
+
+    mxlStatus CudaLinearPayloadAllocator::viewAt(std::size_t slotIndex, Grain const* grain, mxlPayloadView* outView) const noexcept
+    {
+        if ((grain == nullptr) || (outView == nullptr))
+        {
+            return MXL_ERR_INVALID_ARG;
+        }
+        if (slotIndex >= _devicePtrs.size())
+        {
+            return MXL_ERR_INVALID_ARG;
+        }
+
+        fillCommon(outView, grain, _deviceIndex, reinterpret_cast<std::uint64_t>(_devicePtrs[slotIndex]));
+        return MXL_STATUS_OK;
+    }
+
+    void CudaLinearPayloadAllocator::release() noexcept
+    {
+        if (_devicePtrs.empty())
+        {
+            return;
+        }
+
+        // Best-effort device selection; ignore failures during teardown.
+        (void)cudaSetDevice(_deviceIndex);
+
+        for (auto i = std::size_t{0}; i < _devicePtrs.size(); ++i)
+        {
+            auto* ptr = _devicePtrs[i];
+            if (ptr == nullptr)
+            {
+                continue;
+            }
+            if (_ownsDeviceMemory)
+            {
+                if (i < _slotPaths.size())
+                {
+                    LocalCudaPayloadRegistry::instance().unpublish(_slotPaths[i]);
+                }
+                (void)cudaFree(ptr);
+            }
+            else if (!_borrowedFromLocalRegistry)
+            {
+                (void)cudaIpcCloseMemHandle(ptr);
+            }
+        }
+
+        _devicePtrs.clear();
+        _slotPaths.clear();
+        _ownsDeviceMemory = false;
+        _borrowedFromLocalRegistry = false;
+        _logicalPayloadSize = 0;
+    }
+
+    void CudaLinearPayloadAllocator::createPayloads(GrainPayloadAttachContext const& context)
+    {
+        _ownsDeviceMemory = true;
+        _borrowedFromLocalRegistry = false;
+        _devicePtrs.resize(context.grainCount, nullptr);
+        _slotPaths.resize(context.grainCount);
+
+        try
+        {
+            for (auto i = std::size_t{0}; i < context.grainCount; ++i)
+            {
+                void* ptr = nullptr;
+                checkCuda("cudaMalloc", cudaMalloc(&ptr, context.logicalPayloadSize));
+                _devicePtrs[i] = ptr;
+            }
+
+            auto const payloadDir = makePayloadDirectoryName(context.flowDir);
+            std::filesystem::create_directories(payloadDir);
+
+            for (auto i = std::size_t{0}; i < context.grainCount; ++i)
+            {
+                cudaIpcMemHandle_t handle{};
+                checkCuda("cudaIpcGetMemHandle", cudaIpcGetMemHandle(&handle, _devicePtrs[i]));
+
+                auto const slotPath = makePayloadSlotFilePath(context.flowDir, static_cast<unsigned>(i));
+                _slotPaths[i] = slotPath;
+                auto out = std::ofstream{slotPath, std::ios::binary | std::ios::trunc};
+                if (!out)
+                {
+                    throw std::filesystem::filesystem_error{
+                        "Failed to write CUDA IPC handle.", slotPath, std::make_error_code(std::errc::io_error)};
+                }
+                out.write(reinterpret_cast<char const*>(&handle), static_cast<std::streamsize>(sizeof handle));
+                if (!out)
+                {
+                    throw std::filesystem::filesystem_error{
+                        "Failed to write CUDA IPC handle.", slotPath, std::make_error_code(std::errc::io_error)};
+                }
+
+                LocalCudaPayloadRegistry::instance().publish(slotPath, _devicePtrs[i]);
+            }
+
+            writeDescriptor(context);
+            MXL_DEBUG("CudaLinearPayloadAllocator created {} device buffers ({} bytes each) on device {}",
+                context.grainCount,
+                context.logicalPayloadSize,
+                _deviceIndex);
+        }
+        catch (...)
+        {
+            release();
+            throw;
+        }
+    }
+
+    void CudaLinearPayloadAllocator::openPayloads(GrainPayloadAttachContext const& context)
+    {
+        _ownsDeviceMemory = false;
+        _borrowedFromLocalRegistry = false;
+        _devicePtrs.resize(context.grainCount, nullptr);
+        _slotPaths.resize(context.grainCount);
+
+        try
+        {
+            for (auto i = std::size_t{0}; i < context.grainCount; ++i)
+            {
+                auto const slotPath = makePayloadSlotFilePath(context.flowDir, static_cast<unsigned>(i));
+                _slotPaths[i] = slotPath;
+
+                if (auto* localPtr = LocalCudaPayloadRegistry::instance().lookup(slotPath); localPtr != nullptr)
+                {
+                    // Same process as the creator: reuse the original pointer (CUDA IPC forbids
+                    // opening a handle in the creating process).
+                    _devicePtrs[i] = localPtr;
+                    _borrowedFromLocalRegistry = true;
+                    continue;
+                }
+
+                auto in = std::ifstream{slotPath, std::ios::binary};
+                if (!in)
+                {
+                    throw std::filesystem::filesystem_error{
+                        "Failed to read CUDA IPC handle.", slotPath, std::make_error_code(std::errc::no_such_file_or_directory)};
+                }
+
+                cudaIpcMemHandle_t handle{};
+                in.read(reinterpret_cast<char*>(&handle), static_cast<std::streamsize>(sizeof handle));
+                if (!in || (in.gcount() != static_cast<std::streamsize>(sizeof handle)))
+                {
+                    throw std::filesystem::filesystem_error{
+                        "Truncated CUDA IPC handle.", slotPath, std::make_error_code(std::errc::io_error)};
+                }
+
+                void* ptr = nullptr;
+                checkCuda("cudaIpcOpenMemHandle", cudaIpcOpenMemHandle(&ptr, handle, cudaIpcMemLazyEnablePeerAccess));
+                _devicePtrs[i] = ptr;
+            }
+
+            MXL_DEBUG("CudaLinearPayloadAllocator imported {} device buffers on device {} (localRegistry={})",
+                context.grainCount,
+                _deviceIndex,
+                _borrowedFromLocalRegistry);
+        }
+        catch (...)
+        {
+            release();
+            throw;
+        }
+    }
+
+    void CudaLinearPayloadAllocator::writeDescriptor(GrainPayloadAttachContext const& context) const
+    {
+        picojson::object root;
+        root["version"] = picojson::value{1.0};
+        root["backend"] = picojson::value{std::string{PAYLOAD_BACKEND_CUDA_LINEAR}};
+        root["location"] = picojson::value{std::string{"device"}};
+        root["deviceIndex"] = picojson::value{static_cast<double>(_deviceIndex)};
+        root["grainCount"] = picojson::value{static_cast<double>(context.grainCount)};
+        root["grainSize"] = picojson::value{static_cast<double>(context.logicalPayloadSize)};
+        root["export"] = picojson::value{std::string{"cuda-ipc"}};
+
+        picojson::array slots;
+        slots.reserve(context.grainCount);
+        for (auto i = std::size_t{0}; i < context.grainCount; ++i)
+        {
+            picojson::object slot;
+            slot["index"] = picojson::value{static_cast<double>(i)};
+            slot["path"] = picojson::value{fmt::format("{}/{}.{}", PAYLOAD_DIRECTORY_NAME, PAYLOAD_SLOT_FILE_NAME_STEM, i)};
+            slot["size"] = picojson::value{static_cast<double>(context.logicalPayloadSize)};
+            slots.emplace_back(slot);
+        }
+        root["slots"] = picojson::value{slots};
+
+        auto const path = makePayloadDescriptorFilePath(context.flowDir);
+        auto out = std::ofstream{path, std::ios::trunc};
+        if (!out)
+        {
+            throw std::filesystem::filesystem_error{"Failed to write payload.json.", path, std::make_error_code(std::errc::io_error)};
+        }
+        out << picojson::value{root}.serialize(true);
+    }
+}
+
+#endif // MXL_HAS_CUDA

--- a/lib/internal/src/FlowManager.cpp
+++ b/lib/internal/src/FlowManager.cpp
@@ -14,6 +14,7 @@
 #include <sys/stat.h>
 #include <mxl/flow.h>
 #include <mxl/mxl.h>
+#include "mxl-internal/GrainPayloadAllocator.hpp"
 #include "mxl-internal/Logging.hpp"
 #include "mxl-internal/PathUtils.hpp"
 #include "mxl-internal/SharedMemory.hpp"
@@ -101,7 +102,7 @@ namespace mxl::lib
         }
 
         mxlCommonFlowConfigInfo initCommonFlowConfigInfo(uuids::uuid const& flowId, mxlDataFormat format, mxlRational grainRate,
-            std::uint32_t maxSyncBatchSizeHintOpt, std::uint32_t maxCommitBatchSizeHintOpt)
+            std::uint32_t maxSyncBatchSizeHintOpt, std::uint32_t maxCommitBatchSizeHintOpt, mxlPayloadLocation payloadLocation, int32_t deviceIndex)
         {
             auto result = mxlCommonFlowConfigInfo{};
 
@@ -113,9 +114,8 @@ namespace mxl::lib
             result.maxCommitBatchSizeHint = maxCommitBatchSizeHintOpt;
             result.maxSyncBatchSizeHint = maxSyncBatchSizeHintOpt;
 
-            // FIXME: This should come from the configuration when device memory is supported
-            result.payloadLocation = MXL_PAYLOAD_LOCATION_HOST_MEMORY;
-            result.deviceIndex = -1;
+            result.payloadLocation = payloadLocation;
+            result.deviceIndex = deviceIndex;
 
             return result;
         }
@@ -165,16 +165,30 @@ namespace mxl::lib
     std::pair<bool, std::unique_ptr<DiscreteFlowData>> FlowManager::createOrOpenDiscreteFlow(uuids::uuid const& flowId, std::string const& flowDef,
         mxlDataFormat flowFormat, std::size_t grainCount, mxlRational const& grainRate, std::size_t grainPayloadSize, std::size_t grainNumOfSlices,
         std::array<uint32_t, MXL_MAX_PLANES_PER_GRAIN> grainSliceLengths, std::uint32_t maxSyncBatchSizeHintOpt,
-        std::uint32_t maxCommitBatchSizeHintOpt)
+        std::uint32_t maxCommitBatchSizeHintOpt, mxlPayloadLocation payloadLocation, int32_t deviceIndex, std::string const& payloadBackend)
     {
         auto const uuidString = uuids::to_string(flowId);
-        MXL_DEBUG("Create discrete flow. id: {}, grainCount: {}, grain payload size: {}", uuidString, grainCount, grainPayloadSize);
+        MXL_DEBUG("Create discrete flow. id: {}, grainCount: {}, grain payload size: {}, payloadLocation: {}, deviceIndex: {}, backend: {}",
+            uuidString,
+            grainCount,
+            grainPayloadSize,
+            static_cast<int>(payloadLocation),
+            deviceIndex,
+            payloadBackend.empty() ? "<default>" : payloadBackend);
 
         flowFormat = sanitizeFlowFormat(flowFormat);
         if (!mxlIsDiscreteDataFormat(flowFormat))
         {
             throw std::runtime_error{"Attempt to create discrete flow with unsupported or non matching format."};
         }
+
+        auto payloadAllocator = makeGrainPayloadAllocator(GrainPayloadAllocatorSpec{
+            .location = payloadLocation,
+            .deviceIndex = deviceIndex,
+            .logicalPayloadSize = grainPayloadSize,
+            .backend = payloadBackend,
+        });
+        auto const mappedPayloadBytes = payloadAllocator->mappedPayloadBytes();
 
         auto const tempDirectory = createTemporaryFlowDirectory(_mxlDomain);
         auto _ = defer(
@@ -205,7 +219,8 @@ namespace mxl::lib
         auto& info = *flowData->flowInfo();
         info.version = FLOW_DATA_VERSION;
         info.size = sizeof info;
-        info.config.common = initCommonFlowConfigInfo(flowId, flowFormat, grainRate, maxSyncBatchSizeHintOpt, maxCommitBatchSizeHintOpt);
+        info.config.common = initCommonFlowConfigInfo(
+            flowId, flowFormat, grainRate, maxSyncBatchSizeHintOpt, maxCommitBatchSizeHintOpt, payloadAllocator->location(), payloadAllocator->deviceIndex());
         info.config.discrete = {};
         info.config.discrete.grainCount = grainCount;
         std::copy(grainSliceLengths.begin(), grainSliceLengths.end(), info.config.discrete.sliceSizes);
@@ -224,10 +239,11 @@ namespace mxl::lib
         for (auto i = std::size_t{0}; i < grainCount; ++i)
         {
             auto const grainPath = makeGrainDataFilePath(grainDir, i);
-            MXL_TRACE("Creating grain: {}", grainPath.string());
+            MXL_TRACE("Creating grain: {} (mapped payload bytes: {})", grainPath.string(), mappedPayloadBytes);
 
-            // \todo Handle payload stored device memory
-            auto const grain = flowData->emplaceGrain(grainPath.string().c_str(), grainPayloadSize);
+            // Host allocator embeds payload after the header. Device allocators map header only
+            // (grainPayloadSize / logical size is still recorded in grain info).
+            auto const grain = flowData->emplaceGrain(grainPath.string().c_str(), mappedPayloadBytes);
             auto& gInfo = grain->header.info;
             gInfo.grainSize = grainPayloadSize;
             gInfo.totalSlices = grainNumOfSlices;
@@ -239,6 +255,14 @@ namespace mxl::lib
         auto const finalDir = makeFlowDirectoryName(_mxlDomain, uuidString);
         if (publishFlowDirectory(tempDirectory, finalDir))
         {
+            // Attach after publish so payload descriptors / CUDA IPC registry keys use the final path.
+            payloadAllocator->attach(GrainPayloadAttachContext{
+                .flowDir = finalDir,
+                .grainCount = grainCount,
+                .logicalPayloadSize = grainPayloadSize,
+                .accessMode = AccessMode::CREATE_READ_WRITE,
+            });
+            flowData->setPayloadAllocator(std::move(payloadAllocator));
             return {true, std::move(flowData)};
         }
         else
@@ -255,7 +279,8 @@ namespace mxl::lib
 
     std::pair<bool, std::unique_ptr<ContinuousFlowData>> FlowManager::createOrOpenContinuousFlow(uuids::uuid const& flowId,
         std::string const& flowDef, mxlDataFormat flowFormat, mxlRational const& sampleRate, std::size_t channelCount, std::size_t sampleWordSize,
-        std::size_t bufferLength, std::uint32_t maxSyncBatchSizeHintOpt, std::uint32_t maxCommitBatchSizeHintOpt)
+        std::size_t bufferLength, std::uint32_t maxSyncBatchSizeHintOpt, std::uint32_t maxCommitBatchSizeHintOpt, mxlPayloadLocation payloadLocation,
+        int32_t deviceIndex)
     {
         auto const uuidString = uuids::to_string(flowId);
         MXL_DEBUG("Create continuous flow. id: {}, channel count: {}, word size: {}, buffer length: {}",
@@ -282,7 +307,8 @@ namespace mxl::lib
             auto& info = *flowData->flowInfo();
             info.version = FLOW_DATA_VERSION;
             info.size = sizeof info;
-            info.config.common = initCommonFlowConfigInfo(flowId, flowFormat, sampleRate, maxSyncBatchSizeHintOpt, maxCommitBatchSizeHintOpt);
+            info.config.common = initCommonFlowConfigInfo(
+                flowId, flowFormat, sampleRate, maxSyncBatchSizeHintOpt, maxCommitBatchSizeHintOpt, payloadLocation, deviceIndex);
             info.config.continuous = {};
             info.config.continuous.channelCount = channelCount;
             info.config.continuous.bufferLength = bufferLength;
@@ -375,6 +401,7 @@ namespace mxl::lib
                     auto const grainPath = makeGrainDataFilePath(grainDir, i).string();
                     MXL_TRACE("Opening grain: {}", grainPath);
 
+                    // File size is taken from disk; payload may be embedded (host) or absent (device).
                     flowData->emplaceGrain(grainPath.c_str(), /*payloadSize=*/0U);
                 }
             }
@@ -384,6 +411,28 @@ namespace mxl::lib
                     "Grain directory not found.", grainDir, std::make_error_code(std::errc::no_such_file_or_directory)};
             }
         }
+
+        auto const& common = flowData->flowInfo()->config.common;
+        auto logicalPayloadSize = std::size_t{0};
+        if (flowData->grainCount() > 0U)
+        {
+            logicalPayloadSize = flowData->grainAt(0)->header.info.grainSize;
+        }
+
+        auto payloadAllocator = makeGrainPayloadAllocatorForFlow(flowDir,
+            GrainPayloadAllocatorSpec{
+                .location = static_cast<mxlPayloadLocation>(common.payloadLocation),
+                .deviceIndex = common.deviceIndex,
+                .logicalPayloadSize = logicalPayloadSize,
+                .backend = {},
+            });
+        payloadAllocator->attach(GrainPayloadAttachContext{
+            .flowDir = flowDir,
+            .grainCount = flowData->grainCount(),
+            .logicalPayloadSize = logicalPayloadSize,
+            .accessMode = flowData->accessMode(),
+        });
+        flowData->setPayloadAllocator(std::move(payloadAllocator));
 
         return flowData;
     }

--- a/lib/internal/src/FlowOptionsParser.cpp
+++ b/lib/internal/src/FlowOptionsParser.cpp
@@ -2,12 +2,59 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "mxl-internal/FlowOptionsParser.hpp"
+#include <stdexcept>
+#include <string>
 #include <picojson/picojson.h>
 #include <mxl/mxl.h>
 #include "mxl-internal/Logging.hpp"
 
 namespace mxl::lib
 {
+    namespace
+    {
+        mxlPayloadLocation parsePayloadLocationValue(picojson::value const& value)
+        {
+            if (value.is<std::string>())
+            {
+                auto const& s = value.get<std::string>();
+                if ((s == "host") || (s == "HOST") || (s == "host_memory"))
+                {
+                    return MXL_PAYLOAD_LOCATION_HOST_MEMORY;
+                }
+                if ((s == "device") || (s == "DEVICE") || (s == "device_memory"))
+                {
+                    return MXL_PAYLOAD_LOCATION_DEVICE_MEMORY;
+                }
+                throw std::invalid_argument{"payload location must be \"host\" or \"device\"."};
+            }
+
+            if (value.is<double>())
+            {
+                auto const v = static_cast<int>(value.get<double>());
+                if (v == static_cast<int>(MXL_PAYLOAD_LOCATION_HOST_MEMORY))
+                {
+                    return MXL_PAYLOAD_LOCATION_HOST_MEMORY;
+                }
+                if (v == static_cast<int>(MXL_PAYLOAD_LOCATION_DEVICE_MEMORY))
+                {
+                    return MXL_PAYLOAD_LOCATION_DEVICE_MEMORY;
+                }
+                throw std::invalid_argument{"payload location numeric value must be 0 (host) or 1 (device)."};
+            }
+
+            throw std::invalid_argument{"payload location must be a string or number."};
+        }
+
+        int32_t parseDeviceIndexValue(picojson::value const& value)
+        {
+            if (!value.is<double>())
+            {
+                throw std::invalid_argument{"deviceIndex must be a number."};
+            }
+            return static_cast<int32_t>(value.get<double>());
+        }
+    }
+
     FlowOptionsParser::FlowOptionsParser(std::string const& in_options)
     {
         if (in_options.empty())
@@ -67,6 +114,77 @@ namespace mxl::lib
                 throw std::invalid_argument{"maxSyncBatchSizeHint must be a multiple of maxCommitBatchSizeHint."};
             }
         }
+
+        // Nested payload object takes precedence when present.
+        auto payloadIt = _root.find("payload");
+        if (payloadIt != _root.end())
+        {
+            if (!payloadIt->second.is<picojson::object>())
+            {
+                throw std::invalid_argument{"payload must be a JSON object."};
+            }
+            auto const& payloadObj = payloadIt->second.get<picojson::object>();
+
+            if (auto locIt = payloadObj.find("location"); locIt != payloadObj.end())
+            {
+                _payloadLocation = parsePayloadLocationValue(locIt->second);
+            }
+
+            if (auto deviceIt = payloadObj.find("deviceIndex"); deviceIt != payloadObj.end())
+            {
+                _deviceIndex = parseDeviceIndexValue(deviceIt->second);
+            }
+            else if (_payloadLocation == MXL_PAYLOAD_LOCATION_DEVICE_MEMORY)
+            {
+                _deviceIndex = 0;
+            }
+
+            if (auto backendIt = payloadObj.find("backend"); backendIt != payloadObj.end())
+            {
+                if (!backendIt->second.is<std::string>())
+                {
+                    throw std::invalid_argument{"payload.backend must be a string."};
+                }
+                _payloadBackend = backendIt->second.get<std::string>();
+            }
+        }
+        else
+        {
+            if (auto locIt = _root.find("payloadLocation"); locIt != _root.end())
+            {
+                _payloadLocation = parsePayloadLocationValue(locIt->second);
+            }
+
+            if (auto deviceIt = _root.find("deviceIndex"); deviceIt != _root.end())
+            {
+                _deviceIndex = parseDeviceIndexValue(deviceIt->second);
+            }
+            else if (_payloadLocation == MXL_PAYLOAD_LOCATION_DEVICE_MEMORY)
+            {
+                _deviceIndex = 0;
+            }
+
+            if (auto backendIt = _root.find("payloadBackend"); backendIt != _root.end())
+            {
+                if (!backendIt->second.is<std::string>())
+                {
+                    throw std::invalid_argument{"payloadBackend must be a string."};
+                }
+                _payloadBackend = backendIt->second.get<std::string>();
+            }
+        }
+
+        if (_payloadLocation == MXL_PAYLOAD_LOCATION_HOST_MEMORY)
+        {
+            if (_deviceIndex != -1)
+            {
+                throw std::invalid_argument{"deviceIndex must be -1 when payload location is host."};
+            }
+        }
+        else if (_deviceIndex < 0)
+        {
+            throw std::invalid_argument{"deviceIndex must be >= 0 when payload location is device."};
+        }
     }
 
     std::optional<std::uint32_t> FlowOptionsParser::getMaxCommitBatchSizeHint() const
@@ -77,5 +195,20 @@ namespace mxl::lib
     std::optional<std::uint32_t> FlowOptionsParser::getMaxSyncBatchSizeHint() const
     {
         return _maxSyncBatchSizeHint;
+    }
+
+    mxlPayloadLocation FlowOptionsParser::getPayloadLocation() const noexcept
+    {
+        return _payloadLocation;
+    }
+
+    int32_t FlowOptionsParser::getDeviceIndex() const noexcept
+    {
+        return _deviceIndex;
+    }
+
+    std::string const& FlowOptionsParser::getPayloadBackend() const noexcept
+    {
+        return _payloadBackend;
     }
 } // namespace mxl::lib

--- a/lib/internal/src/GrainPayloadAllocator.cpp
+++ b/lib/internal/src/GrainPayloadAllocator.cpp
@@ -1,0 +1,252 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "mxl-internal/GrainPayloadAllocator.hpp"
+#include <fstream>
+#include <stdexcept>
+#include <string>
+#include <picojson/picojson.h>
+#include <mxl/mxl.h>
+#include "mxl-internal/CudaLinearPayloadAllocator.hpp"
+#include "mxl-internal/PathUtils.hpp"
+
+namespace mxl::lib
+{
+    namespace
+    {
+        void fillCommon(mxlPayloadView* outView, mxlPayloadKind kind, Grain const* grain, int32_t deviceIndex) noexcept
+        {
+            *outView = {};
+            outView->kind = kind;
+            outView->grainSize = grain->header.info.grainSize;
+            outView->deviceIndex = deviceIndex;
+            outView->reserved = 0;
+        }
+
+        std::string normalizeBackend(std::string const& backend, mxlPayloadLocation location)
+        {
+            if (!backend.empty())
+            {
+                return backend;
+            }
+            if (location == MXL_PAYLOAD_LOCATION_HOST_MEMORY)
+            {
+                return PAYLOAD_BACKEND_HOST;
+            }
+#if defined(MXL_HAS_CUDA) && MXL_HAS_CUDA
+            if (isCudaRuntimeAvailable())
+            {
+                return PAYLOAD_BACKEND_CUDA_LINEAR;
+            }
+#endif
+            return PAYLOAD_BACKEND_PLACEHOLDER;
+        }
+
+        void writePlaceholderDescriptor(GrainPayloadAttachContext const& context, int32_t deviceIndex)
+        {
+            picojson::object root;
+            root["version"] = picojson::value{1.0};
+            root["backend"] = picojson::value{std::string{PAYLOAD_BACKEND_PLACEHOLDER}};
+            root["location"] = picojson::value{std::string{"device"}};
+            root["deviceIndex"] = picojson::value{static_cast<double>(deviceIndex)};
+            root["grainCount"] = picojson::value{static_cast<double>(context.grainCount)};
+            root["grainSize"] = picojson::value{static_cast<double>(context.logicalPayloadSize)};
+            root["export"] = picojson::value{std::string{"none"}};
+            root["slots"] = picojson::value{picojson::array{}};
+
+            auto const path = makePayloadDescriptorFilePath(context.flowDir);
+            auto out = std::ofstream{path, std::ios::trunc};
+            if (!out)
+            {
+                throw std::filesystem::filesystem_error{"Failed to write payload.json.", path, std::make_error_code(std::errc::io_error)};
+            }
+            out << picojson::value{root}.serialize(true);
+        }
+    }
+
+    HostMappedPayloadAllocator::HostMappedPayloadAllocator(std::size_t mappedPayloadBytes) noexcept
+        : _mappedPayloadBytes{mappedPayloadBytes}
+    {}
+
+    mxlPayloadLocation HostMappedPayloadAllocator::location() const noexcept
+    {
+        return MXL_PAYLOAD_LOCATION_HOST_MEMORY;
+    }
+
+    int32_t HostMappedPayloadAllocator::deviceIndex() const noexcept
+    {
+        return -1;
+    }
+
+    char const* HostMappedPayloadAllocator::backendName() const noexcept
+    {
+        return PAYLOAD_BACKEND_HOST;
+    }
+
+    std::size_t HostMappedPayloadAllocator::mappedPayloadBytes() const noexcept
+    {
+        return _mappedPayloadBytes;
+    }
+
+    void HostMappedPayloadAllocator::attach(GrainPayloadAttachContext const&)
+    {
+        // Host payloads are embedded in the grain mmap created by DiscreteFlowData::emplaceGrain.
+    }
+
+    mxlStatus HostMappedPayloadAllocator::viewAt(std::size_t, Grain const* grain, mxlPayloadView* outView) const noexcept
+    {
+        if ((grain == nullptr) || (outView == nullptr))
+        {
+            return MXL_ERR_INVALID_ARG;
+        }
+
+        fillCommon(outView, MXL_PAYLOAD_KIND_HOST_PTR, grain, -1);
+        outView->u.hostPtr = reinterpret_cast<std::uint8_t*>(const_cast<GrainHeader*>(&grain->header) + 1);
+        return MXL_STATUS_OK;
+    }
+
+    DevicePayloadPlaceholderAllocator::DevicePayloadPlaceholderAllocator(int32_t deviceIndex) noexcept
+        : _deviceIndex{deviceIndex}
+    {}
+
+    mxlPayloadLocation DevicePayloadPlaceholderAllocator::location() const noexcept
+    {
+        return MXL_PAYLOAD_LOCATION_DEVICE_MEMORY;
+    }
+
+    int32_t DevicePayloadPlaceholderAllocator::deviceIndex() const noexcept
+    {
+        return _deviceIndex;
+    }
+
+    char const* DevicePayloadPlaceholderAllocator::backendName() const noexcept
+    {
+        return PAYLOAD_BACKEND_PLACEHOLDER;
+    }
+
+    std::size_t DevicePayloadPlaceholderAllocator::mappedPayloadBytes() const noexcept
+    {
+        return 0U;
+    }
+
+    void DevicePayloadPlaceholderAllocator::attach(GrainPayloadAttachContext const& context)
+    {
+        if (context.accessMode == AccessMode::CREATE_READ_WRITE)
+        {
+            writePlaceholderDescriptor(context, _deviceIndex);
+        }
+    }
+
+    mxlStatus DevicePayloadPlaceholderAllocator::viewAt(std::size_t, Grain const* grain, mxlPayloadView* outView) const noexcept
+    {
+        if ((grain == nullptr) || (outView == nullptr))
+        {
+            return MXL_ERR_INVALID_ARG;
+        }
+
+        fillCommon(outView, MXL_PAYLOAD_KIND_DEVICE_PTR, grain, _deviceIndex);
+        outView->u.devicePtr = 0;
+        return MXL_ERR_UNSUPPORTED_OPERATION;
+    }
+
+    std::unique_ptr<GrainPayloadAllocator> makeGrainPayloadAllocator(GrainPayloadAllocatorSpec const& spec)
+    {
+        auto const backend = normalizeBackend(spec.backend, spec.location);
+
+        if (spec.location == MXL_PAYLOAD_LOCATION_HOST_MEMORY)
+        {
+            if (spec.deviceIndex != -1)
+            {
+                throw std::invalid_argument{"deviceIndex must be -1 when payloadLocation is host memory."};
+            }
+            if (!backend.empty() && (backend != PAYLOAD_BACKEND_HOST))
+            {
+                throw std::invalid_argument{"payload backend \"" + backend + "\" is incompatible with host payload location."};
+            }
+            return std::make_unique<HostMappedPayloadAllocator>(spec.logicalPayloadSize);
+        }
+
+        if (spec.location != MXL_PAYLOAD_LOCATION_DEVICE_MEMORY)
+        {
+            throw std::invalid_argument{"Unsupported payloadLocation."};
+        }
+        if (spec.deviceIndex < 0)
+        {
+            throw std::invalid_argument{"deviceIndex must be >= 0 when payloadLocation is device memory."};
+        }
+
+        if (backend == PAYLOAD_BACKEND_CUDA_LINEAR)
+        {
+#if defined(MXL_HAS_CUDA) && MXL_HAS_CUDA
+            if (!isCudaRuntimeAvailable())
+            {
+                throw std::runtime_error{"payload backend \"cuda-linear\" requested but no CUDA device is available."};
+            }
+            return std::make_unique<CudaLinearPayloadAllocator>(spec.deviceIndex);
+#else
+            throw std::runtime_error{"payload backend \"cuda-linear\" requested but MXL was built without CUDA support."};
+#endif
+        }
+
+        if ((backend == PAYLOAD_BACKEND_PLACEHOLDER) || backend.empty())
+        {
+            return std::make_unique<DevicePayloadPlaceholderAllocator>(spec.deviceIndex);
+        }
+
+        throw std::invalid_argument{"Unsupported payload backend \"" + backend + "\"."};
+    }
+
+    std::unique_ptr<GrainPayloadAllocator> makeGrainPayloadAllocatorForFlow(std::filesystem::path const& flowDir,
+        GrainPayloadAllocatorSpec const& fallbackSpec)
+    {
+        auto spec = fallbackSpec;
+        auto const descriptorPath = makePayloadDescriptorFilePath(flowDir);
+        if (std::filesystem::exists(descriptorPath))
+        {
+            auto in = std::ifstream{descriptorPath};
+            if (!in)
+            {
+                throw std::filesystem::filesystem_error{
+                    "Failed to read payload.json.", descriptorPath, std::make_error_code(std::errc::io_error)};
+            }
+            auto jsonValue = picojson::value{};
+            auto const err = picojson::parse(jsonValue, in);
+            if (!err.empty())
+            {
+                throw std::invalid_argument{"Invalid payload.json: " + err};
+            }
+            if (!jsonValue.is<picojson::object>())
+            {
+                throw std::invalid_argument{"payload.json root must be an object."};
+            }
+            auto const& root = jsonValue.get<picojson::object>();
+
+            if (auto it = root.find("backend"); (it != root.end()) && it->second.is<std::string>())
+            {
+                spec.backend = it->second.get<std::string>();
+            }
+            if (auto it = root.find("deviceIndex"); (it != root.end()) && it->second.is<double>())
+            {
+                spec.deviceIndex = static_cast<int32_t>(it->second.get<double>());
+            }
+            if (auto it = root.find("grainSize"); (it != root.end()) && it->second.is<double>())
+            {
+                spec.logicalPayloadSize = static_cast<std::size_t>(it->second.get<double>());
+            }
+            if (auto it = root.find("location"); (it != root.end()) && it->second.is<std::string>())
+            {
+                auto const& loc = it->second.get<std::string>();
+                if ((loc == "device") || (loc == "DEVICE") || (loc == "device_memory"))
+                {
+                    spec.location = MXL_PAYLOAD_LOCATION_DEVICE_MEMORY;
+                }
+                else
+                {
+                    spec.location = MXL_PAYLOAD_LOCATION_HOST_MEMORY;
+                }
+            }
+        }
+
+        return makeGrainPayloadAllocator(spec);
+    }
+}

--- a/lib/internal/src/Instance.cpp
+++ b/lib/internal/src/Instance.cpp
@@ -249,7 +249,10 @@ namespace mxl::lib
             parser.getTotalPayloadSlices(),
             parser.getPayloadSliceLengths(),
             optionsParser.getMaxSyncBatchSizeHint().value_or(batchSizeDefault),
-            optionsParser.getMaxCommitBatchSizeHint().value_or(batchSizeDefault));
+            optionsParser.getMaxCommitBatchSizeHint().value_or(batchSizeDefault),
+            optionsParser.getPayloadLocation(),
+            optionsParser.getDeviceIndex(),
+            optionsParser.getPayloadBackend());
 
         return {std::move(flowData), created};
     }
@@ -282,7 +285,9 @@ namespace mxl::lib
             sampleWordSize,
             pageAlignedLength,
             optionsParser.getMaxSyncBatchSizeHint().value_or(batchSizeDefault),
-            optionsParser.getMaxCommitBatchSizeHint().value_or(batchSizeDefault));
+            optionsParser.getMaxCommitBatchSizeHint().value_or(batchSizeDefault),
+            optionsParser.getPayloadLocation(),
+            optionsParser.getDeviceIndex());
 
         return {std::move(flowData), created};
     }

--- a/lib/internal/src/PathUtils.cpp
+++ b/lib/internal/src/PathUtils.cpp
@@ -54,4 +54,22 @@ namespace mxl::lib
     {
         return domain / (DOMAIN_OPTIONS_FILE_NAME);
     }
+
+    MXL_EXPORT
+    std::filesystem::path makePayloadDirectoryName(std::filesystem::path const& flowDirectory)
+    {
+        return flowDirectory / PAYLOAD_DIRECTORY_NAME;
+    }
+
+    MXL_EXPORT
+    std::filesystem::path makePayloadDescriptorFilePath(std::filesystem::path const& flowDirectory)
+    {
+        return flowDirectory / PAYLOAD_DESCRIPTOR_FILE_NAME;
+    }
+
+    MXL_EXPORT
+    std::filesystem::path makePayloadSlotFilePath(std::filesystem::path const& flowDirectory, unsigned int index)
+    {
+        return makePayloadDirectoryName(flowDirectory) / fmt::format("{}.{}", PAYLOAD_SLOT_FILE_NAME_STEM, index);
+    }
 }

--- a/lib/internal/src/PosixDiscreteFlowReader.cpp
+++ b/lib/internal/src/PosixDiscreteFlowReader.cpp
@@ -79,7 +79,7 @@ namespace mxl::lib
         auto result = MXL_ERR_UNKNOWN;
         if (_flowData)
         {
-            result = getGrainImpl(in_index, in_minValidSlices, in_deadline, nullptr, nullptr);
+            result = getGrainImpl(in_index, in_minValidSlices, in_deadline, nullptr, static_cast<std::uint8_t**>(nullptr));
             if (result == MXL_ERR_OUT_OF_RANGE_TOO_EARLY)
             {
                 // If we were ultimately too early, even with blocking for a certain amount
@@ -120,6 +120,28 @@ namespace mxl::lib
         return result;
     }
 
+    mxlStatus PosixDiscreteFlowReader::getGrain(std::uint64_t in_index, std::uint16_t in_minValidSlices, Timepoint in_deadline,
+        mxlGrainInfo* out_grainInfo, mxlPayloadView* out_payload)
+    {
+        auto result = MXL_ERR_UNKNOWN;
+        if (_flowData)
+        {
+            result = getGrainImpl(in_index, in_minValidSlices, in_deadline, out_grainInfo, out_payload);
+            if (result == MXL_STATUS_OK)
+            {
+                (void)updateFileAccessTime(_accessFileFd);
+            }
+            else if (result == MXL_ERR_OUT_OF_RANGE_TOO_EARLY)
+            {
+                if (!isFlowValidImpl())
+                {
+                    result = MXL_ERR_FLOW_INVALID;
+                }
+            }
+        }
+        return result;
+    }
+
     mxlStatus PosixDiscreteFlowReader::getGrain(std::uint64_t in_index, std::uint16_t in_minValidSlices, mxlGrainInfo* out_grainInfo,
         std::uint8_t** out_payload)
     {
@@ -146,8 +168,30 @@ namespace mxl::lib
         return result;
     }
 
+    mxlStatus PosixDiscreteFlowReader::getGrain(std::uint64_t in_index, std::uint16_t in_minValidSlices, mxlGrainInfo* out_grainInfo,
+        mxlPayloadView* out_payload)
+    {
+        auto result = MXL_ERR_UNKNOWN;
+        if (_flowData)
+        {
+            result = getGrainImpl(in_index, in_minValidSlices, out_grainInfo, out_payload);
+            if (result == MXL_STATUS_OK)
+            {
+                (void)updateFileAccessTime(_accessFileFd);
+            }
+            else if (result == MXL_ERR_OUT_OF_RANGE_TOO_EARLY)
+            {
+                if (!isFlowValidImpl())
+                {
+                    result = MXL_ERR_FLOW_INVALID;
+                }
+            }
+        }
+        return result;
+    }
+
     mxlStatus PosixDiscreteFlowReader::getGrainImpl(std::uint64_t in_index, std::uint16_t in_minValidSlices, mxlGrainInfo* out_grainInfo,
-        std::uint8_t** out_payload) const
+        mxlPayloadView* out_payload) const
     {
         auto result = MXL_ERR_UNKNOWN;
         auto const flow = _flowData->flow();
@@ -169,10 +213,12 @@ namespace mxl::lib
                     }
                     if (out_payload != nullptr)
                     {
-                        *out_payload = reinterpret_cast<std::uint8_t*>(&grain->header + 1);
+                        result = _flowData->payloadViewAt(offset, out_payload);
                     }
-
-                    result = MXL_STATUS_OK;
+                    else
+                    {
+                        result = MXL_STATUS_OK;
+                    }
                 }
                 else
                 {
@@ -192,8 +238,28 @@ namespace mxl::lib
         return result;
     }
 
+    mxlStatus PosixDiscreteFlowReader::getGrainImpl(std::uint64_t in_index, std::uint16_t in_minValidSlices, mxlGrainInfo* out_grainInfo,
+        std::uint8_t** out_payload) const
+    {
+        mxlPayloadView view{};
+        auto const status = getGrainImpl(in_index, in_minValidSlices, out_grainInfo, (out_payload != nullptr) ? &view : nullptr);
+        if (status != MXL_STATUS_OK)
+        {
+            return status;
+        }
+        if (out_payload != nullptr)
+        {
+            if (view.kind != MXL_PAYLOAD_KIND_HOST_PTR)
+            {
+                return MXL_ERR_UNSUPPORTED_OPERATION;
+            }
+            *out_payload = view.u.hostPtr;
+        }
+        return MXL_STATUS_OK;
+    }
+
     mxlStatus PosixDiscreteFlowReader::getGrainImpl(std::uint64_t in_index, std::uint16_t in_minValidSlices, Timepoint in_deadline,
-        mxlGrainInfo* out_grainInfo, std::uint8_t** out_payload) const
+        mxlGrainInfo* out_grainInfo, mxlPayloadView* out_payload) const
     {
         auto const flow = _flowData->flow();
         auto const syncObject = std::atomic_ref{flow->state.syncCounter};
@@ -214,6 +280,26 @@ namespace mxl::lib
                 return result;
             }
         }
+    }
+
+    mxlStatus PosixDiscreteFlowReader::getGrainImpl(std::uint64_t in_index, std::uint16_t in_minValidSlices, Timepoint in_deadline,
+        mxlGrainInfo* out_grainInfo, std::uint8_t** out_payload) const
+    {
+        mxlPayloadView view{};
+        auto const status = getGrainImpl(in_index, in_minValidSlices, in_deadline, out_grainInfo, (out_payload != nullptr) ? &view : nullptr);
+        if (status != MXL_STATUS_OK)
+        {
+            return status;
+        }
+        if (out_payload != nullptr)
+        {
+            if (view.kind != MXL_PAYLOAD_KIND_HOST_PTR)
+            {
+                return MXL_ERR_UNSUPPORTED_OPERATION;
+            }
+            *out_payload = view.u.hostPtr;
+        }
+        return MXL_STATUS_OK;
     }
 
     bool PosixDiscreteFlowReader::isFlowValid() const

--- a/lib/internal/src/PosixDiscreteFlowReader.hpp
+++ b/lib/internal/src/PosixDiscreteFlowReader.hpp
@@ -52,8 +52,16 @@ namespace mxl::lib
             std::uint8_t** out_payload) override;
 
         /** \see DiscreteFlowReader::getGrain */
+        virtual mxlStatus getGrain(std::uint64_t in_index, std::uint16_t in_minValidSlices, Timepoint in_deadline, mxlGrainInfo* out_grainInfo,
+            mxlPayloadView* out_payload) override;
+
+        /** \see DiscreteFlowReader::getGrain */
         virtual mxlStatus getGrain(std::uint64_t in_index, std::uint16_t in_minValidSlices, mxlGrainInfo* out_grainInfo,
             std::uint8_t** out_payload) override;
+
+        /** \see DiscreteFlowReader::getGrain */
+        virtual mxlStatus getGrain(std::uint64_t in_index, std::uint16_t in_minValidSlices, mxlGrainInfo* out_grainInfo,
+            mxlPayloadView* out_payload) override;
 
     protected:
         /** \see FlowReader::isFlowValid */
@@ -77,6 +85,9 @@ namespace mxl::lib
         mxlStatus getGrainImpl(std::uint64_t in_index, std::uint16_t in_minValidSlices, mxlGrainInfo* out_grainInfo,
             std::uint8_t** out_payload) const;
 
+        mxlStatus getGrainImpl(std::uint64_t in_index, std::uint16_t in_minValidSlices, mxlGrainInfo* out_grainInfo,
+            mxlPayloadView* out_payload) const;
+
         /**
          * Implementation of the blocking form of getGrain() and waitForGrain()
          * that can also be used by other methods that have previously asserted
@@ -85,6 +96,9 @@ namespace mxl::lib
          */
         mxlStatus getGrainImpl(std::uint64_t in_index, std::uint16_t in_minValidSlices, Timepoint in_deadline, mxlGrainInfo* out_grainInfo,
             std::uint8_t** out_payload) const;
+
+        mxlStatus getGrainImpl(std::uint64_t in_index, std::uint16_t in_minValidSlices, Timepoint in_deadline, mxlGrainInfo* out_grainInfo,
+            mxlPayloadView* out_payload) const;
 
     private:
         std::unique_ptr<DiscreteFlowData> _flowData;

--- a/lib/internal/src/PosixDiscreteFlowWriter.cpp
+++ b/lib/internal/src/PosixDiscreteFlowWriter.cpp
@@ -81,13 +81,35 @@ namespace mxl::lib
 
     mxlStatus PosixDiscreteFlowWriter::openGrain(std::uint64_t in_index, mxlGrainInfo* out_grainInfo, std::uint8_t** out_payload)
     {
+        mxlPayloadView view{};
+        auto const status = openGrain(in_index, out_grainInfo, &view);
+        if (status != MXL_STATUS_OK)
+        {
+            return status;
+        }
+        if (view.kind != MXL_PAYLOAD_KIND_HOST_PTR)
+        {
+            return MXL_ERR_UNSUPPORTED_OPERATION;
+        }
+        *out_payload = view.u.hostPtr;
+        return MXL_STATUS_OK;
+    }
+
+    mxlStatus PosixDiscreteFlowWriter::openGrain(std::uint64_t in_index, mxlGrainInfo* out_grainInfo, mxlPayloadView* out_payload)
+    {
         if (_flowData)
         {
             auto offset = in_index % _flowData->flowInfo()->config.discrete.grainCount;
             auto const grain = _flowData->grainAt(offset);
             grain->header.info.index = in_index; // Set the absolute grain index associated to that ring buffer entry
             *out_grainInfo = grain->header.info;
-            *out_payload = reinterpret_cast<std::uint8_t*>(&grain->header + 1);
+
+            auto const status = _flowData->payloadViewAt(offset, out_payload);
+            if (status != MXL_STATUS_OK)
+            {
+                return status;
+            }
+
             _currentIndex = in_index;
             return MXL_STATUS_OK;
         }

--- a/lib/internal/src/PosixDiscreteFlowWriter.hpp
+++ b/lib/internal/src/PosixDiscreteFlowWriter.hpp
@@ -62,6 +62,9 @@ namespace mxl::lib
         /** \see DiscreteFlowWriter::openGrain */
         virtual mxlStatus openGrain(std::uint64_t in_index, mxlGrainInfo* out_grainInfo, std::uint8_t** out_payload) override;
 
+        /** \see DiscreteFlowWriter::openGrain */
+        virtual mxlStatus openGrain(std::uint64_t in_index, mxlGrainInfo* out_grainInfo, mxlPayloadView* out_payload) override;
+
         /** \see DiscreteFlowWriter::commit */
         virtual mxlStatus commit(mxlGrainInfo const& mxlGrainInfo) override;
 

--- a/lib/internal/tests/test_domainwatcher.cpp
+++ b/lib/internal/tests/test_domainwatcher.cpp
@@ -191,6 +191,11 @@ struct MockWriter : mxl::lib::DiscreteFlowWriter
         return MXL_STATUS_OK;
     }
 
+    virtual mxlStatus openGrain(std::uint64_t, mxlGrainInfo*, mxlPayloadView*) override
+    {
+        return MXL_STATUS_OK;
+    }
+
     virtual mxlStatus commit(mxlGrainInfo const&) override
     {
         return MXL_STATUS_OK;

--- a/lib/src/flow.cpp
+++ b/lib/src/flow.cpp
@@ -361,8 +361,38 @@ mxlStatus mxlFlowReaderGetGrain(mxlFlowReader reader, uint64_t index, uint64_t t
 
 extern "C"
 MXL_EXPORT
+mxlStatus mxlFlowReaderGetGrainEx(mxlFlowReader reader, uint64_t index, uint64_t timeoutNs, mxlGrainInfo* grainInfo, mxlPayloadView* payload)
+{
+    return mxlFlowReaderGetGrainSliceEx(reader, index, MXL_GRAIN_VALID_SLICES_ALL, timeoutNs, grainInfo, payload);
+}
+
+extern "C"
+MXL_EXPORT
 mxlStatus mxlFlowReaderGetGrainSlice(mxlFlowReader reader, uint64_t index, uint16_t minValidSlices, uint64_t timeoutNs, mxlGrainInfo* grainInfo,
     uint8_t** payload)
+{
+    try
+    {
+        if ((grainInfo != nullptr) && (payload != nullptr))
+        {
+            if (auto const cppReader = dynamic_cast<DiscreteFlowReader*>(to_FlowReader(reader)); cppReader != nullptr)
+            {
+                return cppReader->getGrain(index, minValidSlices, toDeadline(timeoutNs), grainInfo, payload);
+            }
+            return MXL_ERR_INVALID_FLOW_READER;
+        }
+        return MXL_ERR_INVALID_ARG;
+    }
+    catch (...)
+    {
+        return MXL_ERR_UNKNOWN;
+    }
+}
+
+extern "C"
+MXL_EXPORT
+mxlStatus mxlFlowReaderGetGrainSliceEx(mxlFlowReader reader, uint64_t index, uint16_t minValidSlices, uint64_t timeoutNs, mxlGrainInfo* grainInfo,
+    mxlPayloadView* payload)
 {
     try
     {
@@ -391,8 +421,38 @@ mxlStatus mxlFlowReaderGetGrainNonBlocking(mxlFlowReader reader, uint64_t index,
 
 extern "C"
 MXL_EXPORT
+mxlStatus mxlFlowReaderGetGrainNonBlockingEx(mxlFlowReader reader, uint64_t index, mxlGrainInfo* grainInfo, mxlPayloadView* payload)
+{
+    return mxlFlowReaderGetGrainSliceNonBlockingEx(reader, index, MXL_GRAIN_VALID_SLICES_ALL, grainInfo, payload);
+}
+
+extern "C"
+MXL_EXPORT
 mxlStatus mxlFlowReaderGetGrainSliceNonBlocking(mxlFlowReader reader, uint64_t index, uint16_t minValidSlices, mxlGrainInfo* grainInfo,
     uint8_t** payload)
+{
+    try
+    {
+        if ((grainInfo != nullptr) && (payload != nullptr))
+        {
+            if (auto const cppReader = dynamic_cast<DiscreteFlowReader*>(to_FlowReader(reader)); cppReader != nullptr)
+            {
+                return cppReader->getGrain(index, minValidSlices, grainInfo, payload);
+            }
+            return MXL_ERR_INVALID_FLOW_READER;
+        }
+        return MXL_ERR_INVALID_ARG;
+    }
+    catch (...)
+    {
+        return MXL_ERR_UNKNOWN;
+    }
+}
+
+extern "C"
+MXL_EXPORT
+mxlStatus mxlFlowReaderGetGrainSliceNonBlockingEx(mxlFlowReader reader, uint64_t index, uint16_t minValidSlices, mxlGrainInfo* grainInfo,
+    mxlPayloadView* payload)
 {
     try
     {
@@ -439,6 +499,29 @@ mxlStatus mxlFlowWriterGetGrainInfo(mxlFlowWriter writer, uint64_t index, mxlGra
 extern "C"
 MXL_EXPORT
 mxlStatus mxlFlowWriterOpenGrain(mxlFlowWriter writer, uint64_t index, mxlGrainInfo* grainInfo, uint8_t** payload)
+{
+    try
+    {
+        if ((grainInfo != nullptr) && (payload != nullptr))
+        {
+            if (auto const cppWriter = dynamic_cast<DiscreteFlowWriter*>(to_FlowWriter(writer)); cppWriter != nullptr)
+            {
+                return cppWriter->openGrain(index, grainInfo, payload);
+            }
+
+            return MXL_ERR_INVALID_FLOW_WRITER;
+        }
+        return MXL_ERR_INVALID_ARG;
+    }
+    catch (...)
+    {
+        return MXL_ERR_UNKNOWN;
+    }
+}
+
+extern "C"
+MXL_EXPORT
+mxlStatus mxlFlowWriterOpenGrainEx(mxlFlowWriter writer, uint64_t index, mxlGrainInfo* grainInfo, mxlPayloadView* payload)
 {
     try
     {

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -67,6 +67,18 @@ target_link_libraries(mxl-tests
             Catch2::Catch2WithMain
     )
 
+if (MXL_BUILT_WITH_CUDA)
+    find_package(CUDAToolkit REQUIRED)
+    target_compile_definitions(mxl-tests
+            PRIVATE
+                MXL_HAS_CUDA=1
+        )
+    target_link_libraries(mxl-tests
+            PRIVATE
+                CUDA::cudart
+        )
+endif()
+
 if (TARGET PcapPlusPlus::Pcap++)
     target_link_libraries(mxl-tests
             PRIVATE

--- a/lib/tests/fabrics/ofi/test_ProviderConfig.cpp
+++ b/lib/tests/fabrics/ofi/test_ProviderConfig.cpp
@@ -3,12 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <optional>
+#include <vector>
 #include <catch2/catch_test_macros.hpp>
 #include <rdma/fabric.h>
 #include <mxl/fabrics.h>
 #include "FabricInfo.hpp"
 #include "Provider.hpp"
 #include "ProviderConfig.hpp"
+#include "Region.hpp"
 
 using namespace mxl::lib::fabrics::ofi;
 
@@ -118,12 +120,90 @@ TEST_CASE("ofi: ProviderCapabilities::fromAPI preserves fields", "[ofi][Provider
 {
     auto apiCaps = mxlFabricsInterfaceCaps{
         .version = MXL_FABRICS_API_VERSION,
-        .flags = MXL_FABRICS_IFACE_CAP_REMOTE_WRITE | MXL_FABRICS_IFACE_CAP_BLOCKING_OPERATIONS,
+        .flags = MXL_FABRICS_IFACE_CAP_REMOTE_WRITE | MXL_FABRICS_IFACE_CAP_BLOCKING_OPERATIONS | MXL_FABRICS_IFACE_CAP_HMEM,
         .maxMessageSize = 65536,
     };
     auto caps = ProviderCapabilities::fromAPI(apiCaps);
-    REQUIRE(caps.interfaceCaps == (MXL_FABRICS_IFACE_CAP_REMOTE_WRITE | MXL_FABRICS_IFACE_CAP_BLOCKING_OPERATIONS));
+    REQUIRE(caps.interfaceCaps ==
+            (MXL_FABRICS_IFACE_CAP_REMOTE_WRITE | MXL_FABRICS_IFACE_CAP_BLOCKING_OPERATIONS | MXL_FABRICS_IFACE_CAP_HMEM));
     REQUIRE(caps.maxMessageSize == 65536);
+}
+
+TEST_CASE("ofi: ProviderConfig with HMEM requires FI_HMEM domains", "[ofi][ProviderConfig][hmem]")
+{
+    auto caps = ProviderCapabilities{.maxMessageSize = 0, .interfaceCaps = MXL_FABRICS_IFACE_CAP_REMOTE_WRITE | MXL_FABRICS_IFACE_CAP_HMEM};
+
+    SECTION("VERBS")
+    {
+        auto config = ProviderConfig::verbs(true, caps);
+        REQUIRE((config.getCaps() & FI_HMEM) != 0);
+        REQUIRE((config.getSupportedMemoryRegistrationModes() & FI_MR_HMEM) != 0);
+
+        auto acceptedHmem = false;
+        auto acceptedNonHmem = false;
+        for (auto info : FabricInfoList::get())
+        {
+            auto provider = providerFromString(info->fabric_attr->prov_name);
+            if (!provider || (*provider != Provider::VERBS) || (info->ep_attr->type != FI_EP_MSG))
+            {
+                continue;
+            }
+
+            if ((info->caps & FI_HMEM) != 0)
+            {
+                if (config.isSupportedFabricInfo(info))
+                {
+                    acceptedHmem = true;
+                }
+            }
+            else if (config.isSupportedFabricInfo(info))
+            {
+                acceptedNonHmem = true;
+            }
+        }
+
+        // Host-only configs must keep rejecting HMEM domains; HMEM configs must accept them when present.
+        REQUIRE_FALSE(acceptedNonHmem);
+        if (!acceptedHmem)
+        {
+            WARN("No verbs FI_HMEM domain advertised by libfabric on this host; HMEM selection path could not be positively verified");
+        }
+    }
+}
+
+TEST_CASE("ofi: ProviderConfig without HMEM still rejects FI_HMEM domains", "[ofi][ProviderConfig][hmem]")
+{
+    auto caps = ProviderCapabilities{.maxMessageSize = 0, .interfaceCaps = MXL_FABRICS_IFACE_CAP_REMOTE_WRITE};
+    auto config = ProviderConfig::verbs(true, caps);
+
+    for (auto info : FabricInfoList::get())
+    {
+        auto provider = providerFromString(info->fabric_attr->prov_name);
+        if (!provider || (*provider != Provider::VERBS))
+        {
+            continue;
+        }
+        if ((info->caps & FI_HMEM) != 0)
+        {
+            REQUIRE_FALSE(config.isSupportedFabricInfo(info));
+        }
+    }
+}
+
+TEST_CASE("ofi: regionsNeedHmem detects CUDA locations", "[ofi][Region][hmem]")
+{
+    std::uint64_t grainIndex = 1;
+    std::uint16_t validSlices = 0;
+    auto hostOnly = std::vector<Region>{
+        Region{0x1000, 8192 + 64, &grainIndex, &validSlices, Region::Location::host()},
+    };
+    REQUIRE_FALSE(regionsNeedHmem(hostOnly));
+
+    auto split = std::vector<Region>{
+        Region{0x1000, 8192, &grainIndex, &validSlices, Region::Location::host()},
+        Region{0x2000, 64, nullptr, nullptr, Region::Location::cuda(0)},
+    };
+    REQUIRE(regionsNeedHmem(split));
 }
 
 TEST_CASE("ofi: ProviderConfig::create dispatches to correct provider factory", "[ofi][ProviderConfig]")

--- a/lib/tests/fabrics/ofi/test_Region.cpp
+++ b/lib/tests/fabrics/ofi/test_Region.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <catch2/catch_test_macros.hpp>
+#include <vector>
 #include "Region.hpp"
 
 using namespace mxl::lib::fabrics::ofi;
@@ -38,4 +39,27 @@ TEST_CASE("ofi: RegionGroup view and iovec conversion", "[ofi][RegionGroup]")
 
     REQUIRE(iovecs[1].iov_base == reinterpret_cast<void*>(0x2000));
     REQUIRE(iovecs[1].iov_len == 128);
+}
+
+TEST_CASE("ofi: split header/payload ring slot helpers", "[ofi][Region]")
+{
+    std::uint64_t grainIndex0 = 42;
+    std::uint64_t grainIndex1 = 43;
+    std::uint16_t validSlices0 = 0;
+    std::uint16_t validSlices1 = 0;
+
+    auto regions = std::vector<Region>{
+        Region{0x1000, 8192, &grainIndex0, &validSlices0, Region::Location::host()},
+        Region{0x2000, 1024, nullptr, nullptr, Region::Location::cuda(0)},
+        Region{0x3000, 8192, &grainIndex1, &validSlices1, Region::Location::host()},
+        Region{0x4000, 1024, nullptr, nullptr, Region::Location::cuda(0)},
+    };
+
+    REQUIRE(getGrainIndexInRingSlot(regions, 0, 2) == 42);
+    REQUIRE(getGrainIndexInRingSlot(regions, 1, 2) == 43);
+
+    setValidSlicesForGrain(regions, 0, 7, 2);
+    setValidSlicesForGrain(regions, 1, 9, 2);
+    REQUIRE(validSlices0 == 7);
+    REQUIRE(validSlices1 == 9);
 }

--- a/lib/tests/test_flows.cpp
+++ b/lib/tests/test_flows.cpp
@@ -19,6 +19,7 @@
 #include <filesystem>
 #include <memory>
 #include <thread>
+#include <vector>
 #include <uuid.h>
 #include <catch2/catch_test_macros.hpp>
 #include <picojson/wrapper.h>
@@ -551,9 +552,218 @@ TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Video Flow : Options
     REQUIRE(flowWasCreated);
     REQUIRE(configInfo.common.maxCommitBatchSizeHint == 1080U);
     REQUIRE(configInfo.common.maxSyncBatchSizeHint == 1080U);
+    REQUIRE(configInfo.common.payloadLocation == MXL_PAYLOAD_LOCATION_HOST_MEMORY);
+    REQUIRE(configInfo.common.deviceIndex == -1);
     REQUIRE(mxlReleaseFlowWriter(instanceWriter, writer) == MXL_STATUS_OK);
     REQUIRE(mxlDestroyInstance(instanceWriter) == MXL_STATUS_OK);
 }
+
+TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Video Flow : Payload allocator host/device options", "[mxl flows]")
+{
+    auto flowDef = mxl::tests::readFile("data/v210_flow.json");
+    char const* flowId = "5fbec3b1-1b0f-417d-9059-8b94a47197ed";
+
+    auto instanceWriter = mxlCreateInstance(domain.string().c_str(), "");
+    REQUIRE(instanceWriter != nullptr);
+    auto instanceReader = mxlCreateInstance(domain.string().c_str(), "");
+    REQUIRE(instanceReader != nullptr);
+
+    mxlFlowWriter writer;
+    mxlFlowConfigInfo configInfo;
+    bool flowWasCreated = false;
+
+    // Nested host options (explicit).
+    {
+        picojson::object payload;
+        payload["location"] = picojson::value{"host"};
+        picojson::object optsObj;
+        optsObj["payload"] = picojson::value{payload};
+        auto const optsStr = picojson::value{optsObj}.serialize();
+
+        REQUIRE(mxlCreateFlowWriter(instanceWriter, flowDef.c_str(), optsStr.c_str(), &writer, &configInfo, &flowWasCreated) == MXL_STATUS_OK);
+        REQUIRE(flowWasCreated);
+        REQUIRE(configInfo.common.payloadLocation == MXL_PAYLOAD_LOCATION_HOST_MEMORY);
+        REQUIRE(configInfo.common.deviceIndex == -1);
+
+        auto const rate = mxlRational{60000, 1001};
+        auto const index = mxlTimestampToIndex(&rate, mxlGetTime());
+        mxlGrainInfo gInfo{};
+        mxlPayloadView view{};
+        REQUIRE(mxlFlowWriterOpenGrainEx(writer, index, &gInfo, &view) == MXL_STATUS_OK);
+        REQUIRE(view.kind == MXL_PAYLOAD_KIND_HOST_PTR);
+        REQUIRE(view.u.hostPtr != nullptr);
+        REQUIRE(view.grainSize == gInfo.grainSize);
+        REQUIRE(view.deviceIndex == -1);
+
+        uint8_t* hostPtr = nullptr;
+        REQUIRE(mxlFlowWriterOpenGrain(writer, index, &gInfo, &hostPtr) == MXL_STATUS_OK);
+        REQUIRE(hostPtr == view.u.hostPtr);
+
+        gInfo.validSlices = gInfo.totalSlices;
+        REQUIRE(mxlFlowWriterCommitGrain(writer, &gInfo) == MXL_STATUS_OK);
+
+        mxlFlowReader reader;
+        REQUIRE(mxlCreateFlowReader(instanceReader, flowId, "", &reader) == MXL_STATUS_OK);
+        mxlPayloadView readView{};
+        REQUIRE(mxlFlowReaderGetGrainNonBlockingEx(reader, index, &gInfo, &readView) == MXL_STATUS_OK);
+        REQUIRE(readView.kind == MXL_PAYLOAD_KIND_HOST_PTR);
+        REQUIRE(readView.u.hostPtr != nullptr);
+
+        REQUIRE(mxlReleaseFlowReader(instanceReader, reader) == MXL_STATUS_OK);
+        REQUIRE(mxlReleaseFlowWriter(instanceWriter, writer) == MXL_STATUS_OK);
+        REQUIRE(mxlGarbageCollectFlows(instanceWriter) >= 0);
+    }
+
+    // Device placeholder: metadata recorded, grain files header-only, accessors unsupported.
+    {
+        picojson::object payload;
+        payload["location"] = picojson::value{"device"};
+        payload["deviceIndex"] = picojson::value{0.0};
+        payload["backend"] = picojson::value{"placeholder"};
+        picojson::object optsObj;
+        optsObj["payload"] = picojson::value{payload};
+        auto const optsStr = picojson::value{optsObj}.serialize();
+
+        flowWasCreated = false;
+        REQUIRE(mxlCreateFlowWriter(instanceWriter, flowDef.c_str(), optsStr.c_str(), &writer, &configInfo, &flowWasCreated) == MXL_STATUS_OK);
+        REQUIRE(flowWasCreated);
+        REQUIRE(configInfo.common.payloadLocation == MXL_PAYLOAD_LOCATION_DEVICE_MEMORY);
+        REQUIRE(configInfo.common.deviceIndex == 0);
+
+        auto const rate = mxlRational{60000, 1001};
+        auto const index = mxlTimestampToIndex(&rate, mxlGetTime());
+        mxlGrainInfo gInfo{};
+        mxlPayloadView view{};
+        REQUIRE(mxlFlowWriterOpenGrainEx(writer, index, &gInfo, &view) == MXL_ERR_UNSUPPORTED_OPERATION);
+        REQUIRE(gInfo.grainSize > 0);
+
+        uint8_t* hostPtr = nullptr;
+        REQUIRE(mxlFlowWriterOpenGrain(writer, index, &gInfo, &hostPtr) == MXL_ERR_UNSUPPORTED_OPERATION);
+
+        // Grain file should be header-sized only.
+        auto const grainPath = domain / (std::string{flowId} + ".mxl-flow") / "grains" / "data.0";
+        REQUIRE(fs::exists(grainPath));
+        REQUIRE(fs::file_size(grainPath) == 8192);
+
+        REQUIRE(mxlReleaseFlowWriter(instanceWriter, writer) == MXL_STATUS_OK);
+    }
+
+    // Invalid combinations.
+    {
+        picojson::object optsObj;
+        optsObj["payloadLocation"] = picojson::value{"host"};
+        optsObj["deviceIndex"] = picojson::value{0.0};
+        auto optsStr = picojson::value{optsObj}.serialize();
+        REQUIRE(mxlCreateFlowWriter(instanceWriter, flowDef.c_str(), optsStr.c_str(), &writer, &configInfo, nullptr) == MXL_ERR_UNKNOWN);
+
+        optsObj.clear();
+        optsObj["payloadLocation"] = picojson::value{"device"};
+        optsObj["deviceIndex"] = picojson::value{-1.0};
+        optsStr = picojson::value{optsObj}.serialize();
+        REQUIRE(mxlCreateFlowWriter(instanceWriter, flowDef.c_str(), optsStr.c_str(), &writer, &configInfo, nullptr) == MXL_ERR_UNKNOWN);
+    }
+
+    REQUIRE(mxlDestroyInstance(instanceReader) == MXL_STATUS_OK);
+    REQUIRE(mxlDestroyInstance(instanceWriter) == MXL_STATUS_OK);
+}
+
+#if defined(MXL_HAS_CUDA) && MXL_HAS_CUDA
+#   include <cuda_runtime_api.h>
+
+TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Video Flow : CudaLinear payload", "[mxl flows][cuda]")
+{
+    int deviceCount = 0;
+    if ((cudaGetDeviceCount(&deviceCount) != cudaSuccess) || (deviceCount < 1))
+    {
+        SKIP("No CUDA device available");
+    }
+
+    auto flowDef = mxl::tests::readFile("data/v210_flow.json");
+    char const* flowId = "5fbec3b1-1b0f-417d-9059-8b94a47197ed";
+
+    auto instanceWriter = mxlCreateInstance(domain.string().c_str(), "");
+    REQUIRE(instanceWriter != nullptr);
+    auto instanceReader = mxlCreateInstance(domain.string().c_str(), "");
+    REQUIRE(instanceReader != nullptr);
+
+    picojson::object payload;
+    payload["location"] = picojson::value{"device"};
+    payload["deviceIndex"] = picojson::value{0.0};
+    payload["backend"] = picojson::value{"cuda-linear"};
+    picojson::object optsObj;
+    optsObj["payload"] = picojson::value{payload};
+    auto const optsStr = picojson::value{optsObj}.serialize();
+
+    mxlFlowWriter writer;
+    mxlFlowConfigInfo configInfo;
+    bool flowWasCreated = false;
+    REQUIRE(mxlCreateFlowWriter(instanceWriter, flowDef.c_str(), optsStr.c_str(), &writer, &configInfo, &flowWasCreated) == MXL_STATUS_OK);
+    REQUIRE(flowWasCreated);
+    REQUIRE(configInfo.common.payloadLocation == MXL_PAYLOAD_LOCATION_DEVICE_MEMORY);
+    REQUIRE(configInfo.common.deviceIndex == 0);
+
+    auto const grainPath = domain / (std::string{flowId} + ".mxl-flow") / "grains" / "data.0";
+    auto const payloadJson = domain / (std::string{flowId} + ".mxl-flow") / "payload.json";
+    auto const slot0 = domain / (std::string{flowId} + ".mxl-flow") / "payload" / "slot.0";
+    REQUIRE(fs::exists(grainPath));
+    REQUIRE(fs::file_size(grainPath) == 8192);
+    REQUIRE(fs::exists(payloadJson));
+    REQUIRE(fs::exists(slot0));
+
+    auto const rate = mxlRational{60000, 1001};
+    auto const index = mxlTimestampToIndex(&rate, mxlGetTime());
+
+    mxlGrainInfo gInfo{};
+    mxlPayloadView writeView{};
+    REQUIRE(mxlFlowWriterOpenGrainEx(writer, index, &gInfo, &writeView) == MXL_STATUS_OK);
+    REQUIRE(writeView.kind == MXL_PAYLOAD_KIND_DEVICE_PTR);
+    REQUIRE(writeView.u.devicePtr != 0);
+    REQUIRE(writeView.deviceIndex == 0);
+    REQUIRE(writeView.grainSize == gInfo.grainSize);
+
+    // Classic host pointer API must refuse device payloads.
+    uint8_t* hostPtr = nullptr;
+    REQUIRE(mxlFlowWriterOpenGrain(writer, index, &gInfo, &hostPtr) == MXL_ERR_UNSUPPORTED_OPERATION);
+
+    // Write a marker pattern into device memory and commit the grain.
+    {
+        REQUIRE(cudaSetDevice(0) == cudaSuccess);
+        auto hostPattern = std::vector<std::uint8_t>(64, 0xA5);
+        REQUIRE(cudaMemcpy(reinterpret_cast<void*>(writeView.u.devicePtr),
+                    hostPattern.data(),
+                    hostPattern.size(),
+                    cudaMemcpyHostToDevice) == cudaSuccess);
+    }
+
+    gInfo.validSlices = gInfo.totalSlices;
+    REQUIRE(mxlFlowWriterCommitGrain(writer, &gInfo) == MXL_STATUS_OK);
+
+    // Reader in a separate instance imports via CUDA IPC.
+    mxlFlowReader reader;
+    REQUIRE(mxlCreateFlowReader(instanceReader, flowId, "", &reader) == MXL_STATUS_OK);
+
+    mxlPayloadView readView{};
+    REQUIRE(mxlFlowReaderGetGrainNonBlockingEx(reader, index, &gInfo, &readView) == MXL_STATUS_OK);
+    REQUIRE(readView.kind == MXL_PAYLOAD_KIND_DEVICE_PTR);
+    REQUIRE(readView.u.devicePtr != 0);
+
+    {
+        REQUIRE(cudaSetDevice(0) == cudaSuccess);
+        auto hostBack = std::vector<std::uint8_t>(64, 0);
+        REQUIRE(cudaMemcpy(hostBack.data(),
+                    reinterpret_cast<void const*>(readView.u.devicePtr),
+                    hostBack.size(),
+                    cudaMemcpyDeviceToHost) == cudaSuccess);
+        REQUIRE(hostBack[0] == 0xA5);
+        REQUIRE(hostBack[63] == 0xA5);
+    }
+
+    REQUIRE(mxlReleaseFlowReader(instanceReader, reader) == MXL_STATUS_OK);
+    REQUIRE(mxlReleaseFlowWriter(instanceWriter, writer) == MXL_STATUS_OK);
+    REQUIRE(mxlDestroyInstance(instanceReader) == MXL_STATUS_OK);
+    REQUIRE(mxlDestroyInstance(instanceWriter) == MXL_STATUS_OK);
+}
+#endif
 
 TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Video Flow : Slices", "[mxl flows]")
 {

--- a/tools/mxl-fabrics-demo/demo.cpp
+++ b/tools/mxl-fabrics-demo/demo.cpp
@@ -7,12 +7,14 @@
 #include <cstdint>
 #include <cstdlib>
 #include <fstream>
+#include <iterator>
 #include <optional>
 #include <string>
 #include <type_traits>
 #include <uuid.h>
 #include <sys/types.h>
 #include <CLI/CLI.hpp>
+#include <fmt/format.h>
 #include <mxl-internal/FlowParser.hpp>
 #include <mxl-internal/Logging.hpp>
 #include <mxl/fabrics.h>
@@ -30,7 +32,13 @@
         2- Paste the target info that gets printed in stdout to the --target-info argument of the initiator.
         3- Start a sender: ./mxl-fabrics-demo -i -d <tmpfs folder> -f <test source flow uuid> --service 1234 --target-info <targetInfo>
 
+    Device (CUDA) grain payloads:
+        Target: add --flow-options examples/payload-options/cuda-payload-options.json and prefer -p verbs
+        (HMEM-capable). The demo uses OpenGrainEx / GetGrain*Ex so device flows work; fabrics
+        registers header + CUDA payload regions separately.
+
     The best available interface is selected automatically (EFA > VERBS > TCP > SHM).
+    When a device payload flow is detected, HMEM-capable interfaces are preferred/required.
     Use --node to bind to a specific address.
 */
 
@@ -114,6 +122,10 @@ std::string capabilitiesString(std::uint64_t caps)
     {
         resultLength += capStrings.emplace_back("SEND_RECEIVE").size();
     }
+    if ((caps & MXL_FABRICS_IFACE_CAP_HMEM) != 0)
+    {
+        resultLength += capStrings.emplace_back("HMEM").size();
+    }
     if (capStrings.empty())
     {
         resultLength += capStrings.emplace_back("<none>").size();
@@ -157,8 +169,46 @@ int providerPriority(mxlFabricsProvider provider)
     }
 }
 
+[[nodiscard]]
+bool interfaceHasHmem(mxlFabricsInterfaceConfig const& interface) noexcept
+{
+    return (interface.caps.flags & MXL_FABRICS_IFACE_CAP_HMEM) != 0;
+}
+
+[[nodiscard]]
+int interfaceScore(mxlFabricsInterfaceConfig const& interface, bool preferHmem) noexcept
+{
+    auto score = providerPriority(interface.provider) * 10;
+    if (preferHmem)
+    {
+        score += interfaceHasHmem(interface) ? 5 : -100;
+    }
+    return score;
+}
+
+[[nodiscard]]
+bool flowOptionsRequestDevicePayload(std::string const& flowOptions)
+{
+    return (flowOptions.find("\"device\"") != std::string::npos) || (flowOptions.find("cuda-linear") != std::string::npos) ||
+           (flowOptions.find("\"payloadLocation\":\"device\"") != std::string::npos);
+}
+
+[[nodiscard]]
+bool existingFlowNeedsHmem(std::string const& domain, std::string const& flowId)
+{
+    auto const payloadJsonPath = fmt::format("{}/{}.mxl-flow/payload.json", domain, flowId);
+    auto file = std::ifstream{payloadJsonPath};
+    if (!file)
+    {
+        return false;
+    }
+    auto const contents = std::string{std::istreambuf_iterator<char>{file}, std::istreambuf_iterator<char>{}};
+    return (contents.find("cuda-linear") != std::string::npos) || (contents.find("\"location\": \"device\"") != std::string::npos) ||
+           (contents.find("\"location\":\"device\"") != std::string::npos);
+}
+
 InterfaceSelection selectInterface(mxlFabricsInstance instance, std::optional<std::string> const& node, std::optional<std::string> const& service,
-    std::optional<mxlFabricsProvider> provider = std::nullopt)
+    std::optional<mxlFabricsProvider> provider = std::nullopt, bool preferHmem = false)
 {
     auto list = std::add_pointer_t<mxlFabricsInterfaceList>{nullptr};
     auto query = mxlFabricsInterfaceConfig{};
@@ -183,7 +233,7 @@ InterfaceSelection selectInterface(mxlFabricsInstance instance, std::optional<st
     auto best = std::add_pointer_t<mxlFabricsInterfaceConfig const>{nullptr};
     for (auto* entry = list; entry != nullptr; entry = entry->next)
     {
-        if (!best || (providerPriority(entry->interface.provider) > providerPriority(best->provider)))
+        if (!best || (interfaceScore(entry->interface, preferHmem) > interfaceScore(*best, preferHmem)))
         {
             best = &entry->interface;
         }
@@ -192,6 +242,13 @@ InterfaceSelection selectInterface(mxlFabricsInstance instance, std::optional<st
     if (!best)
     {
         MXL_ERROR("No matching interfaces found");
+        mxlFabricsFreeInterfaceList(list);
+        std::exit(MXL_ERR_NO_FABRIC);
+    }
+
+    if (preferHmem && !interfaceHasHmem(*best))
+    {
+        MXL_ERROR("Device grain payloads require an HMEM-capable fabric interface (e.g. -p verbs with nvidia_peermem loaded)");
         mxlFabricsFreeInterfaceList(list);
         std::exit(MXL_ERR_NO_FABRIC);
     }
@@ -308,6 +365,21 @@ public:
             return status;
         }
 
+        {
+            mxlFlowConfigInfo readerConfig{};
+            if (mxlFlowReaderGetConfigInfo(_reader, &readerConfig) == MXL_STATUS_OK)
+            {
+                if (readerConfig.common.payloadLocation == MXL_PAYLOAD_LOCATION_DEVICE_MEMORY)
+                {
+                    MXL_INFO("Grain payload location: device (deviceIndex={})", readerConfig.common.deviceIndex);
+                }
+                else
+                {
+                    MXL_INFO("Grain payload location: host");
+                }
+            }
+        }
+
         status = mxlFabricsCreateInitiator(_fabricsInstance, &_initiator);
         if (status != MXL_STATUS_OK)
         {
@@ -406,7 +478,7 @@ public:
         MXL_INFO("Using batch size of {} slices", slicesPerBatch);
 
         mxlGrainInfo grainInfo;
-        std::uint8_t* payload;
+        mxlPayloadView payloadView{};
         std::uint16_t startSlice = 0;
         std::uint16_t endSlice = slicesPerBatch;
         auto stats = TransferStats{};
@@ -415,7 +487,8 @@ public:
 
         while (!g_exit_requested)
         {
-            auto status = mxlFlowReaderGetGrainSlice(_reader, grainIndex, endSlice, 200000000, &grainInfo, &payload);
+            // Use the Ex API so device (CUDA) payload flows work; only grain metadata is needed here.
+            auto status = mxlFlowReaderGetGrainSliceEx(_reader, grainIndex, endSlice, 200000000, &grainInfo, &payloadView);
             if (status == MXL_ERR_OUT_OF_RANGE_TOO_LATE)
             {
                 // We are too late.. time travel!
@@ -694,6 +767,15 @@ public:
             MXL_WARN("Reusing existing flow");
         }
 
+        if (_configInfo.common.payloadLocation == MXL_PAYLOAD_LOCATION_DEVICE_MEMORY)
+        {
+            MXL_INFO("Grain payload location: device (deviceIndex={})", _configInfo.common.deviceIndex);
+        }
+        else
+        {
+            MXL_INFO("Grain payload location: host");
+        }
+
         status = mxlFabricsCreateTarget(_fabricsInstance, &_target);
         if (status != MXL_STATUS_OK)
         {
@@ -789,7 +871,7 @@ public:
     {
         mxlGrainInfo grainInfo;
         std::uint64_t grainIndex = 0;
-        std::uint8_t* dummyPayload;
+        mxlPayloadView unusedPayloadView{};
         mxlStatus status;
         auto stats = TransferStats{};
 
@@ -820,8 +902,8 @@ public:
                 return status;
             }
 
-            // Here we open so that we can commit, we are not going to modify the grain as it was already modified by the initiator.
-            status = mxlFlowWriterOpenGrain(_writer, grainIndex, &grainInfo, &dummyPayload);
+            // Open so we can commit. Payload was already written by the remote initiator (host or device).
+            status = mxlFlowWriterOpenGrainEx(_writer, grainIndex, &grainInfo, &unusedPayloadView);
             if (status != MXL_STATUS_OK)
             {
                 MXL_ERROR("Failed to open grain with status '{}'", static_cast<int>(status));
@@ -1001,7 +1083,28 @@ int main(int argc, char** argv)
         return s;
     }
 
-    auto selectedInterface = selectInterface(fabricsInstance, optNode, optService, optProvider);
+    // Detect device payloads before interface selection so we can require HMEM (e.g. verbs).
+    auto preferHmem = false;
+    auto flowOptionsPreview = std::string{};
+    if (!runAsInitiator && !flowOptionsFile.empty())
+    {
+        if (auto optionFile = std::ifstream{flowOptionsFile, std::ios::in | std::ios::binary}; optionFile)
+        {
+            flowOptionsPreview = {std::istreambuf_iterator<char>(optionFile), std::istreambuf_iterator<char>()};
+            preferHmem = flowOptionsRequestDevicePayload(flowOptionsPreview);
+        }
+    }
+    else if (runAsInitiator)
+    {
+        preferHmem = existingFlowNeedsHmem(domain, flowConf);
+    }
+
+    if (preferHmem)
+    {
+        MXL_INFO("Device grain payload detected; preferring HMEM-capable fabric interfaces");
+    }
+
+    auto selectedInterface = selectInterface(fabricsInstance, optNode, optService, optProvider, preferHmem);
     mxlFabricsDestroyInstance(fabricsInstance);
     mxlDestroyInstance(instance);
 
@@ -1079,8 +1182,8 @@ int main(int argc, char** argv)
 
         auto flowId = uuids::to_string(descriptorParser.getId());
 
-        std::string flowOptions;
-        if (!flowOptionsFile.empty())
+        std::string flowOptions = std::move(flowOptionsPreview);
+        if (flowOptions.empty() && !flowOptionsFile.empty())
         {
             std::ifstream optionFile(flowOptionsFile, std::ios::in | std::ios::binary);
             if (!optionFile)

--- a/tools/mxl-fabrics-info/main.cpp
+++ b/tools/mxl-fabrics-info/main.cpp
@@ -73,6 +73,10 @@ namespace
         {
             resultLength += capStrings.emplace_back("SEND_RECEIVE").size();
         }
+        if ((caps & MXL_FABRICS_IFACE_CAP_HMEM) != 0)
+        {
+            resultLength += capStrings.emplace_back("HMEM").size();
+        }
         if (capStrings.empty())
         {
             resultLength += capStrings.emplace_back("<none>").size();

--- a/tools/mxl-gst/CMakeLists.txt
+++ b/tools/mxl-gst/CMakeLists.txt
@@ -57,6 +57,18 @@ if (gstreamer_FOUND)
                 PkgConfig::gstreamer-video
             )
 
+    if (MXL_BUILT_WITH_CUDA)
+        find_package(CUDAToolkit REQUIRED)
+        target_compile_definitions(mxl-gst-testsrc
+                PRIVATE
+                    MXL_HAS_CUDA=1
+            )
+        target_link_libraries(mxl-gst-testsrc
+                PRIVATE
+                    CUDA::cudart
+            )
+    endif()
+
 
     add_executable(mxl-gst-sink)
     target_compile_features(mxl-gst-sink
@@ -90,6 +102,18 @@ if (gstreamer_FOUND)
                 PkgConfig::gstreamer-audio
                 PkgConfig::gstreamer-video
         )
+
+    if (MXL_BUILT_WITH_CUDA)
+        find_package(CUDAToolkit REQUIRED)
+        target_compile_definitions(mxl-gst-sink
+                PRIVATE
+                    MXL_HAS_CUDA=1
+            )
+        target_link_libraries(mxl-gst-sink
+                PRIVATE
+                    CUDA::cudart
+            )
+    endif()
 
     add_executable(mxl-gst-looping-filesrc)
     target_compile_features(mxl-gst-looping-filesrc

--- a/tools/mxl-gst/sink.cpp
+++ b/tools/mxl-gst/sink.cpp
@@ -25,6 +25,10 @@
 #include "mxl/rational.h"
 #include "utils.hpp"
 
+#if defined(MXL_HAS_CUDA) && MXL_HAS_CUDA
+#   include <cuda_runtime_api.h>
+#endif
+
 #ifdef __APPLE__
 #   include <TargetConditionals.h>
 #endif
@@ -36,6 +40,57 @@ namespace
     void signal_handler(int) noexcept
     {
         g_exit_requested = 1;
+    }
+
+    /**
+     * Copy a grain payload view into a host destination buffer.
+     * Host payloads are memcpy'd; CUDA device payloads are downloaded with cudaMemcpy.
+     */
+    [[nodiscard]]
+    mxlStatus copyPayloadViewToHost(mxlPayloadView const& view, void* destination, std::size_t destinationSize)
+    {
+        if ((destination == nullptr) || (destinationSize < view.grainSize))
+        {
+            return MXL_ERR_INVALID_ARG;
+        }
+
+        if (view.kind == MXL_PAYLOAD_KIND_HOST_PTR)
+        {
+            if (view.u.hostPtr == nullptr)
+            {
+                return MXL_ERR_UNKNOWN;
+            }
+            std::memcpy(destination, view.u.hostPtr, view.grainSize);
+            return MXL_STATUS_OK;
+        }
+
+        if (view.kind == MXL_PAYLOAD_KIND_DEVICE_PTR)
+        {
+#if defined(MXL_HAS_CUDA) && MXL_HAS_CUDA
+            if (view.u.devicePtr == 0)
+            {
+                return MXL_ERR_UNKNOWN;
+            }
+            if (auto const err = ::cudaSetDevice(view.deviceIndex); err != cudaSuccess)
+            {
+                MXL_ERROR("cudaSetDevice({}) failed: {}", view.deviceIndex, cudaGetErrorString(err));
+                return MXL_ERR_UNKNOWN;
+            }
+            auto const* const devicePtr = reinterpret_cast<void const*>(static_cast<std::uintptr_t>(view.u.devicePtr));
+            if (auto const err = ::cudaMemcpy(destination, devicePtr, view.grainSize, cudaMemcpyDeviceToHost); err != cudaSuccess)
+            {
+                MXL_ERROR("cudaMemcpy D2H failed: {}", cudaGetErrorString(err));
+                return MXL_ERR_UNKNOWN;
+            }
+            return MXL_STATUS_OK;
+#else
+            MXL_ERROR("Device payload requested but mxl-gst-sink was built without CUDA support");
+            return MXL_ERR_UNSUPPORTED_OPERATION;
+#endif
+        }
+
+        MXL_ERROR("Unsupported grain payload kind {}", view.kind);
+        return MXL_ERR_UNSUPPORTED_OPERATION;
     }
 
     struct VideoPipelineConfig
@@ -370,6 +425,15 @@ namespace
             {
                 throw std::runtime_error{fmt::format("Failed to get flow config info with status code {}", static_cast<int>(ret))};
             }
+
+            if (_configInfo.common.payloadLocation == MXL_PAYLOAD_LOCATION_DEVICE_MEMORY)
+            {
+                MXL_INFO("Grain payload location: device (deviceIndex={})", _configInfo.common.deviceIndex);
+            }
+            else
+            {
+                MXL_INFO("Grain payload location: host");
+            }
         }
 
         ~MxlReader()
@@ -415,8 +479,8 @@ namespace
             while (!g_exit_requested)
             {
                 auto ret = mxlStatus{};
-                mxlGrainInfo grainInfo;
-                uint8_t* payload;
+                mxlGrainInfo grainInfo{};
+                mxlPayloadView payloadView{};
 
                 auto const iterationStartTime = ::mxlGetTime();
                 auto const iterationTimeoutNs =
@@ -426,13 +490,14 @@ namespace
                     // Slice mode is not really useful here since gstreamer needs the full grain to push to the pipeline. But for educational
                     // purposes, here's how you can wait for slices to be available.
                     // Please note that -- contrary to how this sample does it -- you don't have to use the slice based reading just because
-                    // the producer indicates a sub-grain sync batch size and are free to use mxlFlowReaderGetGrain() in any case.
-                    ret = ::mxlFlowReaderGetGrainSlice(_reader, cursor.requestedIndex(), expectedSlices, iterationTimeoutNs, &grainInfo, &payload);
+                    // the producer indicates a sub-grain sync batch size and are free to use mxlFlowReaderGetGrainEx() in any case.
+                    ret = ::mxlFlowReaderGetGrainSliceEx(
+                        _reader, cursor.requestedIndex(), expectedSlices, iterationTimeoutNs, &grainInfo, &payloadView);
                 }
                 else
                 {
                     // Use this function to wait for a full grain
-                    ret = ::mxlFlowReaderGetGrain(_reader, cursor.requestedIndex(), iterationTimeoutNs, &grainInfo, &payload);
+                    ret = ::mxlFlowReaderGetGrainEx(_reader, cursor.requestedIndex(), iterationTimeoutNs, &grainInfo, &payloadView);
                 }
 
                 if (ret == MXL_STATUS_OK)
@@ -452,7 +517,13 @@ namespace
                             auto map = GstMapInfo{};
 
                             ::gst_buffer_map(buffer, &map, GST_MAP_WRITE);
-                            std::memcpy(map.data, payload, grainInfo.grainSize);
+                            if (copyPayloadViewToHost(payloadView, map.data, map.size) != MXL_STATUS_OK)
+                            {
+                                ::gst_buffer_unmap(buffer, &map);
+                                ::gst_buffer_unref(buffer);
+                                MXL_ERROR("Failed to copy grain payload at index {}. Exiting...", cursor.requestedIndex());
+                                return;
+                            }
                             ::gst_buffer_unmap(buffer, &map);
 
                             gstPipeline.pushBuffer(buffer, ::mxlIndexToTimestamp(&rate, cursor.requestedIndex()));

--- a/tools/mxl-gst/testsrc.cpp
+++ b/tools/mxl-gst/testsrc.cpp
@@ -9,6 +9,7 @@
 #include <stdexcept>
 #include <string>
 #include <thread>
+#include <vector>
 #include <glib.h>
 #include <uuid.h>
 #include <CLI/CLI.hpp>
@@ -21,6 +22,10 @@
 #include <mxl/time.h>
 #include "utils.hpp"
 
+#if defined(MXL_HAS_CUDA) && MXL_HAS_CUDA
+#   include <cuda_runtime_api.h>
+#endif
+
 namespace
 {
     auto volatile g_exit_requested = std::sig_atomic_t{0};
@@ -29,6 +34,120 @@ namespace
     {
         g_exit_requested = 1;
     }
+
+    /**
+     * Opens a discrete grain via OpenGrainEx and provides a host-writable pointer.
+     * For host payloads that pointer is the grain itself. For CUDA device payloads a
+     * staging buffer is used and ranges are uploaded with cudaMemcpy on flush/commit.
+     */
+    class GrainWriteSession
+    {
+    public:
+        GrainWriteSession() = default;
+
+        [[nodiscard]]
+        mxlStatus open(mxlFlowWriter writer, std::uint64_t index)
+        {
+            _view = {};
+            _staging.clear();
+            auto const status = ::mxlFlowWriterOpenGrainEx(writer, index, &_info, &_view);
+            if (status != MXL_STATUS_OK)
+            {
+                return status;
+            }
+
+            if (_view.kind == MXL_PAYLOAD_KIND_HOST_PTR)
+            {
+                if (_view.u.hostPtr == nullptr)
+                {
+                    return MXL_ERR_UNKNOWN;
+                }
+                return MXL_STATUS_OK;
+            }
+
+            if (_view.kind == MXL_PAYLOAD_KIND_DEVICE_PTR)
+            {
+#if defined(MXL_HAS_CUDA) && MXL_HAS_CUDA
+                if (_view.u.devicePtr == 0)
+                {
+                    return MXL_ERR_UNKNOWN;
+                }
+                _staging.assign(_view.grainSize, 0);
+                return MXL_STATUS_OK;
+#else
+                MXL_ERROR("Device payload requested but mxl-gst-testsrc was built without CUDA support");
+                return MXL_ERR_UNSUPPORTED_OPERATION;
+#endif
+            }
+
+            MXL_ERROR("Unsupported grain payload kind {}", _view.kind);
+            return MXL_ERR_UNSUPPORTED_OPERATION;
+        }
+
+        [[nodiscard]]
+        mxlGrainInfo& info() noexcept
+        {
+            return _info;
+        }
+
+        [[nodiscard]]
+        std::uint8_t* writableBase() noexcept
+        {
+            if (_view.kind == MXL_PAYLOAD_KIND_HOST_PTR)
+            {
+                return _view.u.hostPtr;
+            }
+            return _staging.data();
+        }
+
+        /**
+         * Ensure bytes [offset, offset+size) written into writableBase() are visible in the
+         * grain payload backing store (no-op for host-mapped payloads).
+         */
+        [[nodiscard]]
+        mxlStatus flushRange(std::size_t offset, std::size_t size) const
+        {
+            if (size == 0U)
+            {
+                return MXL_STATUS_OK;
+            }
+            if (_view.kind == MXL_PAYLOAD_KIND_HOST_PTR)
+            {
+                return MXL_STATUS_OK;
+            }
+            if (_view.kind != MXL_PAYLOAD_KIND_DEVICE_PTR)
+            {
+                return MXL_ERR_UNSUPPORTED_OPERATION;
+            }
+            if ((offset + size) > _staging.size())
+            {
+                return MXL_ERR_INVALID_ARG;
+            }
+
+#if defined(MXL_HAS_CUDA) && MXL_HAS_CUDA
+            if (auto const err = ::cudaSetDevice(_view.deviceIndex); err != cudaSuccess)
+            {
+                MXL_ERROR("cudaSetDevice({}) failed: {}", _view.deviceIndex, cudaGetErrorString(err));
+                return MXL_ERR_UNKNOWN;
+            }
+            auto* const devicePtr = reinterpret_cast<std::uint8_t*>(_view.u.devicePtr);
+            if (auto const err = ::cudaMemcpy(devicePtr + offset, _staging.data() + offset, size, cudaMemcpyHostToDevice); err != cudaSuccess)
+            {
+                MXL_ERROR("cudaMemcpy H2D failed: {}", cudaGetErrorString(err));
+                return MXL_ERR_UNKNOWN;
+            }
+            return MXL_STATUS_OK;
+#else
+            (void)offset;
+            return MXL_ERR_UNSUPPORTED_OPERATION;
+#endif
+        }
+
+    private:
+        mxlGrainInfo _info{};
+        mxlPayloadView _view{};
+        std::vector<std::uint8_t> _staging;
+    };
 
     struct VideoPipelineConfig
     {
@@ -459,6 +578,15 @@ namespace
             {
                 MXL_WARN("Reusing existing flow.");
             }
+
+            if (_configInfo.common.payloadLocation == MXL_PAYLOAD_LOCATION_DEVICE_MEMORY)
+            {
+                MXL_INFO("Grain payload location: device (deviceIndex={})", _configInfo.common.deviceIndex);
+            }
+            else
+            {
+                MXL_INFO("Grain payload location: host");
+            }
         }
 
         ~MxlWriter()
@@ -526,19 +654,17 @@ namespace
                         // Generate the skipped grains as invalid grains
                         while (grainIndex < gstGrainIndex)
                         {
-                            auto gInfo = mxlGrainInfo{};
-                            std::uint8_t* mxlBuffer = nullptr;
                             auto const actualGrainIndex = grainIndex - offset;
+                            auto session = GrainWriteSession{};
 
-                            /// Open the grain for writing.
-                            if (::mxlFlowWriterOpenGrain(_writer, actualGrainIndex, &gInfo, &mxlBuffer) != MXL_STATUS_OK)
+                            if (session.open(_writer, actualGrainIndex) != MXL_STATUS_OK)
                             {
                                 MXL_ERROR("Failed to open grain at index '{}'", actualGrainIndex);
                                 break;
                             }
 
-                            gInfo.flags = MXL_GRAIN_FLAG_INVALID;
-                            if (::mxlFlowWriterCommitGrain(_writer, &gInfo) != MXL_STATUS_OK)
+                            session.info().flags = MXL_GRAIN_FLAG_INVALID;
+                            if (::mxlFlowWriterCommitGrain(_writer, &session.info()) != MXL_STATUS_OK)
                             {
                                 MXL_ERROR("Failed to commit invalid grain at index '{}'", actualGrainIndex);
                                 break;
@@ -557,19 +683,16 @@ namespace
                         auto mapInfo = ::GstMapInfo{};
                         if (::gst_buffer_map(pipelineSample.buffer(), &mapInfo, GST_MAP_READ))
                         {
-                            /// Open the grain.
-                            auto gInfo = ::mxlGrainInfo{};
-                            std::uint8_t* mxlBuffer = nullptr;
-
-                            /// Open the grain for writing.
-                            if (::mxlFlowWriterOpenGrain(_writer, actualGrainIndex, &gInfo, &mxlBuffer) != MXL_STATUS_OK)
+                            auto session = GrainWriteSession{};
+                            if (session.open(_writer, actualGrainIndex) != MXL_STATUS_OK)
                             {
                                 MXL_ERROR("Failed to open grain at index '{}'", actualGrainIndex);
                                 ::gst_buffer_unmap(pipelineSample.buffer(), &mapInfo);
                                 break;
                             }
 
-                            gInfo.validSlices = 0;
+                            session.info().validSlices = 0;
+                            auto* const mxlBuffer = session.writableBase();
 
                             auto const sliceSize = gstPipeline.config().sliceSize;
 
@@ -589,13 +712,21 @@ namespace
 
                             for (auto i = std::size_t{0}; i < nbBatches; ++i)
                             {
-                                auto const nbSlices = std::min<std::uint16_t>(slicesPerBatch, gInfo.totalSlices - gInfo.validSlices);
+                                auto const nbSlices =
+                                    std::min<std::uint16_t>(slicesPerBatch, session.info().totalSlices - session.info().validSlices);
 
                                 auto const batchOffset = sliceSize * slicesPerBatch * i;
-                                ::memcpy(mxlBuffer + batchOffset, mapInfo.data + batchOffset, nbSlices * sliceSize);
-                                gInfo.validSlices += nbSlices;
+                                auto const batchBytes = static_cast<std::size_t>(nbSlices) * sliceSize;
+                                ::memcpy(mxlBuffer + batchOffset, mapInfo.data + batchOffset, batchBytes);
+                                if (session.flushRange(batchOffset, batchBytes) != MXL_STATUS_OK)
+                                {
+                                    MXL_ERROR("Failed to flush grain payload batch at index '{}'", actualGrainIndex);
+                                    break;
+                                }
 
-                                if (::mxlFlowWriterCommitGrain(_writer, &gInfo) != MXL_STATUS_OK)
+                                session.info().validSlices += nbSlices;
+
+                                if (::mxlFlowWriterCommitGrain(_writer, &session.info()) != MXL_STATUS_OK)
                                 {
                                     MXL_ERROR("Failed to commit grain at index '{}'", actualGrainIndex);
                                     break;


### PR DESCRIPTION
## Summary
- Advertise/require `MXL_FABRICS_IFACE_CAP_HMEM` for device grain flows on verbs
- Register split host-header + CUDA-payload regions; use process-local CUDA bounce buffers on egress for IPC imports (not peermem-registerable)
- Fix RC initiator/target CQ binding for HMEM MSG endpoints

**Stacked on #653** — this branch includes the CUDA grain-payload commit. Please merge #653 first; the library commit will drop out of this PR’s diff after that.

## Test plan
- [ ] `mxl-fabrics-ofi-tests "[ofi]"` (ProviderConfig HMEM cases)
- [ ] Fabrics demo on tmpfs domain: target → `mxl-gst-testsrc` (CUDA options) → initiator; confirm ~30 grains/s both sides
- [ ] Domain on ext4/`/tmp` is expected to fail MR pin on this host; use `/dev/shm`