### PR TITLE
Rust: Fix prototype of mkdtemp in gst-mxl-rs tests to avoid a compilation error on arm64

### DIFF
--- a/rust/gst-mxl-rs/tests/common/mod.rs
+++ b/rust/gst-mxl-rs/tests/common/mod.rs
@@ -101,9 +101,9 @@ fn dev_shm_skip_reason() -> Option<String> {
     let mut path = b"/dev/shm/mxl_gst_shm_probeXXXXXX\0".to_vec();
     let created = unsafe {
         unsafe extern "C" {
-            fn mkdtemp(template: *mut i8) -> *mut i8;
+            fn mkdtemp(template: *mut std::ffi::c_char) -> *mut std::ffi::c_char;
         }
-        mkdtemp(path.as_mut_ptr() as *mut i8)
+        mkdtemp(path.as_mut_ptr() as *mut std::ffi::c_char)
     };
     if created.is_null() {
         let err = std::io::Error::last_os_error();


### PR DESCRIPTION
[//]: # (SPDX-FileCopyrightText: 2026 Contributors to the Media eXchange Layer project.)
[//]: # (SPDX-License-Identifier: Apache-2.0)

# Details

The current native prototype of `mkdtemp` in one of the rust tests was falsely prototyped as taking a signed byte pointer instead of a character pointer. This caused a type mismatch, when compiling for linux/arm64.

@pac-work provided this fix, which I confirmed to solve the problem, while having no impact on the compilation on linux/x86_64.

# Backport requirements

Should be back ported to v1.1, not sure if the offending code is also present in v1.0.