### PR TITLE
gst-avsynctest-rs: fix AncillaryMeta DC parity bits

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -10,6 +10,7 @@ resolver = "2"
 edition = "2024"
 publish = false
 version = "0.1.0"
+rust-version = "1.87"
 license = "Apache-2.0"
 license-file = "../LICENSE.txt"
 repository = "https://github.com/dmf-mxl/mxl"

--- a/rust/gst-avsynctest-rs/Cargo.toml
+++ b/rust/gst-avsynctest-rs/Cargo.toml
@@ -10,6 +10,7 @@ edition.workspace = true
 publish.workspace = true
 version.workspace = true
 license.workspace = true
+rust-version = "1.87"
 
 [dependencies]
 cdp-types = "0.3"

--- a/rust/gst-avsynctest-rs/src/ancillary.rs
+++ b/rust/gst-avsynctest-rs/src/ancillary.rs
@@ -1,0 +1,175 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: 2026 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: Apache-2.0
+
+//! SMPTE 291 ancillary packing and `GstAncillaryMeta` validity helpers.
+
+use glib;
+use gstreamer as gst;
+use gstreamer_video as gst_video;
+
+/// Extend an 8-bit value to a 10-bit ST 291 word with even/odd parity.
+///
+/// Per SMPTE ST 291: b8 is even parity over b7 to b0 (so b0 to b8 have an even
+/// number of 1s), and b9 = NOT b8. Matches `SET_WITH_PARITY` in
+/// gst-plugins-base `video-anc.c`: odd popcount gives `0x100 | v`, even gives
+/// `0x200 | v`.
+fn extend_with_even_odd_parity(v: u8) -> u16 {
+    if v.count_ones() & 1 != 0 {
+        // Odd number of ones in v: b8 = 1, b9 = 0
+        0x1_00 | (v as u16)
+    } else {
+        // Even number of ones in v: b8 = 0, b9 = 1
+        0x2_00 | (v as u16)
+    }
+}
+
+fn has_even_odd_parity(w: u16) -> bool {
+    w == extend_with_even_odd_parity((w & 0xff) as u8)
+}
+
+/// SMPTE 291 checksum over the 10-bit DID, SDID, DC and UDW words.
+fn ancillary_checksum(did: u16, sdid: u16, dc: u16, data: &[u16]) -> u16 {
+    let mut checksum = 0u16;
+    checksum = checksum.wrapping_add(did & 0x1ff);
+    checksum = checksum.wrapping_add(sdid & 0x1ff);
+    checksum = checksum.wrapping_add(dc & 0x1ff);
+    for &w in data {
+        checksum = checksum.wrapping_add(w & 0x1ff);
+    }
+    checksum &= 0x1ff;
+    // b9 = NOT b8 (ST 291 checksum word)
+    if checksum & 0x1_00 == 0 {
+        checksum |= 0x2_00;
+    }
+    checksum
+}
+
+/// Attach one `GstAncillaryMeta` carrying 8-bit `payload` under `did`/`sdid` on
+/// `line`/`offset`, as 10-bit even/odd-parity words plus checksum.
+pub fn add_ancillary_meta(
+    buffer: &mut gst::BufferRef,
+    line: u16,
+    offset: u16,
+    did: u8,
+    sdid: u8,
+    payload: &[u8],
+) {
+    let mut meta = gst_video::video_meta::AncillaryMeta::add(buffer);
+    meta.set_c_not_y_channel(false);
+    meta.set_line(line);
+    meta.set_offset(offset);
+    let did_10bit = extend_with_even_odd_parity(did);
+    let sdid_10bit = extend_with_even_odd_parity(sdid);
+    let dc_10bit = extend_with_even_odd_parity(payload.len() as u8);
+    meta.set_did(did_10bit);
+    meta.set_sdid_block_number(sdid_10bit);
+    let data: Vec<u16> = payload
+        .iter()
+        .copied()
+        .map(extend_with_even_odd_parity)
+        .collect();
+    meta.set_data(glib::Slice::from(data));
+    // set_data writes only the length into data_count's low 8 bits and clears
+    // the upper two; restore even/odd parity so DC is a valid 10-bit word.
+    meta.set_data_count_upper_two_bits((dc_10bit >> 8) as u8);
+    let checksum = ancillary_checksum(
+        meta.did(),
+        meta.sdid_block_number(),
+        meta.data_count(),
+        meta.data(),
+    );
+    meta.set_checksum(checksum);
+}
+
+/// Whether `w` is a permitted 10-bit word under ST 291-1 Section 9.1.
+///
+/// Prohibited TRS/sync codes are `0x000`-`0x003` and `0x3FC`-`0x3FF`. Values
+/// above `0x3FF` are also rejected (not a 10-bit word). DID/SDID/DC with
+/// even/odd parity already avoid the prohibited codes.
+fn is_permitted_word(w: u16) -> bool {
+    0x003 < w && w < 0x3fc
+}
+
+/// Whether one `GstAncillaryMeta` is a consistent SMPTE 291 packet: DID, SDID
+/// and DC carry even/odd parity, each UDW is a permitted 10-bit word (ST 291-1
+/// Section 9.1), and the stored checksum matches the sum over the stored
+/// 10-bit DID/SDID/DC/UDW words. UDWs are not required to use 8-bit + parity
+/// packing (ST 291 allows full 10-bit user data).
+pub fn is_valid_ancillary_meta(meta: &gst_video::video_meta::AncillaryMeta) -> bool {
+    let did = meta.did();
+    let sdid = meta.sdid_block_number();
+    let dc = meta.data_count();
+    let data = meta.data();
+    if !has_even_odd_parity(did) || !has_even_odd_parity(sdid) || !has_even_odd_parity(dc) {
+        return false;
+    }
+    if !data.iter().all(|&w| is_permitted_word(w)) {
+        return false;
+    }
+    meta.checksum() == ancillary_checksum(did, sdid, dc, data)
+}
+
+/// Whether every `GstAncillaryMeta` on `buffer` passes [`is_valid_ancillary_meta`].
+pub fn has_valid_ancillary_metas(buffer: &gst::BufferRef) -> bool {
+    buffer
+        .iter_meta::<gst_video::video_meta::AncillaryMeta>()
+        .all(|m| is_valid_ancillary_meta(&m))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn even_odd_parity_matches_st291_and_gst_vbi_encoder() {
+        // Odd popcount gives b8=1, b9=0 (0x100 | v), as SET_WITH_PARITY in video-anc.c
+        assert_eq!(extend_with_even_odd_parity(0x00), 0x200); // 0 ones, even
+        assert_eq!(extend_with_even_odd_parity(0x01), 0x101); // 1 one, odd
+        assert_eq!(extend_with_even_odd_parity(0x03), 0x203); // 2 ones, even
+        assert_eq!(extend_with_even_odd_parity(0x61), 0x161); // 3 ones, odd (CEA-708 DID)
+
+        for v in 0u8..=255 {
+            let w = extend_with_even_odd_parity(v);
+            assert_eq!(w & 0xff, u16::from(v));
+            // Even parity over b0..b8: popcount of those 9 bits must be even
+            let popcount_0_to_8 = (w & 0x1ff).count_ones();
+            assert!(
+                popcount_0_to_8.is_multiple_of(2),
+                "b0..b8 must have even popcount for {v:#04x}, got {w:#05x}"
+            );
+            let b8 = (w >> 8) & 1;
+            let b9 = (w >> 9) & 1;
+            assert_eq!(b9, 1 - b8, "b9 must be NOT b8 for {v:#04x}");
+        }
+    }
+
+    #[test]
+    fn add_ancillary_meta_writes_parity_extended_adf_words() {
+        gst::init().unwrap();
+
+        let mut buf = gst::Buffer::new();
+        {
+            let buf = buf.make_mut();
+            // DC=3 (even popcount) and CEA-708 DID/SDID so values are fixed.
+            add_ancillary_meta(buf, 9, 0, 0x61, 0x01, &[0x41, 0x42, 0x43]);
+        }
+
+        let meta = buf
+            .meta::<gst_video::video_meta::AncillaryMeta>()
+            .expect("missing AncillaryMeta");
+        assert!(
+            is_valid_ancillary_meta(&meta),
+            "DID={:#x} SDID={:#x} DC={:#x} CS={:#x}",
+            meta.did(),
+            meta.sdid_block_number(),
+            meta.data_count(),
+            meta.checksum()
+        );
+        // Direct ST 291 checks so validity is not only circular against a
+        // buggy extend_with_even_odd_parity.
+        assert_eq!(meta.did(), 0x161);
+        assert_eq!(meta.sdid_block_number(), 0x101);
+        assert_eq!(meta.data_count(), 0x203); // DC=3, even popcount => 0x203
+    }
+}

--- a/rust/gst-avsynctest-rs/src/audiosrc/mod.rs
+++ b/rust/gst-avsynctest-rs/src/audiosrc/mod.rs
@@ -2,6 +2,33 @@
 // SPDX-FileCopyrightText: 2026 Contributors to the Media eXchange Layer project.
 // SPDX-License-Identifier: Apache-2.0
 
+/**
+ * SECTION:element-avsyncaudiotestsrc
+ * @see_also: avsyncvideotestsrc
+ *
+ * `avsyncaudiotestsrc` is one half of a phase-locked audio/video test pair for
+ * measuring end-to-end A/V synchronisation. It emits silence with a short tone
+ * pip centred on every *pip* instant, phase-locked to the bar-centre crossing
+ * of `avsyncvideotestsrc`.
+ *
+ * ## Example
+ *
+ * Eyeball-and-ear check — the bar crosses centre exactly on the beep:
+ *
+ * |[
+ * gst-launch-1.0 \
+ *   avsyncvideotestsrc is-live=true ! videoconvert ! autovideosink \
+ *   avsyncaudiotestsrc is-live=true ! audioconvert ! autoaudiosink
+ * ]|
+ *
+ * ## Phase locking
+ *
+ * The content is derived purely from each buffer's running time and the shared
+ * `pip-interval`, so the two sources are aligned by construction and any skew
+ * seen downstream was introduced by the pipeline under test. `pip-interval`
+ * *must* be set to the same value on both elements. Set `is-live=true` to pace
+ * output against the pipeline clock for live capture or transmit pipelines.
+ */
 use gst::glib;
 use gst::prelude::*;
 use gstreamer as gst;

--- a/rust/gst-avsynctest-rs/src/captions.rs
+++ b/rust/gst-avsynctest-rs/src/captions.rs
@@ -25,6 +25,7 @@ pub const CC_DID: u8 = 0x61;
 pub const CC_SDID: u8 = 0x01;
 /// Ancillary line for the caption packet (distinct from the frame-index line).
 pub const CC_LINE: u16 = 10;
+pub const CC_OFFSET: u16 = 0;
 /// The single CEA-708 service the captions are written to.
 pub const CC_SERVICE_NO: u8 = 1;
 

--- a/rust/gst-avsynctest-rs/src/lib.rs
+++ b/rust/gst-avsynctest-rs/src/lib.rs
@@ -26,10 +26,13 @@
 //!   avsyncaudiotestsrc is-live=true ! audioconvert ! autoaudiosink
 //! ```
 
+#![allow(unused_doc_comments)]
+
 use gst::glib;
 use gstreamer as gst;
 
 pub mod analyze;
+pub mod ancillary;
 pub mod audiosrc;
 pub mod captions;
 pub(crate) mod imp_error;
@@ -42,6 +45,11 @@ fn plugin_init(plugin: &gst::Plugin) -> Result<(), glib::BoolError> {
     Ok(())
 }
 
+/**
+ * plugin-avsynctest:
+ *
+ * Phase-locked audio/video test sources for end-to-end synchronisation testing.
+ */
 gst::plugin_define!(
     avsynctest,
     env!("CARGO_PKG_DESCRIPTION"),

--- a/rust/gst-avsynctest-rs/src/videosrc/imp.rs
+++ b/rust/gst-avsynctest-rs/src/videosrc/imp.rs
@@ -156,48 +156,6 @@ fn fill_uyvp(data: &mut [u8], info: &gst_video::VideoInfo, bar_centre: u32, bar_
     }
 }
 
-fn extend_with_even_odd_parity(v: u8) -> u16 {
-    if v.count_ones() & 1 == 0 {
-        0x1_00 | (v as u16)
-    } else {
-        0x2_00 | (v as u16)
-    }
-}
-
-fn compute_checksum(did_10bit: u16, sdid_10bit: u16, dc_10bit: u16, data: &[u16]) -> u16 {
-    let mut checksum = 0u16;
-    checksum = checksum.wrapping_add(did_10bit & 0x1ff);
-    checksum = checksum.wrapping_add(sdid_10bit & 0x1ff);
-    checksum = checksum.wrapping_add(dc_10bit & 0x1ff);
-    for &w in data {
-        checksum = checksum.wrapping_add(w & 0x1ff);
-    }
-    checksum &= 0x1ff;
-    checksum |= ((!(checksum >> 8)) & 0x01) << 9;
-    checksum
-}
-
-/// Attach one `GstAncillaryMeta` carrying `payload` under `did`/`sdid` on `line`,
-/// as `st2038extractor` expects (10-bit even/odd-parity words plus checksum).
-fn add_ancillary(buffer: &mut gst::BufferRef, did: u8, sdid: u8, line: u16, payload: &[u8]) {
-    let mut meta = gst_video::video_meta::AncillaryMeta::add(buffer);
-    meta.set_c_not_y_channel(false);
-    meta.set_line(line);
-    meta.set_offset(signal::ANC_OFFSET);
-    let did_10bit = extend_with_even_odd_parity(did);
-    let sdid_10bit = extend_with_even_odd_parity(sdid);
-    let dc_10bit = extend_with_even_odd_parity(payload.len() as u8);
-    meta.set_did(did_10bit);
-    meta.set_sdid_block_number(sdid_10bit);
-    let data: Vec<u16> = payload
-        .iter()
-        .copied()
-        .map(extend_with_even_odd_parity)
-        .collect();
-    meta.set_checksum(compute_checksum(did_10bit, sdid_10bit, dc_10bit, &data));
-    meta.set_data(glib::Slice::from(data));
-}
-
 #[glib::object_subclass]
 impl ObjectSubclass for AvSyncVideoTestSrc {
     const NAME: &'static str = "GstAvSyncVideoTestSrc";
@@ -625,19 +583,21 @@ impl PushSrcImpl for AvSyncVideoTestSrc {
                 }
                 data[0] = frame_idx;
             }
-            add_ancillary(
+            crate::ancillary::add_ancillary_meta(
                 buffer,
+                signal::ANC_LINE,
+                signal::ANC_OFFSET,
                 signal::ANC_DID,
                 signal::ANC_SDID,
-                signal::ANC_LINE,
                 &[frame_idx],
             );
             if let Some(cdp) = &cdp {
-                add_ancillary(
+                crate::ancillary::add_ancillary_meta(
                     buffer,
+                    captions::CC_LINE,
+                    captions::CC_OFFSET,
                     captions::CC_DID,
                     captions::CC_SDID,
-                    captions::CC_LINE,
                     cdp,
                 );
             }

--- a/rust/gst-avsynctest-rs/src/videosrc/mod.rs
+++ b/rust/gst-avsynctest-rs/src/videosrc/mod.rs
@@ -2,6 +2,39 @@
 // SPDX-FileCopyrightText: 2026 Contributors to the Media eXchange Layer project.
 // SPDX-License-Identifier: Apache-2.0
 
+/**
+ * SECTION:element-avsyncvideotestsrc
+ * @see_also: avsyncaudiotestsrc
+ *
+ * `avsyncvideotestsrc` is one half of a phase-locked audio/video test pair for
+ * measuring end-to-end A/V synchronisation. It renders a white vertical bar on
+ * black that crosses screen centre exactly on every *pip* instant and sweeps
+ * fully across in one pip interval, so the bar-centre crossing lines up with
+ * the tone pip from `avsyncaudiotestsrc`.
+ *
+ * Each frame also carries its frame index and a phase-locked CEA-708 caption
+ * (alternating "TICK"/"TOCK") as ancillary data, so an `st2038extractor` can
+ * split the ANC into its own flow and a downstream analyser can check that
+ * video, audio and caption alignment survive the round trip.
+ *
+ * ## Example
+ *
+ * Eyeball-and-ear check — the bar crosses centre exactly on the beep:
+ *
+ * |[
+ * gst-launch-1.0 \
+ *   avsyncvideotestsrc is-live=true ! videoconvert ! autovideosink \
+ *   avsyncaudiotestsrc is-live=true ! audioconvert ! autoaudiosink
+ * ]|
+ *
+ * ## Phase locking
+ *
+ * The content is derived purely from each buffer's running time and the shared
+ * `pip-interval`, so the two sources are aligned by construction and any skew
+ * seen downstream was introduced by the pipeline under test. `pip-interval`
+ * *must* be set to the same value on both elements. Set `is-live=true` to pace
+ * output against the pipeline clock for live capture or transmit pipelines.
+ */
 use gst::glib;
 use gst::prelude::*;
 use gstreamer as gst;

--- a/rust/gst-avsynctest-rs/tests/generator.rs
+++ b/rust/gst-avsynctest-rs/tests/generator.rs
@@ -190,6 +190,65 @@ fn video_bar_sweeps_and_centres_on_pip() {
     }
 }
 
+/// [`add_ancillary_meta`](gstavsynctest::ancillary::add_ancillary_meta) produces metas
+/// that pass [`has_valid_ancillary_metas`](gstavsynctest::ancillary::has_valid_ancillary_metas)
+/// (odd and even DC bit counts), with DID/SDID/DC matching ST 291 parity.
+#[test]
+fn add_ancillary_meta_produces_valid_meta() {
+    use gstavsynctest::ancillary::add_ancillary_meta;
+    init();
+    let mut buffer = gst::Buffer::with_size(1).unwrap();
+    {
+        let buffer = buffer.get_mut().unwrap();
+        // DC of 1 (odd bit count) and 3 (even bit count) exercise both parity cases.
+        add_ancillary_meta(buffer, 9, 0, 0x44, 0x01, &[0x11]);
+        add_ancillary_meta(buffer, 9, 32, 0x61, 0x01, &[0x22, 0x33, 0x44]);
+    }
+    let metas: Vec<_> = buffer
+        .iter_meta::<gst_video::video_meta::AncillaryMeta>()
+        .collect();
+    assert_eq!(metas.len(), 2);
+    // Direct ST 291 checks (not only circular against extend_with_even_odd_parity).
+    assert_eq!(metas[0].did(), 0x244); // 0x44: 2 ones, even => 0x244
+    assert_eq!(metas[0].sdid_block_number(), 0x101); // 0x01: 1 one, odd => 0x101
+    assert_eq!(metas[0].data_count(), 0x101); // DC=1, odd => 0x101
+    assert_eq!(metas[1].did(), 0x161); // 0x61: 3 ones, odd => 0x161
+    assert_eq!(metas[1].sdid_block_number(), 0x101);
+    assert_eq!(metas[1].data_count(), 0x203); // DC=3, even => 0x203
+    assert!(
+        gstavsynctest::ancillary::has_valid_ancillary_metas(buffer.as_ref()),
+        "add_ancillary_meta wrote invalid AncillaryMeta"
+    );
+}
+
+/// Every `GstAncillaryMeta` (frame-index and CEA-708) passes
+/// [`has_valid_ancillary_metas`](gstavsynctest::ancillary::has_valid_ancillary_metas).
+#[test]
+fn video_has_valid_ancillary_metas() {
+    init();
+    let desc = format!(
+        "avsyncvideotestsrc num-buffers={VIDEO_FRAMES} pip-interval={PIP_INTERVAL_NS} is-live=false \
+           ! video/x-raw,format=v210,width={WIDTH},height={HEIGHT},framerate={FPS}/1 \
+           ! appsink name=sink sync=false"
+    );
+    let samples = run(&desc);
+    assert_eq!(samples.len(), VIDEO_FRAMES as usize);
+    for (i, s) in samples.iter().enumerate() {
+        let buffer = s.buffer().unwrap();
+        let n_meta = buffer
+            .iter_meta::<gst_video::video_meta::AncillaryMeta>()
+            .count();
+        assert!(
+            n_meta >= 2,
+            "frame {i}: expected index + caption ancillary, got {n_meta}"
+        );
+        assert!(
+            gstavsynctest::ancillary::has_valid_ancillary_metas(buffer),
+            "frame {i}: AncillaryMeta invalid (parity, reserved UDW, or checksum)"
+        );
+    }
+}
+
 /// The video source attaches a phase-locked CEA-708 caption: TICK/TOCK on each
 /// pip frame (alternating), a null CDP on every other frame. Round-tripped
 /// through `cdp-types`/`cea708-types` straight off the ancillary meta (before any

--- a/rust/gst-mxl-rs/Cargo.toml
+++ b/rust/gst-mxl-rs/Cargo.toml
@@ -9,6 +9,7 @@ edition.workspace = true
 publish.workspace = true
 version.workspace = true
 license.workspace = true
+rust-version.workspace = true
 
 [package.metadata.cargo-machete]
 ignored = ["regex"]

--- a/rust/gst-mxl-rs/tests/common/mod.rs
+++ b/rust/gst-mxl-rs/tests/common/mod.rs
@@ -149,56 +149,6 @@ impl Drop for TestDomainGuard {
     }
 }
 
-fn extend_with_even_odd_parity(v: u8) -> u16 {
-    if v.count_ones() & 1 == 0 {
-        0x1_00 | (v as u16)
-    } else {
-        0x2_00 | (v as u16)
-    }
-}
-
-fn compute_checksum(did_10bit: u16, sdid_10bit: u16, dc_10bit: u16, data: &[u16]) -> u16 {
-    let mut checksum = 0u16;
-    checksum = checksum.wrapping_add(did_10bit & 0x1ff);
-    checksum = checksum.wrapping_add(sdid_10bit & 0x1ff);
-    checksum = checksum.wrapping_add(dc_10bit & 0x1ff);
-    for &w in data {
-        checksum = checksum.wrapping_add(w & 0x1ff);
-    }
-    checksum &= 0x1ff;
-    checksum |= ((!(checksum >> 8)) & 0x01) << 9;
-    checksum
-}
-
-/// Attach one `GstAncillaryMeta` (SMPTE 291 DID/SDID + payload) to `buffer`,
-/// extending each octet to a 10-bit even/odd-parity word and computing the
-/// checksum, as `st2038extractor` expects on the wire.
-pub fn add_ancillary_meta(
-    buffer: &mut gst::BufferRef,
-    line: u16,
-    offset: u16,
-    did: u8,
-    sdid: u8,
-    payload: &[u8],
-) {
-    let mut meta = gst_video::video_meta::AncillaryMeta::add(buffer);
-    meta.set_c_not_y_channel(false);
-    meta.set_line(line);
-    meta.set_offset(offset);
-    let did_10bit = extend_with_even_odd_parity(did);
-    let sdid_10bit = extend_with_even_odd_parity(sdid);
-    let dc_10bit = extend_with_even_odd_parity(payload.len() as u8);
-    meta.set_did(did_10bit);
-    meta.set_sdid_block_number(sdid_10bit);
-    let data: Vec<u16> = payload
-        .iter()
-        .copied()
-        .map(extend_with_even_odd_parity)
-        .collect();
-    meta.set_checksum(compute_checksum(did_10bit, sdid_10bit, dc_10bit, &data));
-    meta.set_data(glib::Slice::from(data));
-}
-
 /// `parse::launch` the shared producer (`appsrc` → `st2038extractor` → a video
 /// `mxlsink` and a companion data `mxlsink`) and return the pipeline, its
 /// `appsrc`, and the v210 frame size in bytes.

--- a/rust/gst-mxl-rs/tests/mxlsrc_timing.rs
+++ b/rust/gst-mxl-rs/tests/mxlsrc_timing.rs
@@ -15,8 +15,9 @@ use std::time::Duration;
 #[macro_use]
 mod common;
 
-use common::{FRAME_PERIOD_NS, add_ancillary_meta, build_producer, init, skip_reason};
+use common::{FRAME_PERIOD_NS, build_producer, init, skip_reason};
 use gst::prelude::*;
+use gstavsynctest::ancillary::add_ancillary_meta;
 use gstreamer as gst;
 use gstreamer_app as gst_app;
 

--- a/rust/gst-mxl-rs/tests/video_data_sync.rs
+++ b/rust/gst-mxl-rs/tests/video_data_sync.rs
@@ -45,10 +45,11 @@ mod common;
 use std::collections::{BTreeMap, BTreeSet};
 
 use common::{
-    FRAME_PERIOD_NS, FRAMERATE_DEN, FRAMERATE_NUM, add_ancillary_meta, assert_bus_no_errors,
-    build_producer, collect_bus_errors, init, skip_reason, st2038_first_packet_data0,
+    FRAME_PERIOD_NS, FRAMERATE_DEN, FRAMERATE_NUM, assert_bus_no_errors, build_producer,
+    collect_bus_errors, init, skip_reason, st2038_first_packet_data0,
 };
 use gst::prelude::*;
+use gstavsynctest::ancillary::add_ancillary_meta;
 use gstreamer as gst;
 use gstreamer_app as gst_app;
 use gstreamer_video as gst_video;

--- a/rust/mxl-sys/Cargo.toml
+++ b/rust/mxl-sys/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 publish.workspace = true
 version.workspace = true
 license.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 libloading.workspace = true

--- a/rust/mxl/Cargo.toml
+++ b/rust/mxl/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 publish.workspace = true
 version.workspace = true
 license.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 mxl-sys = { path = "../mxl-sys" }


### PR DESCRIPTION
## Summary
- `AncillaryMeta::set_data` only writes DC’s low 8 bits and clears the parity nibble; packing computed a parity-extended DC for the checksum but never called `set_data_count_upper_two_bits`, so attached metas were invalid.
- Centralise SMPTE 291 packing and validity checks in `gst-avsynctest-rs::ancillary`; point `gst-mxl-rs` tests at that helper instead of the duplicate in `tests/common`.
- Add a regression test covering odd and even DC bit counts (`add_ancillary_meta_produces_valid_meta`), plus end-to-end `video_ancillary_metas_valid`.

## Test plan
- [x] `cargo fmt -p gst-avsynctest-rs -- --check`
- [x] `cargo clippy -p gst-avsynctest-rs --all-targets -- -D warnings`
- [x] `cargo test -p gst-avsynctest-rs -- --test-threads=1` (includes `add_ancillary_meta_produces_valid_meta`)

## Backport requirements

Should be backported for v1.1 please