### PR TITLE
Fixes for ease of packaging

### DIFF
--- a/lib/internal/tests/test_domainwatcher.cpp
+++ b/lib/internal/tests/test_domainwatcher.cpp
@@ -4,6 +4,7 @@
 #include <condition_variable>
 #include <cstdio>
 #include <cstdlib>
+#include <algorithm>
 #include <filesystem>
 #include <fstream>
 #include <list>

--- a/lib/tests/fabrics/test_basics.cpp
+++ b/lib/tests/fabrics/test_basics.cpp
@@ -7,6 +7,7 @@
 #include <cstdint>
 #include <cstring>
 #include <algorithm>
+#include <random>
 #include <vector>
 #include <uuid.h>
 #include <catch2/catch_message.hpp>
@@ -708,10 +709,12 @@ TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Fabrics: Transfer Gr
     std::array<std::string, nbTargets> flowDefs;
     std::array<mxlFlowConfigInfo, nbTargets> configInfo;
     std::array<mxlFlowWriter, nbTargets> writer;
+    auto engine = std::mt19937{std::random_device{}()};
+    auto uuidGen = uuids::uuid_random_generator{engine};
     for (size_t i = 0; i < nbTargets; i++)
     {
         REQUIRE(mxlFabricsCreateTarget(fabrics, &targets[i]) == MXL_STATUS_OK);
-        flowIds[i] = uuids::to_string(uuids::uuid_system_generator{}());
+        flowIds[i] = uuids::to_string(uuidGen());
         root.at("id") = picojson::value{flowIds[i]};
         flowDefs[i] = picojson::value{root}.serialize();
         REQUIRE(mxlCreateFlowWriter(instance, flowDefs[i].c_str(), nullptr, &writer[i], &configInfo[i], nullptr) == MXL_STATUS_OK);
@@ -917,10 +920,12 @@ TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Fabrics: Transfer Sa
     std::array<std::string, nbTargets> flowDefs;
     std::array<mxlFlowConfigInfo, nbTargets> configInfo;
     std::array<mxlFlowWriter, nbTargets> writer;
+    auto engine = std::mt19937{std::random_device{}()};
+    auto uuidGen = uuids::uuid_random_generator{engine};
     for (size_t i = 0; i < nbTargets; i++)
     {
         REQUIRE(mxlFabricsCreateTarget(fabrics, &targets[i]) == MXL_STATUS_OK);
-        flowIds[i] = uuids::to_string(uuids::uuid_system_generator{}());
+        flowIds[i] = uuids::to_string(uuidGen());
         root.at("id") = picojson::value{flowIds[i]};
         flowDefs[i] = picojson::value{root}.serialize();
         REQUIRE(mxlCreateFlowWriter(instance, flowDefs[i].c_str(), nullptr, &writer[i], &configInfo[i], nullptr) == MXL_STATUS_OK);

--- a/tools/mxl-gst/looping_filesrc.cpp
+++ b/tools/mxl-gst/looping_filesrc.cpp
@@ -1,13 +1,13 @@
 // SPDX-FileCopyrightText: 2025 Contributors to the Media eXchange Layer project.
 // SPDX-License-Identifier: Apache-2.0
 
-#include <climits>
 #include <csignal>
 #include <cstdint>
 #include <cstring>
 #include <atomic>
 #include <filesystem>
 #include <memory>
+#include <random>
 #include <thread>
 #include <uuid.h>
 #include <CLI/CLI.hpp>
@@ -372,7 +372,7 @@ public:
             gst_object_unref(pad);
 
             // make sure the videoFlowId is set
-            videoFlowId = in_videoId.value_or(uuids::uuid_system_generator{}());
+            videoFlowId = in_videoId.value_or(randomUuid());
 
             std::string flowDef;
             videoGrainRate = mxlRational{fps_n, fps_d};
@@ -459,7 +459,7 @@ public:
             gst_object_unref(pad);
 
             // make sure the audioFlowId is set
-            audioFlowId = in_audioId.value_or(uuids::uuid_system_generator{}());
+            audioFlowId = in_audioId.value_or(randomUuid());
 
             std::string flowDef;
             audioGrainRate = mxlRational{rate, 1};
@@ -623,6 +623,13 @@ private:
         root["maxCommitBatchSizeHint"] = picojson::value(static_cast<double>(maxCommitBatchSizeHint));
         root["maxSyncBatchSizeHint"] = picojson::value(static_cast<double>(maxSyncBatchSizeHint));
         return picojson::value(root).serialize(true);
+    }
+
+    static uuids::uuid randomUuid()
+    {
+        static auto engine = std::mt19937{std::random_device{}()};
+        static auto generator = uuids::uuid_random_generator{engine};
+        return generator();
     }
 
     void videoThread()


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2026 Contributors to the Media eXchange Layer project. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

# Details
Two fixes to ease packaging of libmxl
- fix one is a basic missing include (not sure why it doesn't blow up in upstream builds)
- fix two is removing the dependency on a stduuid build specifically with UUID_SYSTEM_GENERATOR enabled. This is out-of-scope for the stdlib proposal and not enabled everywhere by default. As it only affects tests/utils right now I think this is fine.

# Backport requirements
The domainwatcher include would be nice2have in 1.0