### PR TITLE
Handling writers jumping forward.

### DIFF
--- a/.devcontainer/ubuntu24/devcontainer.json
+++ b/.devcontainer/ubuntu24/devcontainer.json
@@ -15,8 +15,8 @@
     ],
     "mounts": [
         // These 2 mount points are required for GUI applications to work in WSL2. Remove them if you are not using WSL2.
-        "source=/tmp/.X11-unix,target=/tmp/.X11-unix,type=bind,consistency=cached",
-        "source=/mnt/wslg,target=/mnt/wslg,type=bind,consistency=cached"
+        //"source=/tmp/.X11-unix,target=/tmp/.X11-unix,type=bind,consistency=cached",
+        //"source=/mnt/wslg,target=/mnt/wslg,type=bind,consistency=cached"
     ],
     "customizations": {
         "vscode": {

--- a/lib/internal/src/PosixContinuousFlowWriter.cpp
+++ b/lib/internal/src/PosixContinuousFlowWriter.cpp
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "PosixContinuousFlowWriter.hpp"
+#include <cstring>
+#include <algorithm>
 #include <stdexcept>
 #include <mxl/time.h>
 #include "mxl-internal/Sync.hpp"
@@ -15,6 +17,7 @@ namespace mxl::lib
         , _channelCount{_flowData->channelCount()}
         , _bufferLength{_flowData->channelBufferLength()}
         , _currentIndex{MXL_UNDEFINED_INDEX}
+        , _lastCommittedIndex{MXL_UNDEFINED_INDEX}
         , _syncBatchSize{1U}
         , _earlySyncThreshold{}
         , _lastSyncSampleBatch{}
@@ -77,6 +80,45 @@ namespace mxl::lib
         {
             if (count <= (_bufferLength / 2))
             {
+                if (index < count)
+                {
+                    return MXL_ERR_INVALID_ARG;
+                }
+
+                auto const writeStartIndex = index - count;
+                if (_lastCommittedIndex != MXL_UNDEFINED_INDEX)
+                {
+                    if ((index <= _lastCommittedIndex) || (writeStartIndex < _lastCommittedIndex))
+                    {
+                        return MXL_ERR_INVALID_ARG;
+                    }
+
+                    if (writeStartIndex > _lastCommittedIndex)
+                    {
+                        // We have to clear any skipped samples in the writable ring. This prevents readers from
+                        // seeing stale payload data when the producer introduces a write gap.
+                        auto const skippedCount = writeStartIndex - _lastCommittedIndex;
+                        auto const clearedCount = std::min<std::uint64_t>(skippedCount, _bufferLength);
+                        auto const gapEndIndex = writeStartIndex;
+
+                        auto const clearStartOffset = (gapEndIndex + _bufferLength - clearedCount) % _bufferLength;
+                        auto const clearEndOffset = gapEndIndex % _bufferLength;
+                        auto const firstClearLength = (clearStartOffset < clearEndOffset) ? clearedCount : _bufferLength - clearStartOffset;
+                        auto const secondClearLength = clearedCount - firstClearLength;
+
+                        auto const sampleWordSize = _flowData->sampleWordSize();
+                        auto const channelStride = sampleWordSize * _bufferLength;
+                        auto* const baseBufferPtr = static_cast<std::uint8_t*>(_flowData->channelData());
+
+                        for (auto channel = std::size_t{0}; channel < _channelCount; ++channel)
+                        {
+                            auto* const channelBasePtr = baseBufferPtr + (channel * channelStride);
+                            std::memset(channelBasePtr + (sampleWordSize * clearStartOffset), 0, sampleWordSize * firstClearLength);
+                            std::memset(channelBasePtr, 0, sampleWordSize * secondClearLength);
+                        }
+                    }
+                }
+
                 auto const startOffset = (index + _bufferLength - count) % _bufferLength;
                 auto const endOffset = (index % _bufferLength);
 
@@ -109,8 +151,14 @@ namespace mxl::lib
     {
         if (_flowData)
         {
+            if (_currentIndex == MXL_UNDEFINED_INDEX)
+            {
+                return MXL_ERR_INVALID_ARG;
+            }
+
             auto const flow = _flowData->flow();
             flow->info.runtime.headIndex = _currentIndex;
+            _lastCommittedIndex = _currentIndex;
             _currentIndex = MXL_UNDEFINED_INDEX;
 
             if (signalCompletedBatch())

--- a/lib/internal/src/PosixContinuousFlowWriter.hpp
+++ b/lib/internal/src/PosixContinuousFlowWriter.hpp
@@ -10,7 +10,6 @@
 #include <mxl/mxl.h>
 #include "mxl-internal/ContinuousFlowData.hpp"
 #include "mxl-internal/ContinuousFlowWriter.hpp"
-#include "mxl-internal/DomainWatcher.hpp"
 #include "mxl-internal/FlowManager.hpp"
 
 namespace mxl::lib
@@ -82,6 +81,8 @@ namespace mxl::lib
         std::size_t _bufferLength;
         /** The currently opened sample range head index. MXL_UNDEFINED_INDEX if no range is currently opened. */
         std::uint64_t _currentIndex;
+        /** The last committed sample range head index. MXL_UNDEFINED_INDEX if no range has been committed yet. */
+        std::uint64_t _lastCommittedIndex;
 
         /** Cached preprocessed copy of mxlCommonFlowInfo::maxSyncBatchSizeHint. */
         std::uint32_t _syncBatchSize;

--- a/lib/internal/src/PosixDiscreteFlowWriter.cpp
+++ b/lib/internal/src/PosixDiscreteFlowWriter.cpp
@@ -3,6 +3,7 @@
 
 #include "PosixDiscreteFlowWriter.hpp"
 #include <cstdint>
+#include <algorithm>
 #include <stdexcept>
 #include <fcntl.h>
 #include <uuid.h>
@@ -22,6 +23,7 @@ namespace mxl::lib
         : DiscreteFlowWriter{flowId, manager.getDomain()}
         , _flowData{std::move(data)}
         , _currentIndex{MXL_UNDEFINED_INDEX}
+        , _lastCommittedIndex{MXL_UNDEFINED_INDEX}
         , _watcher(watcher)
     {
         _watcher->addFlow(this, flowId);
@@ -81,17 +83,43 @@ namespace mxl::lib
 
     mxlStatus PosixDiscreteFlowWriter::openGrain(std::uint64_t in_index, mxlGrainInfo* out_grainInfo, std::uint8_t** out_payload)
     {
-        if (_flowData)
+        if (!_flowData)
         {
-            auto offset = in_index % _flowData->flowInfo()->config.discrete.grainCount;
-            auto const grain = _flowData->grainAt(offset);
-            grain->header.info.index = in_index; // Set the absolute grain index associated to that ring buffer entry
-            *out_grainInfo = grain->header.info;
-            *out_payload = reinterpret_cast<std::uint8_t*>(&grain->header + 1);
-            _currentIndex = in_index;
-            return MXL_STATUS_OK;
+            return MXL_ERR_UNKNOWN;
         }
-        return MXL_ERR_UNKNOWN;
+
+        if (_lastCommittedIndex != MXL_UNDEFINED_INDEX && in_index <= _lastCommittedIndex)
+        {
+            return MXL_ERR_INVALID_ARG;
+        }
+
+        if (_lastCommittedIndex != MXL_UNDEFINED_INDEX && in_index > (_lastCommittedIndex + 1U))
+        {
+            // We have to invalidate any grain that would've been written to if the write was continuous. This is to ensure that the reader doesn't
+            // read stale data from a previous write.
+            auto const grainCount = _flowData->flowInfo()->config.discrete.grainCount;
+            auto const skippedCount = in_index - _lastCommittedIndex - 1U;
+            auto const invalidatedCount = std::min<std::uint64_t>(skippedCount, grainCount);
+            auto const firstInvalidatedIndex = in_index - invalidatedCount;
+
+            for (auto missingIndex = firstInvalidatedIndex; missingIndex < in_index; ++missingIndex)
+            {
+                auto const missingOffset = missingIndex % grainCount;
+                auto const missingGrain = _flowData->grainAt(missingOffset);
+                missingGrain->header.info.index = missingIndex;
+                missingGrain->header.info.validSlices = 0;
+                missingGrain->header.info.flags |= MXL_GRAIN_FLAG_INVALID;
+            }
+        }
+
+        auto offset = in_index % _flowData->flowInfo()->config.discrete.grainCount;
+        auto const grain = _flowData->grainAt(offset);
+        grain->header.info.index = in_index; // Set the absolute grain index associated to that ring buffer entry
+        grain->header.info.flags &= ~MXL_GRAIN_FLAG_INVALID;
+        *out_grainInfo = grain->header.info;
+        *out_payload = reinterpret_cast<std::uint8_t*>(&grain->header + 1);
+        _currentIndex = in_index;
+        return MXL_STATUS_OK;
     }
 
     mxlStatus PosixDiscreteFlowWriter::cancel()
@@ -134,6 +162,7 @@ namespace mxl::lib
 
             auto const offset = _currentIndex % flow->info.config.discrete.grainCount;
             *_flowData->grainInfoAt(offset) = mxlGrainInfo;
+            _lastCommittedIndex = mxlGrainInfo.index;
             flow->info.runtime.lastWriteTime = currentTime(mxl::lib::Clock::TAI).value;
 
             // If the grain is complete, reset the current index of the flow writer.

--- a/lib/internal/src/PosixDiscreteFlowWriter.cpp
+++ b/lib/internal/src/PosixDiscreteFlowWriter.cpp
@@ -162,13 +162,13 @@ namespace mxl::lib
 
             auto const offset = _currentIndex % flow->info.config.discrete.grainCount;
             *_flowData->grainInfoAt(offset) = mxlGrainInfo;
-            _lastCommittedIndex = mxlGrainInfo.index;
             flow->info.runtime.lastWriteTime = currentTime(mxl::lib::Clock::TAI).value;
 
             // If the grain is complete, reset the current index of the flow writer.
             if (mxlGrainInfo.validSlices == mxlGrainInfo.totalSlices)
             {
                 _currentIndex = MXL_UNDEFINED_INDEX;
+                _lastCommittedIndex = mxlGrainInfo.index;
             }
 
             // Let readers know that the head has moved or that new data is available in a partial grain

--- a/lib/internal/src/PosixDiscreteFlowWriter.hpp
+++ b/lib/internal/src/PosixDiscreteFlowWriter.hpp
@@ -77,6 +77,8 @@ namespace mxl::lib
         std::unique_ptr<DiscreteFlowData> _flowData;
         /** The currently opened grain index. MXL_UNDEFINED_INDEX if no grain is currently opened. */
         std::uint64_t _currentIndex;
+        /** The last committed grain index. MXL_UNDEFINED_INDEX if no grain has been committed yet. */
+        std::uint64_t _lastCommittedIndex;
 
         // The watcher reference needs live in the most derived class of `FlowWriter` because it only synchronizes with the `DomainWatcher` thread
         // while the destructor runs. If it was inside the `FlowWriter` destructor itself, the domain watcher thread could call `flowRead()` of a

--- a/lib/tests/fabrics/test_sliced.cpp
+++ b/lib/tests/fabrics/test_sliced.cpp
@@ -224,12 +224,11 @@ namespace
             fillGrainWithZeros(_targetWriter, index);
         }
 
-        // Get the grain header on the targe side
         mxlGrainInfo getTargetGrainInfo(std::uint64_t index)
         {
             auto payload = std::add_pointer_t<std::uint8_t>{nullptr};
             auto grainInfo = mxlGrainInfo{};
-            REQUIRE(mxlFlowReaderGetGrainNonBlocking(_targetReader, index, &grainInfo, &payload) == MXL_STATUS_OK);
+            REQUIRE(mxlFlowReaderGetGrainSliceNonBlocking(_targetReader, index, MXL_GRAIN_VALID_SLICES_ANY, &grainInfo, &payload) == MXL_STATUS_OK);
             return grainInfo;
         }
 
@@ -238,7 +237,8 @@ namespace
         {
             auto payload = std::add_pointer_t<std::uint8_t>{nullptr};
             auto grainInfo = mxlGrainInfo{};
-            REQUIRE(mxlFlowReaderGetGrainNonBlocking(_initiatorReader, index, &grainInfo, &payload) == MXL_STATUS_OK);
+            REQUIRE(
+                mxlFlowReaderGetGrainSliceNonBlocking(_initiatorReader, index, MXL_GRAIN_VALID_SLICES_ANY, &grainInfo, &payload) == MXL_STATUS_OK);
             return grainInfo;
         }
 
@@ -333,13 +333,11 @@ namespace
             return readIndex;
         }
 
-        // Read the first byte of a slice in the key and fill buffer
-        std::pair<std::uint8_t, std::uint8_t> readTargetGrainSlice(std::uint64_t index, std::uint32_t sliceIndex)
+        std::pair<std::uint8_t, std::uint8_t> readTargetGrainSlice(std::uint64_t index, std::uint32_t sliceIndex, std::uint16_t minValidSlices)
         {
             auto grainInfo = mxlGrainInfo{};
             auto payload = static_cast<std::uint8_t*>(nullptr);
-            REQUIRE(mxlFlowReaderGetGrainSliceNonBlocking(_targetReader, index, static_cast<std::uint16_t>(sliceIndex + 1), &grainInfo, &payload) ==
-                    MXL_STATUS_OK);
+            REQUIRE(mxlFlowReaderGetGrainSliceNonBlocking(_targetReader, index, minValidSlices, &grainInfo, &payload) == MXL_STATUS_OK);
 
             auto result = std::pair<std::uint8_t, std::uint8_t>{0, 0};
             auto planeOffset = std::uint32_t{0};
@@ -389,7 +387,7 @@ namespace
             }
 
             grainInfo.validSlices = 0;
-            grainInfo.flags = MXL_GRAIN_FLAG_INVALID;
+            grainInfo.flags = 0;
             REQUIRE(mxlFlowWriterCommitGrain(writer, &grainInfo) == MXL_STATUS_OK);
         }
 
@@ -451,7 +449,7 @@ TEMPLATE_TEST_CASE_METHOD(FabricsTestFixture, "Slice transfer single", "[sliced]
         for (auto slice = std::uint16_t{0}; slice < info.totalSlices; ++slice)
         {
             // check that the target slice is zeroed
-            auto [fillBefore, keyBefore] = this->readTargetGrainSlice(grainIndex, slice);
+            auto [fillBefore, keyBefore] = this->readTargetGrainSlice(grainIndex, slice, MXL_GRAIN_VALID_SLICES_ANY);
             REQUIRE(fillBefore == 0x00);
             if (this->hasAlphaChannel())
             {
@@ -464,10 +462,9 @@ TEMPLATE_TEST_CASE_METHOD(FabricsTestFixture, "Slice transfer single", "[sliced]
             // write pattern to initiator grain buffer
             this->writeInitiatorGrainSlice(grainIndex, slice, fillValue, keyValue);
             REQUIRE(this->transferGrainSlices(grainIndex, lastSlice, slice + 1) == grainIndex);
-            this->readTargetGrainSlice(grainIndex, slice);
 
-            // read after transfer
-            auto [fillAfter, keyAfter] = this->readTargetGrainSlice(grainIndex, slice);
+            // read after transfer, the transferred slice must now be valid
+            auto [fillAfter, keyAfter] = this->readTargetGrainSlice(grainIndex, slice, static_cast<std::uint16_t>(slice + 1));
             REQUIRE(fillAfter == fillValue);
             if (this->hasAlphaChannel())
             {
@@ -507,7 +504,7 @@ TEMPLATE_TEST_CASE_METHOD(FabricsTestFixture, "Slice transfer blocks", "[sliced]
 
                 // find a slice in the middle of the block <= (endSlice - 1)
                 auto middleSlice = std::min(startSlice + (blockSize / 2), endSlice - 1);
-                auto [fillValueBefore, keyValueBefore] = this->readTargetGrainSlice(grainIndex, middleSlice);
+                auto [fillValueBefore, keyValueBefore] = this->readTargetGrainSlice(grainIndex, middleSlice, MXL_GRAIN_VALID_SLICES_ANY);
                 REQUIRE(fillValueBefore == 0x00);
                 if (this->hasAlphaChannel())
                 {
@@ -524,8 +521,10 @@ TEMPLATE_TEST_CASE_METHOD(FabricsTestFixture, "Slice transfer blocks", "[sliced]
                 // transfer the slices
                 REQUIRE(this->transferGrainSlices(grainIndex, lastSlice, endSlice) == grainIndex);
 
-                // check that the payload is correct
-                auto [fillValueAfter, keyValueAfter] = this->readTargetGrainSlice(grainIndex, middleSlice);
+                // check that the payload is correct. the whole block up to endSlice has been transferred, so the slice
+                // in the middle of it must be valid.
+                auto [fillValueAfter,
+                    keyValueAfter] = this->readTargetGrainSlice(grainIndex, middleSlice, static_cast<std::uint16_t>(middleSlice + 1));
                 REQUIRE(fillValueAfter == fillValue);
                 if (this->hasAlphaChannel())
                 {

--- a/lib/tests/test_flows.cpp
+++ b/lib/tests/test_flows.cpp
@@ -128,7 +128,7 @@ TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Video Flow : Create/
 
     // Use the writer after closing the reader.
     buffer = nullptr;
-    REQUIRE(mxlFlowWriterOpenGrain(writer, index++, &gInfo, &buffer) == MXL_STATUS_OK);
+    REQUIRE(mxlFlowWriterOpenGrain(writer, ++index, &gInfo, &buffer) == MXL_STATUS_OK);
     /// Set a mark at the beginning and the end of the grain payload.
     buffer[0] = 0xCA;
     buffer[gInfo.grainSize - 1] = 0xFE;
@@ -237,7 +237,7 @@ TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Video Flow (With Alp
 
     // Use the writer after closing the reader.
     buffer = nullptr;
-    REQUIRE(mxlFlowWriterOpenGrain(writer, index++, &gInfo, &buffer) == MXL_STATUS_OK);
+    REQUIRE(mxlFlowWriterOpenGrain(writer, ++index, &gInfo, &buffer) == MXL_STATUS_OK);
     /// Set a mark at the beginning and the end of the grain payload.
     buffer[0] = 0xCA;
     buffer[gInfo.grainSize - 1] = 0xFE;
@@ -500,7 +500,7 @@ TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Data Flow : Create/D
 
     // Use the writer after closing the reader.
     uint8_t* buffer2 = nullptr;
-    REQUIRE(mxlFlowWriterOpenGrain(writer, index++, &gInfo, &buffer2) == MXL_STATUS_OK);
+    REQUIRE(mxlFlowWriterOpenGrain(writer, ++index, &gInfo, &buffer2) == MXL_STATUS_OK);
 
     REQUIRE(mxlReleaseFlowWriter(instanceWriter, writer) == MXL_STATUS_OK);
 
@@ -1077,4 +1077,169 @@ TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "mxlFlowWriterCommitS
     REQUIRE(mxlReleaseFlowWriter(instance, writer) == MXL_STATUS_OK);
 
     REQUIRE(mxlDestroyInstance(instance) == MXL_STATUS_OK);
+}
+
+TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Audio Flow : Jump forward", "[mxl flows]")
+{
+    auto const opts = "{}";
+    constexpr std::uint64_t samplesPerCommit = 480;
+
+    auto instanceReader = mxlCreateInstance(domain.string().c_str(), opts);
+    REQUIRE(instanceReader != nullptr);
+
+    auto instanceWriter = mxlCreateInstance(domain.string().c_str(), opts);
+    REQUIRE(instanceWriter != nullptr);
+
+    auto flowDef = mxl::tests::readFile("data/audio_flow.json");
+    mxlFlowWriter writer;
+    mxlFlowConfigInfo configInfo;
+    bool flowWasCreated = false;
+    REQUIRE(mxlCreateFlowWriter(instanceWriter, flowDef.c_str(), opts, &writer, &configInfo, &flowWasCreated) == MXL_STATUS_OK);
+    REQUIRE(flowWasCreated);
+
+    mxlFlowReader reader;
+    auto const flowId = uuids::to_string(configInfo.common.id);
+    REQUIRE(mxlCreateFlowReader(instanceReader, flowId.c_str(), "", &reader) == MXL_STATUS_OK);
+
+    mxlMutableWrappedMultiBufferSlice writeSlices{};
+    auto const groupToSampleIndex = [](std::uint64_t groupIndex)
+    {
+        return ((groupIndex + 1U) * samplesPerCommit) - 1U;
+    };
+
+    for (std::uint64_t writerGroupIndex = 42; writerGroupIndex <= 46; ++writerGroupIndex)
+    {
+        auto const writerSampleIndex = groupToSampleIndex(writerGroupIndex);
+        REQUIRE(mxlFlowWriterOpenSamples(writer, writerSampleIndex, samplesPerCommit, &writeSlices) == MXL_STATUS_OK);
+        auto const firstSamples = writeSlices.base.fragments[0].size / sizeof(std::uint32_t);
+        for (std::size_t i = 0U; i < firstSamples; ++i)
+        {
+            static_cast<std::uint32_t*>(writeSlices.base.fragments[0].pointer)[i] = static_cast<std::uint32_t>(writerGroupIndex);
+        }
+        auto const secondSamples = writeSlices.base.fragments[1].size / sizeof(std::uint32_t);
+        for (std::size_t i = 0U; i < secondSamples; ++i)
+        {
+            static_cast<std::uint32_t*>(writeSlices.base.fragments[1].pointer)[i] = static_cast<std::uint32_t>(writerGroupIndex);
+        }
+        REQUIRE(mxlFlowWriterCommitSamples(writer) == MXL_STATUS_OK);
+    }
+
+    // Jump forward to group 100, skipping groups 47-99.
+    std::uint64_t writerGroupIndex = 100;
+    std::uint64_t writerSampleIndex = groupToSampleIndex(writerGroupIndex);
+    REQUIRE(mxlFlowWriterOpenSamples(writer, writerSampleIndex, samplesPerCommit, &writeSlices) == MXL_STATUS_OK);
+
+    // From the moment we open sample 100, the whole ring buffer should be invalidated. The head does not move until
+    // group 100 is committed though, so we have to check group endpoints 46 and earlier.
+    mxlWrappedMultiBufferSlice readSlices{};
+    for (std::uint64_t readGroupIndex = 42; readGroupIndex <= 46; ++readGroupIndex)
+    {
+        auto const sampleIndex = groupToSampleIndex(readGroupIndex);
+        auto const returnCode = mxlFlowReaderGetSamplesNonBlocking(reader, sampleIndex, 1U, &readSlices);
+        // This condition lines up because we picked 480 samples (10ms), which is a divider of the default history duration (200 ms).
+        if (sampleIndex % configInfo.continuous.bufferLength == writerSampleIndex % configInfo.continuous.bufferLength)
+        {
+            REQUIRE(returnCode == MXL_ERR_OUT_OF_RANGE_TOO_EARLY);
+        }
+        else
+        {
+            REQUIRE(returnCode == MXL_STATUS_OK);
+            if (readSlices.base.fragments[0].size > 0U)
+            {
+                REQUIRE(static_cast<std::uint32_t const*>(readSlices.base.fragments[0].pointer)[0] == 0U);
+            }
+            if (readSlices.base.fragments[1].size > 0U)
+            {
+                REQUIRE(static_cast<std::uint32_t const*>(readSlices.base.fragments[1].pointer)[0] == 0U);
+            }
+        }
+    }
+
+    auto const firstSamples = writeSlices.base.fragments[0].size / sizeof(std::uint32_t);
+    for (std::size_t i = 0U; i < firstSamples; ++i)
+    {
+        static_cast<std::uint32_t*>(writeSlices.base.fragments[0].pointer)[i] = static_cast<std::uint32_t>(writerGroupIndex);
+    }
+    auto const secondSamples = writeSlices.base.fragments[1].size / sizeof(std::uint32_t);
+    for (std::size_t i = 0U; i < secondSamples; ++i)
+    {
+        static_cast<std::uint32_t*>(writeSlices.base.fragments[1].pointer)[i] = static_cast<std::uint32_t>(writerGroupIndex);
+    }
+    REQUIRE(mxlFlowWriterCommitSamples(writer) == MXL_STATUS_OK);
+
+    // Group 100 endpoint should contain the latest write after commit.
+    REQUIRE(mxlFlowReaderGetSamplesNonBlocking(reader, writerSampleIndex, 1U, &readSlices) == MXL_STATUS_OK);
+    REQUIRE(static_cast<std::uint32_t const*>(readSlices.base.fragments[0].pointer)[0] == 100U);
+
+    REQUIRE(mxlReleaseFlowReader(instanceReader, reader) == MXL_STATUS_OK);
+    REQUIRE(mxlReleaseFlowWriter(instanceWriter, writer) == MXL_STATUS_OK);
+    REQUIRE(mxlDestroyInstance(instanceReader) == MXL_STATUS_OK);
+    REQUIRE(mxlDestroyInstance(instanceWriter) == MXL_STATUS_OK);
+}
+
+TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Video Flow : Jump forward", "[mxl flows]")
+{
+    auto const opts = "{}";
+    auto instanceReader = mxlCreateInstance(domain.string().c_str(), opts);
+    REQUIRE(instanceReader != nullptr);
+
+    auto instanceWriter = mxlCreateInstance(domain.string().c_str(), opts);
+    REQUIRE(instanceWriter != nullptr);
+
+    auto flowDef = mxl::tests::readFile("data/v210_flow.json");
+    mxlFlowWriter writer;
+    mxlFlowConfigInfo configInfo;
+    bool flowWasCreated = false;
+    REQUIRE(mxlCreateFlowWriter(instanceWriter, flowDef.c_str(), opts, &writer, &configInfo, &flowWasCreated) == MXL_STATUS_OK);
+    REQUIRE(flowWasCreated);
+
+    mxlFlowReader reader;
+    auto const flowId = uuids::to_string(configInfo.common.id);
+    REQUIRE(mxlCreateFlowReader(instanceReader, flowId.c_str(), "", &reader) == MXL_STATUS_OK);
+
+    mxlGrainInfo gInfo;
+    std::uint8_t* buffer = nullptr;
+    for (std::uint64_t writerGrainIndex = 42; writerGrainIndex <= 46; ++writerGrainIndex)
+    {
+        REQUIRE(mxlFlowWriterOpenGrain(writer, writerGrainIndex, &gInfo, &buffer) == MXL_STATUS_OK);
+        REQUIRE(buffer != nullptr);
+        memcpy(buffer, &writerGrainIndex, sizeof(std::uint64_t));
+        gInfo.validSlices = gInfo.totalSlices;
+        REQUIRE(mxlFlowWriterCommitGrain(writer, &gInfo) == MXL_STATUS_OK);
+    }
+
+    // Jump forward to grain 100, skipping grains 47-99
+    std::uint64_t writerGrainIndex = 100;
+    REQUIRE(mxlFlowWriterOpenGrain(writer, writerGrainIndex, &gInfo, &buffer) == MXL_STATUS_OK);
+
+    // From the moment we open grain 100, the whole ring buffer should be invalidated. The head does not move until grain 100 is committed though, so
+    // we have to check grains 46 and earlier.
+    for (std::uint64_t grainIndex = std::max(std::uint64_t(46) - configInfo.discrete.grainCount + 2, std::uint64_t(42)); grainIndex <= 46;
+        ++grainIndex)
+    {
+        mxlGrainInfo readGrainInfo;
+        std::uint8_t* readBuffer = nullptr;
+        auto returnCode = mxlFlowReaderGetGrain(reader, grainIndex, 0, &readGrainInfo, &readBuffer);
+        if (grainIndex % configInfo.discrete.grainCount == writerGrainIndex % configInfo.discrete.grainCount)
+        {
+            REQUIRE(returnCode == MXL_ERR_OUT_OF_RANGE_TOO_EARLY);
+        }
+        else
+        {
+            REQUIRE(returnCode == MXL_STATUS_OK);
+        }
+        REQUIRE((readGrainInfo.flags & MXL_GRAIN_FLAG_INVALID) != 0);
+    }
+
+    // Commit grain 100 and verify that it is readable.
+    memcpy(buffer, &writerGrainIndex, sizeof(std::uint64_t));
+    gInfo.validSlices = gInfo.totalSlices;
+    REQUIRE(mxlFlowWriterCommitGrain(writer, &gInfo) == MXL_STATUS_OK);
+    REQUIRE(mxlFlowReaderGetGrain(reader, writerGrainIndex, 0, &gInfo, &buffer) == MXL_STATUS_OK);
+    REQUIRE(reinterpret_cast<std::uint64_t*>(buffer)[0] == writerGrainIndex);
+
+    REQUIRE(mxlReleaseFlowReader(instanceReader, reader) == MXL_STATUS_OK);
+    REQUIRE(mxlReleaseFlowWriter(instanceWriter, writer) == MXL_STATUS_OK);
+    REQUIRE(mxlDestroyInstance(instanceReader) == MXL_STATUS_OK);
+    REQUIRE(mxlDestroyInstance(instanceWriter) == MXL_STATUS_OK);
 }


### PR DESCRIPTION
# Details
As discussed in the TSC call August 20th 2026, this PR handles a writer jumping forward in time. For discrete flows, this is done by setting the invalid flag on relevant grains. For continuous flows, this is done with a memset 0 (silence).

The update to the ring buffer is done on the writer opening the grain as the open call creates a jump in ring buffer usage and it is likely that the writer writing to the buffer will corrupt the data that was sitting in that data ring while a reader reads the data. The cleanest solution seems to handle the invalidation on opening the out of sequence media buffer.

# Backport requirements
1.0 and 1.1.