### PR TITLE
fix(PosixDiscreteFlowReader): open the flow access file with O_CLOEXEC

### DIFF
--- a/lib/internal/src/PosixDiscreteFlowReader.cpp
+++ b/lib/internal/src/PosixDiscreteFlowReader.cpp
@@ -43,7 +43,7 @@ namespace mxl::lib
         , _accessFileFd{-1}
     {
         auto const accessFile = makeFlowAccessFilePath(manager.getDomain(), to_string(flowId));
-        _accessFileFd = ::open(accessFile.string().c_str(), O_RDWR);
+        _accessFileFd = ::open(accessFile.string().c_str(), O_RDWR | O_CLOEXEC);
 
         // Opening the access file may fail if the domain is in a read only volume.
         // we can still execute properly but the 'lastReadTime' will never be updated.


### PR DESCRIPTION
# Details

`PosixDiscreteFlowReader`'s constructor opens the flow access file without `O_CLOEXEC`, which makes it the only descriptor in the library that does not set the flag:

| site | flags |
|---|---|
| `lib/src/flow.cpp:47` | `O_RDONLY \| O_CLOEXEC` |
| `lib/internal/src/Instance.cpp:328` | `O_RDONLY \| O_CLOEXEC` |
| `lib/internal/src/SharedMemory.cpp:26-28` | all three `OMODE_*` constants |
| `lib/internal/src/PosixDiscreteFlowReader.cpp:46` | `O_RDWR` |

Consequence: a reader's access-file descriptor survives into a forked child's exec'd image, where it pins the flow directory for the lifetime of an unrelated process. Since a writer that recreates a flow unlinks the old directory, the child can hold the only reference to a ring nothing can observe it holding. Applications that embed MXL alongside a process launcher are the ones that notice.

This is the residual half of a fix we have been carrying downstream. The other half, the missing destructor that leaked the descriptor outright, has since landed here independently (`~PosixDiscreteFlowReader` at `PosixDiscreteFlowReader.cpp:53`), so only the flag is left to reconcile.

Not addressed here: `DomainWatcher.cpp:217` opens with `O_EVTONLY` under `__APPLE__` and also omits `O_CLOEXEC`. It looks like the same omission, but I have no Darwin build to verify it on, so I left it for someone who does.

# Backport requirements

Applies cleanly to `release/v1.1.x` if you want it there. No API, ABI, or behavioural change for existing callers: the flag only affects descriptor inheritance across `exec`, and nothing in the library forks.

# Testing

No new test. The behaviour is observable only across `fork`/`exec`, which the suite does not currently exercise, and asserting on `FD_CLOEXEC` via `fcntl` would test the flag rather than the property. Existing tests pass unchanged since nothing in the read path reads the flag.
