### PR TITLE
Fix discrete reader/writer tail conflict

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -49,6 +49,12 @@ See [timing model](./Timing.md)
 
 The MXL SDK provides two ringbuffer types: Discrete and Continuous.  Discrete ringbuffers are used for granular data types such as video and ancillary data.  Continuous ringbuffers are used for audio. 
 
+### Ring buffer access model
+
+Continuous: the tail half of the ring buffer is reserved for the writer, and readers can access the remaining half.
+
+Discrete: the tail entry of the ring buffer is reserved for the writer, and readers can access the remaining entries.
+
 ## Discrete Grain I/O
 
 Grain I/O can be 'partial'. In other words, a FlowWriter can write the bytes of a grain progressively (as slices for example).

--- a/lib/internal/src/PosixDiscreteFlowReader.cpp
+++ b/lib/internal/src/PosixDiscreteFlowReader.cpp
@@ -167,7 +167,14 @@ namespace mxl::lib
         if (auto const headIndex = flow->info.runtime.headIndex; in_index <= headIndex)
         {
             auto const grainCount = flow->info.config.discrete.grainCount;
-            auto const minIndex = (headIndex >= grainCount) ? (headIndex - grainCount + 1U) : std::uint64_t{0};
+
+            // Reserve the tail position for the writer. The +2U advances
+            // minIndex one position past the tail. Since the tail and
+            // headIndex+1 alias the same physical ring-buffer position,
+            // this hides uncommitted headIndex+1 write state from
+            // readers.
+            auto const minIndex = (headIndex >= grainCount) ? (headIndex - grainCount + 2U) : std::uint64_t{0};
+
             if (in_index >= minIndex)
             {
                 auto const offset = in_index % grainCount;

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ target_sources(mxl-tests
             test_flows_timing.cpp
             test_instance.cpp
             test_time.cpp
+            test_read_write_conflict.cpp
     )
 
 target_link_libraries(mxl-tests

--- a/lib/tests/test_read_write_conflict.cpp
+++ b/lib/tests/test_read_write_conflict.cpp
@@ -1,0 +1,376 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include <limits>
+#include <string>
+#include <catch2/catch_test_macros.hpp>
+#include <mxl/flow.h>
+#include <mxl/mxl.h>
+#include <mxl/time.h>
+#include "Utils.hpp"
+
+/*
+  This test verifies that a read request for the ring buffer's
+  tailIndex grain returns TOO_LATE when the writer has a write
+  operation open at headIndex+1.
+
+  +-----------+-- --+-------------+-----------+-------------+--
+  | index  0  |     | index N-2   | index N-1 |  index 0    |
+  | tailIndex | ... | headIndex-1 | headIndex | headIndex+1 | ...
+  +-----------+-- --+-------------+-----------+-------------+--
+                                              ^
+                                              ring wrap
+
+   N = grainCount
+
+   The diagram illustrates that tailIndex and headIndex+1 address the
+   same ring-buffer index.
+
+   Note: index 0 is used here for illustration. The actual ring-buffer
+   starting index is tailIndex % grainCount.
+*/
+TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Video Flow : tail read during open write", "[mxl flows]")
+{
+    auto const flowId = "5fbec3b1-1b0f-417d-9059-8b94a47197ed";
+    auto const flowDef = mxl::tests::readFile("data/v210_flow.json");
+
+    // Init the domain instance.
+    auto instance = mxlCreateInstance(domain.string().c_str(), "");
+    REQUIRE(instance != nullptr);
+
+    // Init a flow writer.
+    auto writer = mxlFlowWriter{};
+    auto configInfo = mxlFlowConfigInfo{};
+    auto flowWasCreated = false;
+
+    REQUIRE(mxlCreateFlowWriter(instance, flowDef.c_str(), "", &writer, &configInfo, &flowWasCreated) == MXL_STATUS_OK);
+    REQUIRE(flowWasCreated);
+
+    // Init headIndex from the current MXL time.
+    auto const now = mxlGetTime();
+    auto headIndex = mxlTimestampToIndex(&configInfo.common.grainRate, now);
+    REQUIRE(headIndex != MXL_UNDEFINED_INDEX);
+
+    auto const grainCount = static_cast<std::uint64_t>(configInfo.discrete.grainCount);
+
+    REQUIRE(grainCount > 1U);
+    REQUIRE(headIndex > grainCount);
+
+    // Init each grain in the ring buffer.
+    auto tailIndex = headIndex - grainCount + 1;
+    for (auto i = std::uint64_t{0}; i < grainCount; ++i)
+    {
+        auto grainInfo = mxlGrainInfo{};
+        std::uint8_t* buffer = nullptr;
+
+        REQUIRE(mxlFlowWriterOpenGrain(writer, tailIndex + i, &grainInfo, &buffer) == MXL_STATUS_OK);
+
+        buffer[0] = 0xCA;
+        buffer[grainInfo.grainSize - 1] = 0xFE;
+        grainInfo.validSlices = grainInfo.totalSlices;
+
+        REQUIRE(mxlFlowWriterCommitGrain(writer, &grainInfo) == MXL_STATUS_OK);
+    }
+
+    // Init a reader and sanity check the flow's headIndex.
+    auto reader = mxlFlowReader{};
+    REQUIRE(mxlCreateFlowReader(instance, flowId, "", &reader) == MXL_STATUS_OK);
+
+    auto runtimeInfo = mxlFlowRuntimeInfo{};
+    REQUIRE(mxlFlowReaderGetRuntimeInfo(reader, &runtimeInfo) == MXL_STATUS_OK);
+    REQUIRE(runtimeInfo.headIndex == headIndex);
+
+    // Reading the tailIndex grain should be TOO_LATE when write is
+    // not in progress.
+    auto readGrainInfo = mxlGrainInfo{};
+    std::uint8_t* readBuffer = nullptr;
+    auto const grainReadStatusOutsideWrite = mxlFlowReaderGetGrainNonBlocking(reader, tailIndex, &readGrainInfo, &readBuffer);
+    {
+        INFO("The tailIndex grain read should return TOO_LATE even when no write "
+             "is in progress because the tail grain is reserved for the writer.");
+        CHECK(grainReadStatusOutsideWrite == MXL_ERR_OUT_OF_RANGE_TOO_LATE);
+    }
+
+    // Reading the tailIndex grain through the slice API should be
+    // TOO_LATE when write is not in progress.
+    readBuffer = nullptr;
+    readGrainInfo = {};
+    auto const sliceReadStatusOutsideWrite = mxlFlowReaderGetGrainSliceNonBlocking(
+        reader, tailIndex, MXL_GRAIN_VALID_SLICES_ANY, &readGrainInfo, &readBuffer);
+    {
+        INFO("The tailIndex slice read should return TOO_LATE even when no write "
+             "is in progress because the tail grain is reserved for the writer.");
+        CHECK(sliceReadStatusOutsideWrite == MXL_ERR_OUT_OF_RANGE_TOO_LATE);
+    }
+
+    // Open a write to the next sequential grain at headIndex+1. This
+    // grain shares a ring-buffer position with the tailIndex grain.
+    auto writeGrainInfo = mxlGrainInfo{};
+    std::uint8_t* writeBuffer = nullptr;
+    {
+        REQUIRE(mxlFlowWriterOpenGrain(writer, headIndex + 1, &writeGrainInfo, &writeBuffer) == MXL_STATUS_OK);
+
+        INFO("The newly opened grain should identify headIndex+1.");
+        CAPTURE(writeGrainInfo.index, headIndex + 1, writeGrainInfo.validSlices, writeGrainInfo.totalSlices);
+        CHECK(writeGrainInfo.index == headIndex + 1);
+    }
+
+    // Sanity check: verify that headIndex has not yet moved.
+    REQUIRE(mxlFlowReaderGetRuntimeInfo(reader, &runtimeInfo) == MXL_STATUS_OK);
+    REQUIRE(runtimeInfo.headIndex == headIndex);
+
+    // Reading a grain at tailIndex during an open write of
+    // headIndex+1 should return TOO_LATE to prevent reader/writer
+    // conflict during the writer's open/commit interval.
+    constexpr auto NOT_CHANGED_INDEX_SENTINEL_VALUE = std::numeric_limits<decltype(readGrainInfo.index)>::max();
+    readBuffer = nullptr;
+    readGrainInfo = {};
+    readGrainInfo.index = NOT_CHANGED_INDEX_SENTINEL_VALUE;
+    auto const grainReadStatusInsideWrite = mxlFlowReaderGetGrainNonBlocking(reader, tailIndex, &readGrainInfo, &readBuffer);
+    {
+        INFO("A tailIndex read should return TOO_LATE while a write of "
+             "headIndex+1 is open because both logical grains alias the "
+             "same physical ring-buffer position."
+
+        );
+        CHECK(grainReadStatusInsideWrite == MXL_ERR_OUT_OF_RANGE_TOO_LATE);
+    }
+    {
+        INFO("Because the tailIndex grain read is expected to return TOO_LATE, "
+             "it should not return a payload or modify the grain index.");
+        CHECK(readBuffer == nullptr);
+        CHECK(readGrainInfo.index == NOT_CHANGED_INDEX_SENTINEL_VALUE);
+    }
+
+    // REVIEW-ONLY (pre-fix diagnostic): Retained so running this test
+    // against the old implementation also exposes the inconsistent
+    // state returned when MXL_STATUS_OK is returned.
+    if (grainReadStatusInsideWrite == MXL_STATUS_OK)
+    {
+        INFO("The tailIndex read was permitted, therefore the returned grain "
+             "metadata must be internally consistent: the payload must be "
+             "available, the grain index must identify the requested tailIndex "
+             "grain, and the full-grain read must report all slices as valid.");
+        CAPTURE(readBuffer, readGrainInfo.index, tailIndex, headIndex + 1, readGrainInfo.validSlices, readGrainInfo.totalSlices);
+        CHECK(readBuffer != nullptr);
+        CHECK(readGrainInfo.validSlices == readGrainInfo.totalSlices);
+
+        // REVIEW-ONLY: Fails with the pre-fix read boundary.  The
+        // returned grain is headIndex+1 although tailIndex was
+        // requested.
+        CHECK(readGrainInfo.index == tailIndex);
+    }
+
+    // Reading tailIndex through the slice API during an open write of
+    // headIndex+1 should return TOO_LATE, should not return a payload,
+    // and should not modify readGrainInfo.validSlices.
+    constexpr auto NOT_CHANGED_SLICE_SENTINEL_VALUE = std::numeric_limits<decltype(readGrainInfo.validSlices)>::max();
+    readBuffer = nullptr;
+    readGrainInfo = {};
+    readGrainInfo.validSlices = NOT_CHANGED_SLICE_SENTINEL_VALUE;
+    auto const sliceReadStatus = mxlFlowReaderGetGrainSliceNonBlocking(reader, tailIndex, MXL_GRAIN_VALID_SLICES_ANY, &readGrainInfo, &readBuffer);
+    {
+        INFO("A tailIndex slice read should return TOO_LATE while a write of "
+             "headIndex+1 is open because both logical grains alias the "
+             "same physical ring-buffer position.");
+        CHECK(sliceReadStatus == MXL_ERR_OUT_OF_RANGE_TOO_LATE);
+    }
+    {
+        INFO("Because the tailIndex slice read is expected to return TOO_LATE, "
+             "it should not return a payload or modify validSlices.");
+        CHECK(readBuffer == nullptr);
+        CHECK(readGrainInfo.validSlices == NOT_CHANGED_SLICE_SENTINEL_VALUE);
+    }
+
+    // REVIEW-ONLY (pre-fix diagnostic): Retained so running this test
+    // against the old implementation also exposes the inconsistent
+    // state returned when MXL_STATUS_OK is returned.
+    if (sliceReadStatus == MXL_STATUS_OK)
+    {
+        INFO("The tailIndex slice read was permitted, therefore the returned "
+             "grain state must be internally consistent: the payload must be "
+             "available, the grain index must identify the requested tailIndex "
+             "grain, and the previously committed tail grain must still be "
+             "reported as fully valid.");
+
+        CAPTURE(readBuffer, readGrainInfo.index, tailIndex, headIndex + 1, readGrainInfo.validSlices, readGrainInfo.totalSlices);
+        CHECK(readBuffer != nullptr);
+        CHECK(readGrainInfo.validSlices == readGrainInfo.totalSlices);
+
+        // REVIEW-ONLY: Fails with the pre-fix read boundary.  The
+        // returned grain is headIndex+1 although tailIndex was
+        // requested.
+        CHECK(readGrainInfo.index == tailIndex);
+    }
+
+    // Commit the write and update local headIndex.
+    writeBuffer[0] = 0xCA;
+    writeBuffer[writeGrainInfo.grainSize - 1] = 0xFE;
+    writeGrainInfo.validSlices = writeGrainInfo.totalSlices;
+    REQUIRE(mxlFlowWriterCommitGrain(writer, &writeGrainInfo) == MXL_STATUS_OK);
+
+    headIndex = headIndex + 1;
+    tailIndex = headIndex - grainCount + 1;
+
+    // Sanity check local headIndex matches flow's headIndex.
+    REQUIRE(mxlFlowReaderGetRuntimeInfo(reader, &runtimeInfo) == MXL_STATUS_OK);
+    REQUIRE(runtimeInfo.headIndex == headIndex);
+
+    // Post commit read of the tailIndex grain should continue to be
+    // TOO_LATE.
+    readBuffer = nullptr;
+    readGrainInfo = {};
+    auto const grainReadStatusPostCommit = mxlFlowReaderGetGrainNonBlocking(reader, tailIndex, &readGrainInfo, &readBuffer);
+    {
+        INFO("A post commit tailIndex read should return TOO_LATE after a "
+             "write of headIndex+1 is committed because both logical grains "
+             "alias the same physical ring-buffer position.");
+        CHECK(grainReadStatusPostCommit == MXL_ERR_OUT_OF_RANGE_TOO_LATE);
+    }
+
+    // Tear down.
+    REQUIRE(mxlReleaseFlowReader(instance, reader) == MXL_STATUS_OK);
+
+    REQUIRE(mxlReleaseFlowWriter(instance, writer) == MXL_STATUS_OK);
+
+    REQUIRE(mxlDestroyInstance(instance) == MXL_STATUS_OK);
+}
+
+/*
+  This test verifies that the audio reader boundary between the
+  writer's half-ring and the reader's half-ring is enforced regardless
+  of whether the writer has a write operation open.
+
+  +--------------------------+--------------------------+--------------------------+--
+  | physical half 0          | physical half 1          | physical half 0          |
+  | writer's half-ring       | reader's half-ring       | writer's half-ring       | ...
+  +--------------------------+--------------------------+--------------------------+--
+  ^                          ^                          ^
+  ringTailIndex              boundaryIndex              headIndex
+                                                        ring wrap
+
+  ringTailIndex = headIndex - bufferLength + 1
+  boundaryIndex = headIndex - bufferLength/2 + 1
+
+  Reads at boundaryIndex are allowed. Reads at boundaryIndex-1 and
+  earlier are TOO_LATE.
+
+  Note: physical half 0/1 are used here to illustrate the two
+  half-ring regions and their reuse after ring wrap.
+*/
+TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Audio Flow : tail read during open write", "[mxl flows]")
+{
+    auto const flowId = "b3bb5be7-9fe9-4324-a5bb-4c70e1084449";
+    auto const flowDef = mxl::tests::readFile("data/audio_flow.json");
+
+    // Init the domain instance.
+    auto instance = mxlCreateInstance(domain.string().c_str(), "");
+    REQUIRE(instance != nullptr);
+
+    // Init a flow writer.
+    auto writer = mxlFlowWriter{};
+    auto configInfo = mxlFlowConfigInfo{};
+    auto flowWasCreated = false;
+
+    REQUIRE(mxlCreateFlowWriter(instance, flowDef.c_str(), "", &writer, &configInfo, &flowWasCreated) == MXL_STATUS_OK);
+    REQUIRE(flowWasCreated);
+
+    // Init headIndex from the current MXL time.
+    auto const now = mxlGetTime();
+    auto headIndex = mxlTimestampToIndex(&configInfo.common.grainRate, now);
+    REQUIRE(headIndex != MXL_UNDEFINED_INDEX);
+
+    auto const bufferLength = static_cast<std::uint64_t>(configInfo.continuous.bufferLength);
+    auto const halfBufferLength = bufferLength / 2U;
+
+    REQUIRE(halfBufferLength > 0U);
+    REQUIRE(headIndex > bufferLength);
+
+    // Init the full ring buffer using two sequential half-buffer
+    // writes ending at headIndex. Each write respects the writer's
+    // half-ring limit.
+    {
+        auto const boundaryIndex = headIndex - halfBufferLength + 1;
+        auto tmpWriteIndex = boundaryIndex - 1;
+        for (auto i = std::uint64_t{0}; i < 2U; ++i)
+        {
+            auto writeBuffer = mxlMutableWrappedMultiBufferSlice{};
+
+            REQUIRE(mxlFlowWriterOpenSamples(writer, tmpWriteIndex, halfBufferLength, &writeBuffer) == MXL_STATUS_OK);
+
+            REQUIRE(mxlFlowWriterCommitSamples(writer) == MXL_STATUS_OK);
+
+            tmpWriteIndex += halfBufferLength;
+        }
+    }
+
+    // Init a reader and sanity check the flow's headIndex.
+    auto reader = mxlFlowReader{};
+    REQUIRE(mxlCreateFlowReader(instance, flowId, "", &reader) == MXL_STATUS_OK);
+
+    auto runtimeInfo = mxlFlowRuntimeInfo{};
+    REQUIRE(mxlFlowReaderGetRuntimeInfo(reader, &runtimeInfo) == MXL_STATUS_OK);
+    REQUIRE(runtimeInfo.headIndex == headIndex);
+
+    // boundaryIndex separates the writer's half-ring from the reader's
+    // half-ring.
+    auto const boundaryIndex = headIndex - halfBufferLength + 1;
+    auto const ringTailIndex = headIndex - bufferLength + 1;
+
+    auto readBuffer = mxlWrappedMultiBufferSlice{};
+
+    // Reading at boundaryIndex is OK.
+    REQUIRE(mxlFlowReaderGetSamplesNonBlocking(reader, boundaryIndex, 1U, &readBuffer) == MXL_STATUS_OK);
+
+    // Reading one index before boundaryIndex is TOO_LATE.
+    readBuffer = {};
+    REQUIRE(mxlFlowReaderGetSamplesNonBlocking(reader, boundaryIndex - 1, 1U, &readBuffer) == MXL_ERR_OUT_OF_RANGE_TOO_LATE);
+
+    // Open a write to the next sequential half-buffer at
+    // headIndex+halfBufferLength. This does *not* overlap the
+    // reader's half-ring.
+    auto writeBuffer = mxlMutableWrappedMultiBufferSlice{};
+    REQUIRE(mxlFlowWriterOpenSamples(writer, headIndex + halfBufferLength, halfBufferLength, &writeBuffer) == MXL_STATUS_OK);
+
+    // Sanity check: verify that headIndex has not yet moved.
+    REQUIRE(mxlFlowReaderGetRuntimeInfo(reader, &runtimeInfo) == MXL_STATUS_OK);
+    REQUIRE(runtimeInfo.headIndex == headIndex);
+
+    // The reader boundary is unchanged while the write is open.
+    readBuffer = {};
+    REQUIRE(mxlFlowReaderGetSamplesNonBlocking(reader, boundaryIndex, 1U, &readBuffer) == MXL_STATUS_OK);
+
+    // A read at the tail is also in the writer's half-ring and should
+    // fail with TOO_LATE.
+    readBuffer = {};
+    REQUIRE(mxlFlowReaderGetSamplesNonBlocking(reader, ringTailIndex, 1U, &readBuffer) == MXL_ERR_OUT_OF_RANGE_TOO_LATE);
+
+    // A read just before boundaryIndex should also fail with
+    // TOO_LATE.
+    readBuffer = {};
+    REQUIRE(mxlFlowReaderGetSamplesNonBlocking(reader, boundaryIndex - 1, 1U, &readBuffer) == MXL_ERR_OUT_OF_RANGE_TOO_LATE);
+
+    // Commit the write and update local headIndex.
+    REQUIRE(mxlFlowWriterCommitSamples(writer) == MXL_STATUS_OK);
+
+    headIndex = headIndex + halfBufferLength;
+
+    // Sanity check that the local headIndex matches the flow's
+    // headIndex.
+    REQUIRE(mxlFlowReaderGetRuntimeInfo(reader, &runtimeInfo) == MXL_STATUS_OK);
+    REQUIRE(runtimeInfo.headIndex == headIndex);
+
+    // Post commit read at the new boundaryIndex is OK.
+    auto const newBoundaryIndex = headIndex - halfBufferLength + 1;
+    readBuffer = {};
+
+    REQUIRE(mxlFlowReaderGetSamplesNonBlocking(reader, newBoundaryIndex, 1U, &readBuffer) == MXL_STATUS_OK);
+
+    // Tear down.
+    REQUIRE(mxlReleaseFlowReader(instance, reader) == MXL_STATUS_OK);
+
+    REQUIRE(mxlReleaseFlowWriter(instance, writer) == MXL_STATUS_OK);
+
+    REQUIRE(mxlDestroyInstance(instance) == MXL_STATUS_OK);
+}

--- a/rust/gst-mxl-rs/src/mxlsrc/timing.rs
+++ b/rust/gst-mxl-rs/src/mxlsrc/timing.rs
@@ -28,6 +28,17 @@ pub(crate) fn oldest_retained_index(head: u64, grain_count: u32) -> u64 {
     head.saturating_sub((grain_count as u64).saturating_sub(1))
 }
 
+/// Oldest absolute grain index accessible to a discrete reader.
+pub(crate) fn oldest_reader_visible_index(head: u64, grain_count: u32) -> u64 {
+    let oldest_retained = oldest_retained_index(head, grain_count);
+
+    if head >= grain_count as u64 {
+        oldest_retained.saturating_add(1)
+    } else {
+        oldest_retained
+    }
+}
+
 /// What a discrete reader should do for its next grain.
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) enum ReadStep {
@@ -49,9 +60,9 @@ pub(crate) fn resolve_read_step(index: u64, head: u64, grain_count: u32) -> Read
     if head == 0 || index > head {
         return ReadStep::WaitForProducer;
     }
-    let oldest = oldest_retained_index(head, grain_count);
+    let oldest = oldest_reader_visible_index(head, grain_count);
     if index < oldest {
-        // The writer lapped us; resume at the oldest grain still in the ring.
+        // The writer lapped us; resume at the oldest reader-visible grain.
         ReadStep::Read {
             index: oldest,
             discont: true,
@@ -120,7 +131,7 @@ pub(crate) fn index_period(rate: &Rational) -> gst::ClockTime {
 
 #[cfg(test)]
 mod tests {
-    use super::{ReadStep, oldest_retained_index, resolve_read_step};
+    use super::{ReadStep, oldest_reader_visible_index, oldest_retained_index, resolve_read_step};
 
     const GRAIN_COUNT: u32 = 300;
 
@@ -133,6 +144,18 @@ mod tests {
     #[test]
     fn oldest_retained_when_ring_full() {
         assert_eq!(oldest_retained_index(400, GRAIN_COUNT), 101);
+    }
+
+    #[test]
+    fn reader_visible_index_saturates_at_zero() {
+        // Low indices must not underflow.
+        assert_eq!(oldest_reader_visible_index(50, GRAIN_COUNT), 0);
+    }
+
+    #[test]
+    fn reader_visible_range_excludes_tail() {
+        // The reader visible range begins one past the tail index.
+        assert_eq!(oldest_reader_visible_index(400, GRAIN_COUNT), 102);
     }
 
     #[test]
@@ -180,7 +203,7 @@ mod tests {
     #[test]
     fn catches_up_with_discont_when_lapped() {
         let head = 53_429_298_000;
-        let oldest = oldest_retained_index(head, GRAIN_COUNT);
+        let oldest = oldest_reader_visible_index(head, GRAIN_COUNT);
         // Reader fell far behind the ring.
         assert_eq!(
             resolve_read_step(head - 5_000, head, GRAIN_COUNT),
@@ -192,14 +215,29 @@ mod tests {
     }
 
     #[test]
-    fn oldest_retained_grain_is_read_without_discont() {
+    fn oldest_reader_visible_grain_is_read_without_discont() {
         let head = 53_429_298_000;
-        let oldest = oldest_retained_index(head, GRAIN_COUNT);
+        let oldest = oldest_reader_visible_index(head, GRAIN_COUNT);
         assert_eq!(
             resolve_read_step(oldest, head, GRAIN_COUNT),
             ReadStep::Read {
                 index: oldest,
                 discont: false,
+            }
+        );
+    }
+
+    #[test]
+    fn oldest_retained_grain_is_not_reader_visible() {
+        let head = 53_429_298_000;
+        let retained = oldest_retained_index(head, GRAIN_COUNT);
+        let visible = oldest_reader_visible_index(head, GRAIN_COUNT);
+
+        assert_eq!(
+            resolve_read_step(retained, head, GRAIN_COUNT),
+            ReadStep::Read {
+                index: visible,
+                discont: true,
             }
         );
     }


### PR DESCRIPTION
Fixes #691

These tests compare reader behavior for discrete/video and
continuous/audio flows at their respective reader/writer boundaries,
including while a writer has a write operation open but has not yet
committed it.

For discrete/video flows, tailIndex and headIndex+1 address the same
physical ring-buffer position. When the writer opens headIndex+1 but has
not yet committed it, a read request for tailIndex currently returns
MXL_STATUS_OK. I believe it should return
MXL_ERR_OUT_OF_RANGE_TOO_LATE.

Under the current implementation, reading tailIndex while the
headIndex+1 write is open returns an internally inconsistent grain
state: readGrainInfo.index is headIndex+1 when tailIndex was
requested, while validSlices == totalSlices reports the returned grain
as fully valid even though headIndex+1 has not yet been committed. The
slice API also returns MXL_STATUS_OK and exposes the payload from the
physical ring-buffer position shared concurrently by the reader as
tailIndex and by the writer as headIndex+1.

In contrast, the continuous/audio API enforces its reader/writer
half-ring boundary and correctly returns MXL_ERR_OUT_OF_RANGE_TOO_LATE
for reader access to the writer's half-ring.

This change modifies the behavior of the discrete/video read API by
treating a tailIndex read as TOO_LATE regardless of whether a write is
currently open, thereby reserving the tail entry for the writer. This
is consistent with the continuous/audio API, which similarly excludes
the writer's portion of the ring buffer from reader access.

Example test output when run against the current implementation without
this fix:

```
Code fragment:
auto const grainReadStatusInsideWrite =
    mxlFlowReaderGetGrainNonBlocking(
        reader,
        tailIndex,
        &readGrainInfo,
        &readBuffer
    );

CHECK( grainReadStatusInsideWrite == MXL_ERR_OUT_OF_RANGE_TOO_LATE )
with expansion:
  0 == 3                     <<< MXL_STATUS_OK was returned by read API call
with message:
  A tailIndex read should return TOO_LATE while a write of headIndex+1 is open
  because both logical grains alias the same physical ring-buffer position.

CHECK( readGrainInfo.index == tailIndex )
with expansion:
  53584619384 (0xc79e46778)   <<< This is headIndex+1, but tailIndex was requested!
  ==
  53584619379 (0xc79e46773)   <<< tailIndex value
with messages:
  The tailIndex read was permitted, therefore the returned grain metadata must
  be internally consistent: the payload must be available, the grain index must
  identify the requested tailIndex grain, and the full-grain read must report
  all slices as valid.
  readBuffer := 0x00007a5d66331000
  readGrainInfo.index := 53584619384 (0xc79e46778)
  tailIndex := 53584619379 (0xc79e46773)
  headIndex + 1 := 53584619384 (0xc79e46778)
  readGrainInfo.validSlices := 1080
  readGrainInfo.totalSlices := 1080
```

The captured values show that the successful read of tailIndex (while
the write of headIndex+1 was open) does not actually return metadata
identifying tailIndex. Instead, readGrainInfo.index is equal to
headIndex+1, i.e. the new grain currently open for writing in the
aliased physical ring-buffer position.

At the same time, validSlices == totalSlices == 1080 reports the
returned grain as fully valid. In effect, the result says:

  "This is headIndex+1, and it is already a fully valid grain."

However, the reader requested tailIndex, and headIndex+1 has only been
opened by the writer but has not yet been committed. The reader is
therefore exposed to the uncommitted state of the writer's grain. The
returned mxlGrainInfo combines the identity of the new, open writer
grain with the validity state left by the previous committed tail
grain. This is inconsistent.

The existing MXL_STATUS_OK result is a problem because it tells the
caller that the requested grain was successfully returned and that the
associated metadata and payload may be used. In this case that is not
true: the returned state belongs, at least in part, to the aliased
headIndex+1 grain currently open for writing rather than the requested
committed tailIndex grain.

There are two consequences: i) the reader can access the aliased
grain's memory while the writer is modifying it, creating the
possibility of reading a partially updated or otherwise corrupted
frame, and ii) the inconsistent grain metadata can cause program logic
to make incorrect decisions about which grain was returned and whether
that grain is valid and safe to use.

Finally, the continuous/audio API does not exhibit these errors: its
reader/writer boundary and returned status codes are internally
consistent while a write is open. The discrete/video ring-buffer
implementation provides no equivalent restriction on read access to
the grain that is currently in use by the writer. That is an API
inconsistency. Resolving this discrete/video API problem by making
the tail entry inaccessible to the reader would bring the
discrete/video API into alignment with the continuous/audio API.
