### PR TITLE
Rust: manage flow instance lifecycle automatically

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -391,7 +391,7 @@ dependencies = [
 
 [[package]]
 name = "gst-avsynctest-rs"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cdp-types",
  "cea708-types",
@@ -406,7 +406,7 @@ dependencies = [
 
 [[package]]
 name = "gst-mxl-rs"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bitstream-io",
  "glib",
@@ -735,7 +735,7 @@ checksum = "956787520e75e9bd233246045d19f42fb73242759cc57fba9611d940ae96d4b0"
 
 [[package]]
 name = "mxl"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "libloading",
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "mxl-sys"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bindgen",
  "cmake",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 publish = false
-version = "0.1.0"
+version = "0.2.0"
 rust-version = "1.87"
 license = "Apache-2.0"
 license-file = "../LICENSE.txt"

--- a/rust/gst-mxl-rs/src/mxlsink/imp.rs
+++ b/rust/gst-mxl-rs/src/mxlsink/imp.rs
@@ -349,27 +349,7 @@ impl BaseSinkImpl for MxlSink {
 
         // Destroy the flow writers before dropping the MXL instance they belong
         // to, then release the instance and clock.
-        if let Some(mut state) = context.state.take() {
-            match state.flow_state.take() {
-                Some(FlowState::Discrete(discrete)) => {
-                    discrete.writer.destroy().map_err(|e| {
-                        gst::error_msg!(
-                            gst::CoreError::Failed,
-                            ["Failed to destroy discrete writer: {}", e]
-                        )
-                    })?;
-                }
-                Some(FlowState::Continuous(continuous)) => {
-                    continuous.writer.destroy().map_err(|e| {
-                        gst::error_msg!(
-                            gst::CoreError::Failed,
-                            ["Failed to destroy continuous writer: {}", e]
-                        )
-                    })?;
-                }
-                None => {}
-            }
-        }
+        context.state.take();
 
         gst::info!(CAT, imp = self, "Stopped");
         Ok(())

--- a/rust/gst-mxl-rs/src/mxlsink/imp.rs
+++ b/rust/gst-mxl-rs/src/mxlsink/imp.rs
@@ -347,8 +347,6 @@ impl BaseSinkImpl for MxlSink {
             )
         })?;
 
-        // Destroy the flow writers before dropping the MXL instance they belong
-        // to, then release the instance and clock.
         context.state.take();
 
         gst::info!(CAT, imp = self, "Stopped");

--- a/rust/mxl/examples/flow-writer.rs
+++ b/rust/mxl/examples/flow-writer.rs
@@ -38,7 +38,7 @@ fn main() -> Result<(), mxl::Error> {
     let flow_def = std::fs::read_to_string(opts.flow_config_file.as_str()).map_err(|error| {
         mxl::Error::Other(format!(
             "Error while reading flow definition from \"{}\": {}",
-            &opts.flow_config_file, error
+            opts.flow_config_file, error
         ))
     })?;
 
@@ -115,7 +115,6 @@ pub fn write_grains(
     }
 
     info!("Finished writing requested number of grains, deleting the flow.");
-    writer.destroy()?;
     Ok(())
 }
 
@@ -176,6 +175,5 @@ pub fn write_samples(
     }
 
     info!("Finished writing requested number of samples, deleting the flow.");
-    writer.destroy()?;
     Ok(())
 }

--- a/rust/mxl/src/flow.rs
+++ b/rust/mxl/src/flow.rs
@@ -39,6 +39,7 @@ pub struct FlowInfo {
     pub runtime: FlowRuntimeInfo,
 }
 
+#[derive(Clone)]
 pub struct FlowConfigInfo {
     pub(crate) value: mxl_sys::FlowConfigInfo,
 }

--- a/rust/mxl/src/flow/reader.rs
+++ b/rust/mxl/src/flow/reader.rs
@@ -1,20 +1,19 @@
 // SPDX-FileCopyrightText: 2025 2025 Contributors to the Media eXchange Layer project.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{ptr::NonNull, sync::Arc};
+use std::{cell::Cell, marker::PhantomData, ptr::NonNull, sync::Arc};
 
 use crate::{
-    DataFormat, Error, FlowConfigInfo, FlowRuntimeInfo, GrainReader, Result, SamplesReader,
-    flow::{FlowInfo, is_discrete_data_format},
+    Error, FlowConfigInfo, FlowRuntimeInfo, GrainReader, Result, SamplesReader, flow::FlowInfo,
     instance::InstanceContext,
 };
 
 /// A wrapper around the MXL FlowReader instance to manage its lifetime and ensure proper cleanup.
-pub(crate) struct FlowReaderInstance {
+pub(crate) struct FlowReaderResource {
     pub(crate) context: Arc<InstanceContext>,
     inner: NonNull<mxl_sys::FlowReader_t>,
 }
-impl FlowReaderInstance {
+impl FlowReaderResource {
     pub(crate) fn new(context: Arc<InstanceContext>, flow_id: &str) -> Result<Self> {
         let flow_id = std::ffi::CString::new(flow_id)?;
         let options = std::ffi::CString::new("")?;
@@ -35,11 +34,20 @@ impl FlowReaderInstance {
                 .ok_or_else(|| Error::Other("Failed to create flow reader.".to_string()))?,
         })
     }
-    pub(crate) fn as_ptr(&self) -> mxl_sys::FlowReader {
+    /// # Safety
+    ///
+    /// This is only safe to be called by a single instance of FlowReader, GrainReader or SamplesReader at a time.
+    /// The underlying MXL FlowReader is not thread-safe.
+    pub(crate) unsafe fn as_ptr(&self) -> mxl_sys::FlowReader {
         self.inner.as_ptr()
     }
+    pub(crate) fn keep_alive(self: &Arc<Self>) -> FlowReaderResourceKeepAlive {
+        FlowReaderResourceKeepAlive {
+            _instance: self.clone(),
+        }
+    }
 }
-impl Drop for FlowReaderInstance {
+impl Drop for FlowReaderResource {
     fn drop(&mut self) {
         if let Err(err) = Error::from_status(unsafe {
             self.context
@@ -51,17 +59,24 @@ impl Drop for FlowReaderInstance {
     }
 }
 
-// SAFETY: The native reader may be moved between threads, but must not be accessed
-// concurrently. Do not implement Sync for this type.
-unsafe impl Send for FlowReaderInstance {}
+// SAFETY:
+// This type is only used to manage the lifetime of the underlying MXL FlowReader instance.
+// No operation can be done directly, thus the type itself is thread-safe.
+unsafe impl Send for FlowReaderResource {}
+unsafe impl Sync for FlowReaderResource {}
 
-pub struct FlowReader {
-    reader: Arc<FlowReaderInstance>,
+/// A wrapper around FlowReaderResource to keep it alive. Users can't mutate the underlying pointer.
+pub(crate) struct FlowReaderResourceKeepAlive {
+    _instance: Arc<FlowReaderResource>,
 }
 
-/// The MXL readers and writers are not thread-safe, so we do not implement `Sync` for them, but
-/// there is no reason to not implement `Send`.
-unsafe impl Send for FlowReader {}
+/// Generic MXL Flow Reader, which can be further used to build either the "discrete" (grain-based
+/// data like video frames or meta) or "continuous" (audio samples) flow writers in MXL terminology.
+pub struct FlowReader {
+    reader: Arc<FlowReaderResource>,
+    _not_sync: PhantomData<Cell<()>>, // Prevent Sync implementation, as the underlying MXL reader
+                                      // is not thread-safe.
+}
 
 pub(crate) fn get_flow_info(
     context: &InstanceContext,
@@ -110,17 +125,20 @@ pub(crate) fn get_runtime_info(
 }
 
 impl FlowReader {
-    pub(crate) fn new(reader: FlowReaderInstance) -> Self {
+    pub(crate) fn new(reader: FlowReaderResource) -> Self {
         Self {
-            // Arc provides shared ownership for conversions without making the native
-            // reader safe for concurrent access.
-            #[allow(clippy::arc_with_non_send_sync)]
             reader: Arc::new(reader),
+            _not_sync: PhantomData,
         }
     }
 
+    #[allow(dead_code)]
+    pub(crate) fn keep_alive(&self) -> FlowReaderResourceKeepAlive {
+        self.reader.keep_alive()
+    }
+
     pub fn get_info(&self) -> Result<FlowInfo> {
-        get_flow_info(&self.reader.context, self.reader.as_ptr())
+        get_flow_info(&self.reader.context, unsafe { self.reader.as_ptr() })
     }
 
     pub fn to_grain_reader(self) -> Result<GrainReader> {
@@ -136,11 +154,11 @@ impl FlowReader {
     }
 
     pub fn to_samples_reader(self) -> Result<SamplesReader> {
-        let flow_type = self.get_info()?.config.value.common.format;
-        if is_discrete_data_format(flow_type) {
+        let config_info = self.get_info()?.config;
+        if config_info.is_discrete_flow() {
             return Err(Error::Other(format!(
                 "Cannot convert FlowReader to SamplesReader for discrete flow of type \"{:?}\".",
-                DataFormat::from(flow_type)
+                config_info.common().data_format()
             )));
         }
         let result = SamplesReader::new(self.reader);

--- a/rust/mxl/src/flow/reader.rs
+++ b/rust/mxl/src/flow/reader.rs
@@ -11,7 +11,7 @@ use crate::{
 
 /// A wrapper around the MXL FlowReader instance to manage its lifetime and ensure proper cleanup.
 pub(crate) struct FlowReaderInstance {
-    context: Arc<InstanceContext>,
+    pub(crate) context: Arc<InstanceContext>,
     inner: NonNull<mxl_sys::FlowReader_t>,
 }
 impl FlowReaderInstance {
@@ -56,7 +56,6 @@ impl Drop for FlowReaderInstance {
 unsafe impl Send for FlowReaderInstance {}
 
 pub struct FlowReader {
-    context: Arc<InstanceContext>,
     reader: Arc<FlowReaderInstance>,
 }
 
@@ -111,9 +110,8 @@ pub(crate) fn get_runtime_info(
 }
 
 impl FlowReader {
-    pub(crate) fn new(context: Arc<InstanceContext>, reader: FlowReaderInstance) -> Self {
+    pub(crate) fn new(reader: FlowReaderInstance) -> Self {
         Self {
-            context,
             // Arc provides shared ownership for conversions without making the native
             // reader safe for concurrent access.
             #[allow(clippy::arc_with_non_send_sync)]
@@ -122,7 +120,7 @@ impl FlowReader {
     }
 
     pub fn get_info(&self) -> Result<FlowInfo> {
-        get_flow_info(&self.context, self.reader.as_ptr())
+        get_flow_info(&self.reader.context, self.reader.as_ptr())
     }
 
     pub fn to_grain_reader(self) -> Result<GrainReader> {
@@ -133,7 +131,7 @@ impl FlowReader {
                 config_info.common().data_format()
             )));
         }
-        let result = GrainReader::new(self.context.clone(), self.reader);
+        let result = GrainReader::new(self.reader);
         Ok(result)
     }
 
@@ -145,7 +143,7 @@ impl FlowReader {
                 DataFormat::from(flow_type)
             )));
         }
-        let result = SamplesReader::new(self.context.clone(), self.reader);
+        let result = SamplesReader::new(self.reader);
         Ok(result)
     }
 }

--- a/rust/mxl/src/flow/reader.rs
+++ b/rust/mxl/src/flow/reader.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2025 2025 Contributors to the Media eXchange Layer project.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
+use std::{ptr::NonNull, sync::Arc};
 
 use crate::{
     DataFormat, Error, FlowConfigInfo, FlowRuntimeInfo, GrainReader, Result, SamplesReader,
@@ -9,9 +9,55 @@ use crate::{
     instance::InstanceContext,
 };
 
+/// A wrapper around the MXL FlowReader instance to manage its lifetime and ensure proper cleanup.
+pub(crate) struct FlowReaderInstance {
+    context: Arc<InstanceContext>,
+    inner: NonNull<mxl_sys::FlowReader_t>,
+}
+impl FlowReaderInstance {
+    pub(crate) fn new(context: Arc<InstanceContext>, flow_id: &str) -> Result<Self> {
+        let flow_id = std::ffi::CString::new(flow_id)?;
+        let options = std::ffi::CString::new("")?;
+        let mut reader: mxl_sys::FlowReader = std::ptr::null_mut();
+
+        Error::from_status(unsafe {
+            context.api.create_flow_reader(
+                context.instance,
+                flow_id.as_ptr(),
+                options.as_ptr(),
+                &mut reader,
+            )
+        })?;
+
+        Ok(Self {
+            context,
+            inner: NonNull::new(reader)
+                .ok_or_else(|| Error::Other("Failed to create flow reader.".to_string()))?,
+        })
+    }
+    pub(crate) fn as_ptr(&self) -> mxl_sys::FlowReader {
+        self.inner.as_ptr()
+    }
+}
+impl Drop for FlowReaderInstance {
+    fn drop(&mut self) {
+        if let Err(err) = Error::from_status(unsafe {
+            self.context
+                .api
+                .release_flow_reader(self.context.instance, self.inner.as_ptr())
+        }) {
+            tracing::error!("Failed to release MXL flow reader: {:?}", err);
+        }
+    }
+}
+
+// SAFETY: The native reader may be moved between threads, but must not be accessed
+// concurrently. Do not implement Sync for this type.
+unsafe impl Send for FlowReaderInstance {}
+
 pub struct FlowReader {
     context: Arc<InstanceContext>,
-    reader: mxl_sys::FlowReader,
+    reader: Arc<FlowReaderInstance>,
 }
 
 /// The MXL readers and writers are not thread-safe, so we do not implement `Sync` for them, but
@@ -19,13 +65,11 @@ pub struct FlowReader {
 unsafe impl Send for FlowReader {}
 
 pub(crate) fn get_flow_info(
-    context: &Arc<InstanceContext>,
+    context: &InstanceContext,
     reader: mxl_sys::FlowReader,
 ) -> Result<FlowInfo> {
     let mut flow_info: mxl_sys::FlowInfo = unsafe { std::mem::zeroed() };
-    unsafe {
-        Error::from_status(context.api.flow_reader_get_info(reader, &mut flow_info))?;
-    }
+    Error::from_status(unsafe { context.api.flow_reader_get_info(reader, &mut flow_info) })?;
     Ok(FlowInfo {
         config: FlowConfigInfo {
             value: flow_info.config,
@@ -37,7 +81,7 @@ pub(crate) fn get_flow_info(
 }
 
 pub(crate) fn get_config_info(
-    context: &Arc<InstanceContext>,
+    context: &InstanceContext,
     reader: mxl_sys::FlowReader,
 ) -> Result<FlowConfigInfo> {
     let mut config_info: mxl_sys::FlowConfigInfo = unsafe { std::mem::zeroed() };
@@ -52,7 +96,7 @@ pub(crate) fn get_config_info(
 }
 
 pub(crate) fn get_runtime_info(
-    context: &Arc<InstanceContext>,
+    context: &InstanceContext,
     reader: mxl_sys::FlowReader,
 ) -> Result<mxl_sys::FlowRuntimeInfo> {
     let mut runtime_info: mxl_sys::FlowRuntimeInfo = unsafe { std::mem::zeroed() };
@@ -67,28 +111,33 @@ pub(crate) fn get_runtime_info(
 }
 
 impl FlowReader {
-    pub(crate) fn new(context: Arc<InstanceContext>, reader: mxl_sys::FlowReader) -> Self {
-        Self { context, reader }
+    pub(crate) fn new(context: Arc<InstanceContext>, reader: FlowReaderInstance) -> Self {
+        Self {
+            context,
+            // Arc provides shared ownership for conversions without making the native
+            // reader safe for concurrent access.
+            #[allow(clippy::arc_with_non_send_sync)]
+            reader: Arc::new(reader),
+        }
     }
 
     pub fn get_info(&self) -> Result<FlowInfo> {
-        get_flow_info(&self.context, self.reader)
+        get_flow_info(&self.context, self.reader.as_ptr())
     }
 
-    pub fn to_grain_reader(mut self) -> Result<GrainReader> {
-        let flow_type = self.get_info()?.config.value.common.format;
-        if !is_discrete_data_format(flow_type) {
+    pub fn to_grain_reader(self) -> Result<GrainReader> {
+        let config_info = self.get_info()?.config;
+        if !config_info.is_discrete_flow() {
             return Err(Error::Other(format!(
                 "Cannot convert FlowReader to GrainReader for continuous flow of type \"{:?}\".",
-                DataFormat::from(flow_type)
+                config_info.common().data_format()
             )));
         }
         let result = GrainReader::new(self.context.clone(), self.reader);
-        self.reader = std::ptr::null_mut();
         Ok(result)
     }
 
-    pub fn to_samples_reader(mut self) -> Result<SamplesReader> {
+    pub fn to_samples_reader(self) -> Result<SamplesReader> {
         let flow_type = self.get_info()?.config.value.common.format;
         if is_discrete_data_format(flow_type) {
             return Err(Error::Other(format!(
@@ -97,21 +146,6 @@ impl FlowReader {
             )));
         }
         let result = SamplesReader::new(self.context.clone(), self.reader);
-        self.reader = std::ptr::null_mut();
         Ok(result)
-    }
-}
-
-impl Drop for FlowReader {
-    fn drop(&mut self) {
-        if !self.reader.is_null()
-            && let Err(err) = Error::from_status(unsafe {
-                self.context
-                    .api
-                    .release_flow_reader(self.context.instance, self.reader)
-            })
-        {
-            tracing::error!("Failed to release MXL flow reader: {:?}", err);
-        }
     }
 }

--- a/rust/mxl/src/flow/writer.rs
+++ b/rust/mxl/src/flow/writer.rs
@@ -1,16 +1,16 @@
 // SPDX-FileCopyrightText: 2025 2025 Contributors to the Media eXchange Layer project.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{ffi::CString, ptr::NonNull, sync::Arc};
+use std::{cell::Cell, ffi::CString, marker::PhantomData, ptr::NonNull, sync::Arc};
 
 use crate::{Error, FlowConfigInfo, GrainWriter, Result, SamplesWriter, instance::InstanceContext};
 
 /// A wrapper around the MXL FlowWriter instance to manage its lifetime and ensure proper cleanup.
-pub(crate) struct FlowWriterInstance {
+pub(crate) struct FlowWriterResource {
     pub(crate) context: Arc<InstanceContext>,
     inner: NonNull<mxl_sys::FlowWriter_t>,
 }
-impl FlowWriterInstance {
+impl FlowWriterResource {
     pub(crate) fn new(
         context: Arc<InstanceContext>,
         flow_def: &str,
@@ -46,11 +46,20 @@ impl FlowWriterInstance {
             was_created,
         ))
     }
-    pub(crate) fn as_ptr(&self) -> mxl_sys::FlowWriter {
+    /// # Safety
+    ///
+    /// This is only safe to be called by a single instance of FlowWriter, GrainWriter or SamplesWriter at a time.
+    /// The underlying MXL FlowWriter is not thread-safe.
+    pub(crate) unsafe fn as_ptr(&self) -> mxl_sys::FlowWriter {
         self.inner.as_ptr()
     }
+    pub(crate) fn keep_alive(self: &Arc<Self>) -> FlowWriterResourceKeepAlive {
+        FlowWriterResourceKeepAlive {
+            _instance: self.clone(),
+        }
+    }
 }
-impl Drop for FlowWriterInstance {
+impl Drop for FlowWriterResource {
     fn drop(&mut self) {
         if let Err(err) = Error::from_status(unsafe {
             self.context
@@ -62,30 +71,38 @@ impl Drop for FlowWriterInstance {
     }
 }
 
-// SAFETY: The native writer may be moved between threads, but must not be accessed
-// concurrently. Do not implement Sync for this type.
-unsafe impl Send for FlowWriterInstance {}
+// SAFETY:
+// This type is only used to manage the lifetime of the underlying MXL FlowWriter instance.
+// No operation can be done directly, thus the type itself is thread-safe.
+unsafe impl Send for FlowWriterResource {}
+unsafe impl Sync for FlowWriterResource {}
+
+/// A wrapper around FlowWriterResource to keep it alive. Users can't mutate the underlying pointer.
+pub(crate) struct FlowWriterResourceKeepAlive {
+    _instance: Arc<FlowWriterResource>,
+}
 
 /// Generic MXL Flow Writer, which can be further used to build either the "discrete" (grain-based
 /// data like video frames or meta) or "continuous" (audio samples) flow writers in MXL terminology.
 pub struct FlowWriter {
-    writer: Arc<FlowWriterInstance>,
+    writer: Arc<FlowWriterResource>,
     info: FlowConfigInfo,
+    _not_sync: PhantomData<Cell<()>>, // Prevent Sync implementation, as the underlying MXL writer
+                                      // is not thread-safe
 }
 
-/// The MXL readers and writers are not thread-safe, so we do not implement `Sync` for them, but
-/// there is no reason to not implement `Send`.
-unsafe impl Send for FlowWriter {}
-
 impl FlowWriter {
-    pub(crate) fn new(writer: FlowWriterInstance, info: FlowConfigInfo) -> Self {
+    pub(crate) fn new(writer: FlowWriterResource, info: FlowConfigInfo) -> Self {
         Self {
-            // Arc keeps write accesses alive without making the native writer safe
-            // for concurrent access.
-            #[allow(clippy::arc_with_non_send_sync)]
             writer: Arc::new(writer),
             info,
+            _not_sync: PhantomData,
         }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn keep_alive(&self) -> FlowWriterResourceKeepAlive {
+        self.writer.keep_alive()
     }
 
     pub fn to_grain_writer(self) -> Result<GrainWriter> {

--- a/rust/mxl/src/flow/writer.rs
+++ b/rust/mxl/src/flow/writer.rs
@@ -7,7 +7,7 @@ use crate::{Error, FlowConfigInfo, GrainWriter, Result, SamplesWriter, instance:
 
 /// A wrapper around the MXL FlowWriter instance to manage its lifetime and ensure proper cleanup.
 pub(crate) struct FlowWriterInstance {
-    context: Arc<InstanceContext>,
+    pub(crate) context: Arc<InstanceContext>,
     inner: NonNull<mxl_sys::FlowWriter_t>,
 }
 impl FlowWriterInstance {
@@ -69,7 +69,6 @@ unsafe impl Send for FlowWriterInstance {}
 /// Generic MXL Flow Writer, which can be further used to build either the "discrete" (grain-based
 /// data like video frames or meta) or "continuous" (audio samples) flow writers in MXL terminology.
 pub struct FlowWriter {
-    context: Arc<InstanceContext>,
     writer: Arc<FlowWriterInstance>,
     info: FlowConfigInfo,
 }
@@ -79,13 +78,8 @@ pub struct FlowWriter {
 unsafe impl Send for FlowWriter {}
 
 impl FlowWriter {
-    pub(crate) fn new(
-        context: Arc<InstanceContext>,
-        writer: FlowWriterInstance,
-        info: FlowConfigInfo,
-    ) -> Self {
+    pub(crate) fn new(writer: FlowWriterInstance, info: FlowConfigInfo) -> Self {
         Self {
-            context,
             // Arc keeps write accesses alive without making the native writer safe
             // for concurrent access.
             #[allow(clippy::arc_with_non_send_sync)]
@@ -101,7 +95,7 @@ impl FlowWriter {
                 self.info.common().data_format()
             )));
         }
-        let result = GrainWriter::new(self.context.clone(), self.writer);
+        let result = GrainWriter::new(self.writer);
         Ok(result)
     }
 
@@ -112,7 +106,7 @@ impl FlowWriter {
                 self.info.common().data_format()
             )));
         }
-        let result = SamplesWriter::new(self.context.clone(), self.writer);
+        let result = SamplesWriter::new(self.writer);
         Ok(result)
     }
 }

--- a/rust/mxl/src/flow/writer.rs
+++ b/rust/mxl/src/flow/writer.rs
@@ -1,20 +1,77 @@
 // SPDX-FileCopyrightText: 2025 2025 Contributors to the Media eXchange Layer project.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
+use std::{ffi::CString, ptr::NonNull, sync::Arc};
 
-use crate::{
-    DataFormat, Error, GrainWriter, Result, SamplesWriter,
-    flow::is_discrete_data_format,
-    instance::{InstanceContext, create_flow_reader},
-};
+use crate::{Error, FlowConfigInfo, GrainWriter, Result, SamplesWriter, instance::InstanceContext};
+
+/// A wrapper around the MXL FlowWriter instance to manage its lifetime and ensure proper cleanup.
+pub(crate) struct FlowWriterInstance {
+    context: Arc<InstanceContext>,
+    inner: NonNull<mxl_sys::FlowWriter_t>,
+}
+impl FlowWriterInstance {
+    pub(crate) fn new(
+        context: Arc<InstanceContext>,
+        flow_def: &str,
+        options: Option<&str>,
+    ) -> Result<(Self, FlowConfigInfo, bool)> {
+        let flow_def = CString::new(flow_def)?;
+        let options = options.map(CString::new).transpose()?;
+        let mut writer: mxl_sys::FlowWriter = std::ptr::null_mut();
+        let mut info_unsafe = std::mem::MaybeUninit::<mxl_sys::FlowConfigInfo>::uninit();
+        let mut was_created = false;
+
+        Error::from_status(unsafe {
+            context.api.create_flow_writer(
+                context.instance,
+                flow_def.as_ptr(),
+                options.map(|cs| cs.as_ptr()).unwrap_or(std::ptr::null()),
+                &mut writer,
+                info_unsafe.as_mut_ptr(),
+                &mut was_created,
+            )
+        })?;
+
+        Ok((
+            Self {
+                context,
+                inner: NonNull::new(writer)
+                    .ok_or_else(|| Error::Other("Failed to create flow writer.".to_string()))?,
+            },
+            FlowConfigInfo {
+                //SAFETY: The MXL API guarantees that the info is initialized if the function returns success.
+                value: unsafe { info_unsafe.assume_init() },
+            },
+            was_created,
+        ))
+    }
+    pub(crate) fn as_ptr(&self) -> mxl_sys::FlowWriter {
+        self.inner.as_ptr()
+    }
+}
+impl Drop for FlowWriterInstance {
+    fn drop(&mut self) {
+        if let Err(err) = Error::from_status(unsafe {
+            self.context
+                .api
+                .release_flow_writer(self.context.instance, self.inner.as_ptr())
+        }) {
+            tracing::error!("Failed to release MXL flow writer: {:?}", err);
+        }
+    }
+}
+
+// SAFETY: The native writer may be moved between threads, but must not be accessed
+// concurrently. Do not implement Sync for this type.
+unsafe impl Send for FlowWriterInstance {}
 
 /// Generic MXL Flow Writer, which can be further used to build either the "discrete" (grain-based
 /// data like video frames or meta) or "continuous" (audio samples) flow writers in MXL terminology.
 pub struct FlowWriter {
     context: Arc<InstanceContext>,
-    writer: mxl_sys::FlowWriter,
-    id: uuid::Uuid,
+    writer: Arc<FlowWriterInstance>,
+    info: FlowConfigInfo,
 }
 
 /// The MXL readers and writers are not thread-safe, so we do not implement `Sync` for them, but
@@ -24,69 +81,38 @@ unsafe impl Send for FlowWriter {}
 impl FlowWriter {
     pub(crate) fn new(
         context: Arc<InstanceContext>,
-        writer: mxl_sys::FlowWriter,
-        id: uuid::Uuid,
+        writer: FlowWriterInstance,
+        info: FlowConfigInfo,
     ) -> Self {
         Self {
             context,
-            writer,
-            id,
+            // Arc keeps write accesses alive without making the native writer safe
+            // for concurrent access.
+            #[allow(clippy::arc_with_non_send_sync)]
+            writer: Arc::new(writer),
+            info,
         }
     }
 
-    pub fn to_grain_writer(mut self) -> Result<GrainWriter> {
-        let flow_type = self.get_flow_type()?;
-        if !is_discrete_data_format(flow_type) {
+    pub fn to_grain_writer(self) -> Result<GrainWriter> {
+        if !self.info.is_discrete_flow() {
             return Err(Error::Other(format!(
                 "Cannot convert FlowWriter to GrainWriter for continuous flow of type \"{:?}\".",
-                DataFormat::from(flow_type)
+                self.info.common().data_format()
             )));
         }
         let result = GrainWriter::new(self.context.clone(), self.writer);
-        self.writer = std::ptr::null_mut();
         Ok(result)
     }
 
-    pub fn to_samples_writer(mut self) -> Result<SamplesWriter> {
-        let flow_type = self.get_flow_type()?;
-        if is_discrete_data_format(flow_type) {
+    pub fn to_samples_writer(self) -> Result<SamplesWriter> {
+        if self.info.is_discrete_flow() {
             return Err(Error::Other(format!(
                 "Cannot convert FlowWriter to SamplesWriter for discrete flow of type \"{:?}\".",
-                DataFormat::from(flow_type)
+                self.info.common().data_format()
             )));
         }
         let result = SamplesWriter::new(self.context.clone(), self.writer);
-        self.writer = std::ptr::null_mut();
         Ok(result)
-    }
-
-    fn get_flow_type(&self) -> Result<u32> {
-        // This feels pretty ugly, but currently, the only way how to get a flow type in MXL is to
-        // use a reader.
-        let reader = create_flow_reader(&self.context, &self.id.to_string()).map_err(|error| {
-            Error::Other(format!(
-                "Error while creating flow reader to get the flow type: {error}"
-            ))
-        })?;
-        let flow_info = reader.get_info().map_err(|error| {
-            Error::Other(format!(
-                "Error while getting flow type from temporary reader: {error}"
-            ))
-        })?;
-        Ok(flow_info.config.value.common.format)
-    }
-}
-
-impl Drop for FlowWriter {
-    fn drop(&mut self) {
-        if !self.writer.is_null()
-            && let Err(err) = Error::from_status(unsafe {
-                self.context
-                    .api
-                    .release_flow_writer(self.context.instance, self.writer)
-            })
-        {
-            tracing::error!("Failed to release MXL flow writer: {:?}", err);
-        }
     }
 }

--- a/rust/mxl/src/grain/reader.rs
+++ b/rust/mxl/src/grain/reader.rs
@@ -10,11 +10,12 @@ use crate::{
         reader::{get_config_info, get_flow_info, get_runtime_info},
     },
     instance::InstanceContext,
+    reader::FlowReaderInstance,
 };
 
 pub struct GrainReader {
     context: Arc<InstanceContext>,
-    reader: mxl_sys::FlowReader,
+    reader: Arc<FlowReaderInstance>,
 }
 
 /// The MXL readers and writers are not thread-safe, so we do not implement `Sync` for them, but
@@ -22,26 +23,30 @@ pub struct GrainReader {
 unsafe impl Send for GrainReader {}
 
 impl GrainReader {
-    pub(crate) fn new(context: Arc<InstanceContext>, reader: mxl_sys::FlowReader) -> Self {
+    pub(crate) fn new(context: Arc<InstanceContext>, reader: Arc<FlowReaderInstance>) -> Self {
         Self { context, reader }
     }
 
-    pub fn destroy(mut self) -> Result<()> {
-        self.destroy_inner()
+    #[deprecated(
+        since = "0.2.0",
+        note = "The MXL FlowWriter lifetime is now automatically managed internally. You should not be calling destroy() on it anymore. This function is a no-op and will be removed in a future version."
+    )]
+    pub fn destroy(self) -> Result<()> {
+        Ok(())
     }
 
     /// The whole FlowInfo is quite a chunk of data. Go for `get_config_info` or `get_runtime_info`
     /// if they contain what you need.
     pub fn get_info(&self) -> Result<FlowInfo> {
-        get_flow_info(&self.context, self.reader)
+        get_flow_info(&self.context, self.reader.as_ptr())
     }
 
     pub fn get_config_info(&self) -> Result<FlowConfigInfo> {
-        get_config_info(&self.context, self.reader)
+        get_config_info(&self.context, self.reader.as_ptr())
     }
 
     pub fn get_runtime_info(&self) -> Result<mxl_sys::FlowRuntimeInfo> {
-        get_runtime_info(&self.context, self.reader)
+        get_runtime_info(&self.context, self.reader.as_ptr())
     }
 
     pub fn get_complete_grain<'a>(
@@ -55,7 +60,7 @@ impl GrainReader {
         loop {
             unsafe {
                 Error::from_status(self.context.api.flow_reader_get_grain(
-                    self.reader,
+                    self.reader.as_ptr(),
                     index,
                     timeout_ns,
                     &mut grain_info,
@@ -95,7 +100,7 @@ impl GrainReader {
         let mut payload_ptr: *mut u8 = std::ptr::null_mut();
         unsafe {
             Error::from_status(self.context.api.flow_reader_get_grain_non_blocking(
-                self.reader,
+                self.reader.as_ptr(),
                 index,
                 &mut grain_info,
                 &mut payload_ptr,
@@ -120,30 +125,5 @@ impl GrainReader {
             flags: grain_info.flags,
             index: grain_info.index,
         })
-    }
-
-    fn destroy_inner(&mut self) -> Result<()> {
-        if self.reader.is_null() {
-            return Err(Error::InvalidArg);
-        }
-
-        let mut reader = std::ptr::null_mut();
-        std::mem::swap(&mut self.reader, &mut reader);
-
-        Error::from_status(unsafe {
-            self.context
-                .api
-                .release_flow_reader(self.context.instance, reader)
-        })
-    }
-}
-
-impl Drop for GrainReader {
-    fn drop(&mut self) {
-        if !self.reader.is_null()
-            && let Err(err) = self.destroy_inner()
-        {
-            tracing::error!("Failed to release MXL flow reader (discrete): {:?}", err);
-        }
     }
 }

--- a/rust/mxl/src/grain/reader.rs
+++ b/rust/mxl/src/grain/reader.rs
@@ -9,12 +9,10 @@ use crate::{
         FlowInfo,
         reader::{get_config_info, get_flow_info, get_runtime_info},
     },
-    instance::InstanceContext,
     reader::FlowReaderInstance,
 };
 
 pub struct GrainReader {
-    context: Arc<InstanceContext>,
     reader: Arc<FlowReaderInstance>,
 }
 
@@ -23,13 +21,13 @@ pub struct GrainReader {
 unsafe impl Send for GrainReader {}
 
 impl GrainReader {
-    pub(crate) fn new(context: Arc<InstanceContext>, reader: Arc<FlowReaderInstance>) -> Self {
-        Self { context, reader }
+    pub(crate) fn new(reader: Arc<FlowReaderInstance>) -> Self {
+        Self { reader }
     }
 
     #[deprecated(
         since = "0.2.0",
-        note = "The MXL FlowWriter lifetime is now automatically managed internally. You should not be calling destroy() on it anymore. This function is a no-op and will be removed in a future version."
+        note = "Flow reader lifetimes are now managed automatically. This method only consumes the handle and always returns `Ok(())`; the underlying reader is released when the last related handle is dropped."
     )]
     pub fn destroy(self) -> Result<()> {
         Ok(())
@@ -38,15 +36,15 @@ impl GrainReader {
     /// The whole FlowInfo is quite a chunk of data. Go for `get_config_info` or `get_runtime_info`
     /// if they contain what you need.
     pub fn get_info(&self) -> Result<FlowInfo> {
-        get_flow_info(&self.context, self.reader.as_ptr())
+        get_flow_info(&self.reader.context, self.reader.as_ptr())
     }
 
     pub fn get_config_info(&self) -> Result<FlowConfigInfo> {
-        get_config_info(&self.context, self.reader.as_ptr())
+        get_config_info(&self.reader.context, self.reader.as_ptr())
     }
 
     pub fn get_runtime_info(&self) -> Result<mxl_sys::FlowRuntimeInfo> {
-        get_runtime_info(&self.context, self.reader.as_ptr())
+        get_runtime_info(&self.reader.context, self.reader.as_ptr())
     }
 
     pub fn get_complete_grain<'a>(
@@ -59,7 +57,7 @@ impl GrainReader {
         let timeout_ns = timeout.as_nanos() as u64;
         loop {
             unsafe {
-                Error::from_status(self.context.api.flow_reader_get_grain(
+                Error::from_status(self.reader.context.api.flow_reader_get_grain(
                     self.reader.as_ptr(),
                     index,
                     timeout_ns,
@@ -99,7 +97,7 @@ impl GrainReader {
         let mut grain_info: mxl_sys::GrainInfo = unsafe { std::mem::zeroed() };
         let mut payload_ptr: *mut u8 = std::ptr::null_mut();
         unsafe {
-            Error::from_status(self.context.api.flow_reader_get_grain_non_blocking(
+            Error::from_status(self.reader.context.api.flow_reader_get_grain_non_blocking(
                 self.reader.as_ptr(),
                 index,
                 &mut grain_info,

--- a/rust/mxl/src/grain/reader.rs
+++ b/rust/mxl/src/grain/reader.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2025-2026 Contributors to the Media eXchange Layer project.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{sync::Arc, time::Duration};
+use std::{cell::Cell, marker::PhantomData, sync::Arc, time::Duration};
 
 use crate::{
     Error, FlowConfigInfo, GrainData, Result,
@@ -9,20 +9,26 @@ use crate::{
         FlowInfo,
         reader::{get_config_info, get_flow_info, get_runtime_info},
     },
-    reader::FlowReaderInstance,
+    reader::{FlowReaderResource, FlowReaderResourceKeepAlive},
 };
 
 pub struct GrainReader {
-    reader: Arc<FlowReaderInstance>,
+    reader: Arc<FlowReaderResource>,
+    _not_sync: PhantomData<Cell<()>>, // Prevent Sync implementation, as the underlying MXL reader
+                                      // is not thread-safe.
 }
 
-/// The MXL readers and writers are not thread-safe, so we do not implement `Sync` for them, but
-/// there is no reason to not implement `Send`.
-unsafe impl Send for GrainReader {}
-
 impl GrainReader {
-    pub(crate) fn new(reader: Arc<FlowReaderInstance>) -> Self {
-        Self { reader }
+    pub(crate) fn new(reader: Arc<FlowReaderResource>) -> Self {
+        Self {
+            reader,
+            _not_sync: PhantomData,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn keep_alive(&self) -> FlowReaderResourceKeepAlive {
+        self.reader.keep_alive()
     }
 
     #[deprecated(
@@ -36,15 +42,15 @@ impl GrainReader {
     /// The whole FlowInfo is quite a chunk of data. Go for `get_config_info` or `get_runtime_info`
     /// if they contain what you need.
     pub fn get_info(&self) -> Result<FlowInfo> {
-        get_flow_info(&self.reader.context, self.reader.as_ptr())
+        get_flow_info(&self.reader.context, unsafe { self.reader.as_ptr() })
     }
 
     pub fn get_config_info(&self) -> Result<FlowConfigInfo> {
-        get_config_info(&self.reader.context, self.reader.as_ptr())
+        get_config_info(&self.reader.context, unsafe { self.reader.as_ptr() })
     }
 
     pub fn get_runtime_info(&self) -> Result<mxl_sys::FlowRuntimeInfo> {
-        get_runtime_info(&self.reader.context, self.reader.as_ptr())
+        get_runtime_info(&self.reader.context, unsafe { self.reader.as_ptr() })
     }
 
     pub fn get_complete_grain<'a>(

--- a/rust/mxl/src/grain/write_access.rs
+++ b/rust/mxl/src/grain/write_access.rs
@@ -1,29 +1,28 @@
 // SPDX-FileCopyrightText: 2025 2025 Contributors to the Media eXchange Layer project.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{marker::PhantomData, sync::Arc};
+use std::sync::Arc;
 
 use tracing::error;
 
-use crate::{Error, Result, instance::InstanceContext};
+use crate::{Error, Result, instance::InstanceContext, writer::FlowWriterInstance};
 
 /// RAII grain writing session
 ///
 /// Automatically cancels the grain if not explicitly committed.
 pub struct GrainWriteAccess<'a> {
     context: Arc<InstanceContext>,
-    writer: mxl_sys::FlowWriter,
+    writer: &'a FlowWriterInstance,
     grain_info: mxl_sys::GrainInfo,
     payload_ptr: *mut u8,
     /// Serves as a flag to know whether to cancel the grain on drop.
     committed_or_canceled: bool,
-    phantom: PhantomData<&'a ()>,
 }
 
 impl<'a> GrainWriteAccess<'a> {
     pub(crate) fn new(
         context: Arc<InstanceContext>,
-        writer: mxl_sys::FlowWriter,
+        writer: &'a FlowWriterInstance,
         grain_info: mxl_sys::GrainInfo,
         payload_ptr: *mut u8,
     ) -> Self {
@@ -33,7 +32,6 @@ impl<'a> GrainWriteAccess<'a> {
             grain_info,
             payload_ptr,
             committed_or_canceled: false,
-            phantom: Default::default(),
         }
     }
 
@@ -66,7 +64,7 @@ impl<'a> GrainWriteAccess<'a> {
             Error::from_status(
                 self.context
                     .api
-                    .flow_writer_commit_grain(self.writer, &self.grain_info),
+                    .flow_writer_commit_grain(self.writer.as_ptr(), &self.grain_info),
             )
         }
     }
@@ -78,7 +76,13 @@ impl<'a> GrainWriteAccess<'a> {
     pub fn cancel(mut self) -> Result<()> {
         self.committed_or_canceled = true;
 
-        unsafe { Error::from_status(self.context.api.flow_writer_cancel_grain(self.writer)) }
+        unsafe {
+            Error::from_status(
+                self.context
+                    .api
+                    .flow_writer_cancel_grain(self.writer.as_ptr()),
+            )
+        }
     }
 }
 
@@ -86,7 +90,11 @@ impl<'a> Drop for GrainWriteAccess<'a> {
     fn drop(&mut self) {
         if !self.committed_or_canceled
             && let Err(error) = unsafe {
-                Error::from_status(self.context.api.flow_writer_cancel_grain(self.writer))
+                Error::from_status(
+                    self.context
+                        .api
+                        .flow_writer_cancel_grain(self.writer.as_ptr()),
+                )
             }
         {
             error!("Failed to cancel grain write on drop: {:?}", error);

--- a/rust/mxl/src/grain/write_access.rs
+++ b/rust/mxl/src/grain/write_access.rs
@@ -1,17 +1,14 @@
 // SPDX-FileCopyrightText: 2025 2025 Contributors to the Media eXchange Layer project.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
-
 use tracing::error;
 
-use crate::{Error, Result, instance::InstanceContext, writer::FlowWriterInstance};
+use crate::{Error, Result, writer::FlowWriterInstance};
 
 /// RAII grain writing session
 ///
 /// Automatically cancels the grain if not explicitly committed.
 pub struct GrainWriteAccess<'a> {
-    context: Arc<InstanceContext>,
     writer: &'a FlowWriterInstance,
     grain_info: mxl_sys::GrainInfo,
     payload_ptr: *mut u8,
@@ -21,13 +18,11 @@ pub struct GrainWriteAccess<'a> {
 
 impl<'a> GrainWriteAccess<'a> {
     pub(crate) fn new(
-        context: Arc<InstanceContext>,
         writer: &'a FlowWriterInstance,
         grain_info: mxl_sys::GrainInfo,
         payload_ptr: *mut u8,
     ) -> Self {
         Self {
-            context,
             writer,
             grain_info,
             payload_ptr,
@@ -62,7 +57,8 @@ impl<'a> GrainWriteAccess<'a> {
 
         unsafe {
             Error::from_status(
-                self.context
+                self.writer
+                    .context
                     .api
                     .flow_writer_commit_grain(self.writer.as_ptr(), &self.grain_info),
             )
@@ -78,7 +74,8 @@ impl<'a> GrainWriteAccess<'a> {
 
         unsafe {
             Error::from_status(
-                self.context
+                self.writer
+                    .context
                     .api
                     .flow_writer_cancel_grain(self.writer.as_ptr()),
             )
@@ -91,7 +88,8 @@ impl<'a> Drop for GrainWriteAccess<'a> {
         if !self.committed_or_canceled
             && let Err(error) = unsafe {
                 Error::from_status(
-                    self.context
+                    self.writer
+                        .context
                         .api
                         .flow_writer_cancel_grain(self.writer.as_ptr()),
                 )

--- a/rust/mxl/src/grain/write_access.rs
+++ b/rust/mxl/src/grain/write_access.rs
@@ -3,13 +3,13 @@
 
 use tracing::error;
 
-use crate::{Error, Result, writer::FlowWriterInstance};
+use crate::{Error, Result, writer::FlowWriterResource};
 
 /// RAII grain writing session
 ///
 /// Automatically cancels the grain if not explicitly committed.
 pub struct GrainWriteAccess<'a> {
-    writer: &'a FlowWriterInstance,
+    writer: &'a FlowWriterResource,
     grain_info: mxl_sys::GrainInfo,
     payload_ptr: *mut u8,
     /// Serves as a flag to know whether to cancel the grain on drop.
@@ -18,7 +18,7 @@ pub struct GrainWriteAccess<'a> {
 
 impl<'a> GrainWriteAccess<'a> {
     pub(crate) fn new(
-        writer: &'a FlowWriterInstance,
+        writer: &'a FlowWriterResource,
         grain_info: mxl_sys::GrainInfo,
         payload_ptr: *mut u8,
     ) -> Self {

--- a/rust/mxl/src/grain/writer.rs
+++ b/rust/mxl/src/grain/writer.rs
@@ -1,24 +1,32 @@
 // SPDX-FileCopyrightText: 2025 2025 Contributors to the Media eXchange Layer project.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
+use std::{cell::Cell, marker::PhantomData, sync::Arc};
 
 use super::write_access::GrainWriteAccess;
 
-use crate::{Error, Result, writer::FlowWriterInstance};
+use crate::{
+    Error, Result,
+    writer::{FlowWriterResource, FlowWriterResourceKeepAlive},
+};
 
 /// MXL Flow Writer for discrete flows (grain-based data like video frames)
 pub struct GrainWriter {
-    writer: Arc<FlowWriterInstance>,
+    writer: Arc<FlowWriterResource>,
+    _not_sync: PhantomData<Cell<()>>, // Prevent Sync implementation, as the underlying MXL writer
+                                      // is not thread-safe
 }
 
-/// The MXL readers and writers are not thread-safe, so we do not implement `Sync` for them, but
-/// there is no reason to not implement `Send`.
-unsafe impl Send for GrainWriter {}
-
 impl GrainWriter {
-    pub(crate) fn new(writer: Arc<FlowWriterInstance>) -> Self {
-        Self { writer }
+    pub(crate) fn new(writer: Arc<FlowWriterResource>) -> Self {
+        Self {
+            writer,
+            _not_sync: PhantomData,
+        }
+    }
+    #[allow(dead_code)]
+    pub(crate) fn keep_alive(&self) -> FlowWriterResourceKeepAlive {
+        self.writer.keep_alive()
     }
 
     #[deprecated(

--- a/rust/mxl/src/grain/writer.rs
+++ b/rust/mxl/src/grain/writer.rs
@@ -5,12 +5,12 @@ use std::sync::Arc;
 
 use super::write_access::GrainWriteAccess;
 
-use crate::{Error, Result, instance::InstanceContext};
+use crate::{Error, Result, instance::InstanceContext, writer::FlowWriterInstance};
 
 /// MXL Flow Writer for discrete flows (grain-based data like video frames)
 pub struct GrainWriter {
     context: Arc<InstanceContext>,
-    writer: mxl_sys::FlowWriter,
+    writer: Arc<FlowWriterInstance>,
 }
 
 /// The MXL readers and writers are not thread-safe, so we do not implement `Sync` for them, but
@@ -18,12 +18,16 @@ pub struct GrainWriter {
 unsafe impl Send for GrainWriter {}
 
 impl GrainWriter {
-    pub(crate) fn new(context: Arc<InstanceContext>, writer: mxl_sys::FlowWriter) -> Self {
+    pub(crate) fn new(context: Arc<InstanceContext>, writer: Arc<FlowWriterInstance>) -> Self {
         Self { context, writer }
     }
 
-    pub fn destroy(mut self) -> Result<()> {
-        self.destroy_inner()
+    #[deprecated(
+        since = "0.2.0",
+        note = "The MXL FlowWriter lifetime is now automatically managed internally. You should not be calling destroy() on it anymore. This function is now a no-op and will be removed in a future version."
+    )]
+    pub fn destroy(self) -> Result<()> {
+        Ok(())
     }
 
     /// The current MXL implementation states a TODO to allow multiple grains to be edited at the
@@ -35,7 +39,7 @@ impl GrainWriter {
         let mut payload_ptr: *mut u8 = std::ptr::null_mut();
         unsafe {
             Error::from_status(self.context.api.flow_writer_open_grain(
-                self.writer,
+                self.writer.as_ptr(),
                 index,
                 &mut grain_info,
                 &mut payload_ptr,
@@ -50,34 +54,9 @@ impl GrainWriter {
 
         Ok(GrainWriteAccess::new(
             self.context.clone(),
-            self.writer,
+            self.writer.as_ref(),
             grain_info,
             payload_ptr,
         ))
-    }
-
-    fn destroy_inner(&mut self) -> Result<()> {
-        if self.writer.is_null() {
-            return Err(Error::InvalidArg);
-        }
-
-        let mut writer = std::ptr::null_mut();
-        std::mem::swap(&mut self.writer, &mut writer);
-
-        Error::from_status(unsafe {
-            self.context
-                .api
-                .release_flow_writer(self.context.instance, writer)
-        })
-    }
-}
-
-impl Drop for GrainWriter {
-    fn drop(&mut self) {
-        if !self.writer.is_null()
-            && let Err(err) = self.destroy_inner()
-        {
-            tracing::error!("Failed to release MXL flow writer (discrete): {:?}", err);
-        }
     }
 }

--- a/rust/mxl/src/grain/writer.rs
+++ b/rust/mxl/src/grain/writer.rs
@@ -5,11 +5,10 @@ use std::sync::Arc;
 
 use super::write_access::GrainWriteAccess;
 
-use crate::{Error, Result, instance::InstanceContext, writer::FlowWriterInstance};
+use crate::{Error, Result, writer::FlowWriterInstance};
 
 /// MXL Flow Writer for discrete flows (grain-based data like video frames)
 pub struct GrainWriter {
-    context: Arc<InstanceContext>,
     writer: Arc<FlowWriterInstance>,
 }
 
@@ -18,13 +17,13 @@ pub struct GrainWriter {
 unsafe impl Send for GrainWriter {}
 
 impl GrainWriter {
-    pub(crate) fn new(context: Arc<InstanceContext>, writer: Arc<FlowWriterInstance>) -> Self {
-        Self { context, writer }
+    pub(crate) fn new(writer: Arc<FlowWriterInstance>) -> Self {
+        Self { writer }
     }
 
     #[deprecated(
         since = "0.2.0",
-        note = "The MXL FlowWriter lifetime is now automatically managed internally. You should not be calling destroy() on it anymore. This function is now a no-op and will be removed in a future version."
+        note = "Flow writer lifetimes are now managed automatically. This method only consumes the handle and always returns `Ok(())`; the underlying writer is released when the last related handle is dropped."
     )]
     pub fn destroy(self) -> Result<()> {
         Ok(())
@@ -38,7 +37,7 @@ impl GrainWriter {
         let mut grain_info: mxl_sys::GrainInfo = unsafe { std::mem::zeroed() };
         let mut payload_ptr: *mut u8 = std::ptr::null_mut();
         unsafe {
-            Error::from_status(self.context.api.flow_writer_open_grain(
+            Error::from_status(self.writer.context.api.flow_writer_open_grain(
                 self.writer.as_ptr(),
                 index,
                 &mut grain_info,
@@ -53,7 +52,6 @@ impl GrainWriter {
         }
 
         Ok(GrainWriteAccess::new(
-            self.context.clone(),
             self.writer.as_ref(),
             grain_info,
             payload_ptr,

--- a/rust/mxl/src/instance.rs
+++ b/rust/mxl/src/instance.rs
@@ -5,7 +5,7 @@ use std::{ffi::CString, sync::Arc};
 
 use crate::{
     Error, FlowConfigInfo, FlowReader, FlowWriter, Result, api::MxlApiHandle,
-    reader::FlowReaderInstance, writer::FlowWriterInstance,
+    reader::FlowReaderResource, writer::FlowWriterResource,
 };
 
 /// This struct stores the context that is shared by all objects.
@@ -65,7 +65,7 @@ impl MxlInstance {
     }
 
     pub fn create_flow_reader(&self, flow_id: &str) -> Result<FlowReader> {
-        let reader = FlowReaderInstance::new(self.context.clone(), flow_id)?;
+        let reader = FlowReaderResource::new(self.context.clone(), flow_id)?;
         Ok(FlowReader::new(reader))
     }
 
@@ -75,7 +75,7 @@ impl MxlInstance {
         options: Option<&str>,
     ) -> Result<(FlowWriter, FlowConfigInfo, bool)> {
         let (writer, info, was_created) =
-            FlowWriterInstance::new(self.context.clone(), flow_def, options)?;
+            FlowWriterResource::new(self.context.clone(), flow_def, options)?;
 
         Ok((FlowWriter::new(writer, info.clone()), info, was_created))
     }

--- a/rust/mxl/src/instance.rs
+++ b/rust/mxl/src/instance.rs
@@ -3,7 +3,10 @@
 
 use std::{ffi::CString, sync::Arc};
 
-use crate::{Error, FlowConfigInfo, FlowReader, FlowWriter, Result, api::MxlApiHandle};
+use crate::{
+    Error, FlowConfigInfo, FlowReader, FlowWriter, Result, api::MxlApiHandle,
+    reader::FlowReaderInstance, writer::FlowWriterInstance,
+};
 
 /// This struct stores the context that is shared by all objects.
 /// It is separated out from `MxlInstance` so that it can be cloned
@@ -40,27 +43,6 @@ impl Drop for InstanceContext {
     }
 }
 
-pub(crate) fn create_flow_reader(
-    context: &Arc<InstanceContext>,
-    flow_id: &str,
-) -> Result<FlowReader> {
-    let flow_id = CString::new(flow_id)?;
-    let options = CString::new("")?;
-    let mut reader: mxl_sys::FlowReader = std::ptr::null_mut();
-    unsafe {
-        Error::from_status(context.api.create_flow_reader(
-            context.instance,
-            flow_id.as_ptr(),
-            options.as_ptr(),
-            &mut reader,
-        ))?;
-    }
-    if reader.is_null() {
-        return Err(Error::Other("Failed to create flow reader.".to_string()));
-    }
-    Ok(FlowReader::new(context.clone(), reader))
-}
-
 #[derive(Clone)]
 pub struct MxlInstance {
     context: Arc<InstanceContext>,
@@ -83,7 +65,8 @@ impl MxlInstance {
     }
 
     pub fn create_flow_reader(&self, flow_id: &str) -> Result<FlowReader> {
-        create_flow_reader(&self.context, flow_id)
+        let reader = FlowReaderInstance::new(self.context.clone(), flow_id)?;
+        Ok(FlowReader::new(self.context.clone(), reader))
     }
 
     pub fn create_flow_writer(
@@ -91,34 +74,12 @@ impl MxlInstance {
         flow_def: &str,
         options: Option<&str>,
     ) -> Result<(FlowWriter, FlowConfigInfo, bool)> {
-        let flow_def = CString::new(flow_def)?;
-        let options = options.map(CString::new).transpose()?;
-        let mut writer: mxl_sys::FlowWriter = std::ptr::null_mut();
-        let mut info_unsafe = std::mem::MaybeUninit::<mxl_sys::FlowConfigInfo>::uninit();
-        let mut was_created = false;
-        unsafe {
-            Error::from_status(self.context.api.create_flow_writer(
-                self.context.instance,
-                flow_def.as_ptr(),
-                options.map(|cs| cs.as_ptr()).unwrap_or(std::ptr::null()),
-                &mut writer,
-                info_unsafe.as_mut_ptr(),
-                &mut was_created,
-            ))?;
-        }
-        if writer.is_null() {
-            return Err(Error::Other("Failed to create flow writer.".to_string()));
-        }
-
-        let info = unsafe { info_unsafe.assume_init() };
+        let (writer, info, was_created) =
+            FlowWriterInstance::new(self.context.clone(), flow_def, options)?;
 
         Ok((
-            FlowWriter::new(
-                self.context.clone(),
-                writer,
-                uuid::Uuid::from_bytes(info.common.id),
-            ),
-            FlowConfigInfo { value: info },
+            FlowWriter::new(self.context.clone(), writer, info.clone()),
+            info,
             was_created,
         ))
     }

--- a/rust/mxl/src/instance.rs
+++ b/rust/mxl/src/instance.rs
@@ -66,7 +66,7 @@ impl MxlInstance {
 
     pub fn create_flow_reader(&self, flow_id: &str) -> Result<FlowReader> {
         let reader = FlowReaderInstance::new(self.context.clone(), flow_id)?;
-        Ok(FlowReader::new(self.context.clone(), reader))
+        Ok(FlowReader::new(reader))
     }
 
     pub fn create_flow_writer(
@@ -77,11 +77,7 @@ impl MxlInstance {
         let (writer, info, was_created) =
             FlowWriterInstance::new(self.context.clone(), flow_def, options)?;
 
-        Ok((
-            FlowWriter::new(self.context.clone(), writer, info.clone()),
-            info,
-            was_created,
-        ))
+        Ok((FlowWriter::new(writer, info.clone()), info, was_created))
     }
 
     pub fn get_flow_def(&self, flow_id: &str) -> Result<String> {

--- a/rust/mxl/src/samples/reader.rs
+++ b/rust/mxl/src/samples/reader.rs
@@ -10,11 +10,12 @@ use crate::{
         reader::{get_config_info, get_flow_info, get_runtime_info},
     },
     instance::InstanceContext,
+    reader::FlowReaderInstance,
 };
 
 pub struct SamplesReader {
     context: Arc<InstanceContext>,
-    reader: mxl_sys::FlowReader,
+    reader: Arc<FlowReaderInstance>,
 }
 
 /// The MXL readers and writers are not thread-safe, so we do not implement `Sync` for them, but
@@ -22,26 +23,30 @@ pub struct SamplesReader {
 unsafe impl Send for SamplesReader {}
 
 impl SamplesReader {
-    pub(crate) fn new(context: Arc<InstanceContext>, reader: mxl_sys::FlowReader) -> Self {
+    pub(crate) fn new(context: Arc<InstanceContext>, reader: Arc<FlowReaderInstance>) -> Self {
         Self { context, reader }
     }
 
-    pub fn destroy(mut self) -> Result<()> {
-        self.destroy_inner()
+    #[deprecated(
+        since = "0.2.0",
+        note = "The MXL FlowWriter lifetime is now automatically managed internally. You should not be calling destroy() on it anymore. This function is a no-op and will be removed in a future version."
+    )]
+    pub fn destroy(self) -> Result<()> {
+        Ok(())
     }
 
     /// The whole FlowInfo is quite a chunk of data. Go for `get_config_info` or `get_runtime_info`
     /// if they contain what you need.
     pub fn get_info(&self) -> Result<FlowInfo> {
-        get_flow_info(&self.context, self.reader)
+        get_flow_info(&self.context, self.reader.as_ptr())
     }
 
     pub fn get_config_info(&self) -> Result<FlowConfigInfo> {
-        get_config_info(&self.context, self.reader)
+        get_config_info(&self.context, self.reader.as_ptr())
     }
 
     pub fn get_runtime_info(&self) -> Result<mxl_sys::FlowRuntimeInfo> {
-        get_runtime_info(&self.context, self.reader)
+        get_runtime_info(&self.context, self.reader.as_ptr())
     }
 
     pub fn get_samples(
@@ -54,7 +59,7 @@ impl SamplesReader {
         let mut buffer_slice: mxl_sys::WrappedMultiBufferSlice = unsafe { std::mem::zeroed() };
         unsafe {
             Error::from_status(self.context.api.flow_reader_get_samples(
-                self.reader,
+                self.reader.as_ptr(),
                 index,
                 count,
                 timeout_ns,
@@ -68,37 +73,12 @@ impl SamplesReader {
         let mut buffer_slice: mxl_sys::WrappedMultiBufferSlice = unsafe { std::mem::zeroed() };
         unsafe {
             Error::from_status(self.context.api.flow_reader_get_samples_non_blocking(
-                self.reader,
+                self.reader.as_ptr(),
                 index,
                 count,
                 &mut buffer_slice,
             ))?;
         }
         Ok(SamplesData::new(buffer_slice))
-    }
-
-    fn destroy_inner(&mut self) -> Result<()> {
-        if self.reader.is_null() {
-            return Err(Error::InvalidArg);
-        }
-
-        let mut reader = std::ptr::null_mut();
-        std::mem::swap(&mut self.reader, &mut reader);
-
-        Error::from_status(unsafe {
-            self.context
-                .api
-                .release_flow_reader(self.context.instance, reader)
-        })
-    }
-}
-
-impl Drop for SamplesReader {
-    fn drop(&mut self) {
-        if !self.reader.is_null()
-            && let Err(err) = self.destroy_inner()
-        {
-            tracing::error!("Failed to release MXL flow reader (continuous): {:?}", err);
-        }
     }
 }

--- a/rust/mxl/src/samples/reader.rs
+++ b/rust/mxl/src/samples/reader.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2025 2025 Contributors to the Media eXchange Layer project.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{sync::Arc, time::Duration};
+use std::{cell::Cell, marker::PhantomData, sync::Arc, time::Duration};
 
 use crate::{
     Error, Result, SamplesData,
@@ -9,20 +9,26 @@ use crate::{
         FlowConfigInfo, FlowInfo,
         reader::{get_config_info, get_flow_info, get_runtime_info},
     },
-    reader::FlowReaderInstance,
+    reader::{FlowReaderResource, FlowReaderResourceKeepAlive},
 };
 
 pub struct SamplesReader {
-    reader: Arc<FlowReaderInstance>,
+    reader: Arc<FlowReaderResource>,
+    _not_sync: PhantomData<Cell<()>>, // Prevent Sync implementation, as the underlying MXL reader
+                                      // is not thread-safe.
 }
 
-/// The MXL readers and writers are not thread-safe, so we do not implement `Sync` for them, but
-/// there is no reason to not implement `Send`.
-unsafe impl Send for SamplesReader {}
-
 impl SamplesReader {
-    pub(crate) fn new(reader: Arc<FlowReaderInstance>) -> Self {
-        Self { reader }
+    pub(crate) fn new(reader: Arc<FlowReaderResource>) -> Self {
+        Self {
+            reader,
+            _not_sync: PhantomData,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn keep_alive(&self) -> FlowReaderResourceKeepAlive {
+        self.reader.keep_alive()
     }
 
     #[deprecated(
@@ -36,15 +42,15 @@ impl SamplesReader {
     /// The whole FlowInfo is quite a chunk of data. Go for `get_config_info` or `get_runtime_info`
     /// if they contain what you need.
     pub fn get_info(&self) -> Result<FlowInfo> {
-        get_flow_info(&self.reader.context, self.reader.as_ptr())
+        get_flow_info(&self.reader.context, unsafe { self.reader.as_ptr() })
     }
 
     pub fn get_config_info(&self) -> Result<FlowConfigInfo> {
-        get_config_info(&self.reader.context, self.reader.as_ptr())
+        get_config_info(&self.reader.context, unsafe { self.reader.as_ptr() })
     }
 
     pub fn get_runtime_info(&self) -> Result<mxl_sys::FlowRuntimeInfo> {
-        get_runtime_info(&self.reader.context, self.reader.as_ptr())
+        get_runtime_info(&self.reader.context, unsafe { self.reader.as_ptr() })
     }
 
     pub fn get_samples(

--- a/rust/mxl/src/samples/reader.rs
+++ b/rust/mxl/src/samples/reader.rs
@@ -9,12 +9,10 @@ use crate::{
         FlowConfigInfo, FlowInfo,
         reader::{get_config_info, get_flow_info, get_runtime_info},
     },
-    instance::InstanceContext,
     reader::FlowReaderInstance,
 };
 
 pub struct SamplesReader {
-    context: Arc<InstanceContext>,
     reader: Arc<FlowReaderInstance>,
 }
 
@@ -23,13 +21,13 @@ pub struct SamplesReader {
 unsafe impl Send for SamplesReader {}
 
 impl SamplesReader {
-    pub(crate) fn new(context: Arc<InstanceContext>, reader: Arc<FlowReaderInstance>) -> Self {
-        Self { context, reader }
+    pub(crate) fn new(reader: Arc<FlowReaderInstance>) -> Self {
+        Self { reader }
     }
 
     #[deprecated(
         since = "0.2.0",
-        note = "The MXL FlowWriter lifetime is now automatically managed internally. You should not be calling destroy() on it anymore. This function is a no-op and will be removed in a future version."
+        note = "Flow reader lifetimes are now managed automatically. This method only consumes the handle and always returns `Ok(())`; the underlying reader is released when the last related handle is dropped."
     )]
     pub fn destroy(self) -> Result<()> {
         Ok(())
@@ -38,15 +36,15 @@ impl SamplesReader {
     /// The whole FlowInfo is quite a chunk of data. Go for `get_config_info` or `get_runtime_info`
     /// if they contain what you need.
     pub fn get_info(&self) -> Result<FlowInfo> {
-        get_flow_info(&self.context, self.reader.as_ptr())
+        get_flow_info(&self.reader.context, self.reader.as_ptr())
     }
 
     pub fn get_config_info(&self) -> Result<FlowConfigInfo> {
-        get_config_info(&self.context, self.reader.as_ptr())
+        get_config_info(&self.reader.context, self.reader.as_ptr())
     }
 
     pub fn get_runtime_info(&self) -> Result<mxl_sys::FlowRuntimeInfo> {
-        get_runtime_info(&self.context, self.reader.as_ptr())
+        get_runtime_info(&self.reader.context, self.reader.as_ptr())
     }
 
     pub fn get_samples(
@@ -58,7 +56,7 @@ impl SamplesReader {
         let timeout_ns = timeout.as_nanos() as u64;
         let mut buffer_slice: mxl_sys::WrappedMultiBufferSlice = unsafe { std::mem::zeroed() };
         unsafe {
-            Error::from_status(self.context.api.flow_reader_get_samples(
+            Error::from_status(self.reader.context.api.flow_reader_get_samples(
                 self.reader.as_ptr(),
                 index,
                 count,
@@ -72,12 +70,17 @@ impl SamplesReader {
     pub fn get_samples_non_blocking(&self, index: u64, count: usize) -> Result<SamplesData<'_>> {
         let mut buffer_slice: mxl_sys::WrappedMultiBufferSlice = unsafe { std::mem::zeroed() };
         unsafe {
-            Error::from_status(self.context.api.flow_reader_get_samples_non_blocking(
-                self.reader.as_ptr(),
-                index,
-                count,
-                &mut buffer_slice,
-            ))?;
+            Error::from_status(
+                self.reader
+                    .context
+                    .api
+                    .flow_reader_get_samples_non_blocking(
+                        self.reader.as_ptr(),
+                        index,
+                        count,
+                        &mut buffer_slice,
+                    ),
+            )?;
         }
         Ok(SamplesData::new(buffer_slice))
     }

--- a/rust/mxl/src/samples/write_access.rs
+++ b/rust/mxl/src/samples/write_access.rs
@@ -3,7 +3,7 @@
 
 use tracing::error;
 
-use crate::{Error, writer::FlowWriterInstance};
+use crate::{Error, writer::FlowWriterResource};
 
 /// RAII samples writing session
 ///
@@ -12,7 +12,7 @@ use crate::{Error, writer::FlowWriterInstance};
 /// The data may be split into 2 different buffer slices in case of a wrapped ring. Provides access
 /// either directly to the slices or to individual samples by index inside the batch.
 pub struct SamplesWriteAccess<'a> {
-    writer: &'a FlowWriterInstance,
+    writer: &'a FlowWriterResource,
     buffer_slice: mxl_sys::MutableWrappedMultiBufferSlice,
     /// Serves as a flag to know whether to cancel the samples on drop.
     committed_or_canceled: bool,
@@ -20,7 +20,7 @@ pub struct SamplesWriteAccess<'a> {
 
 impl<'a> SamplesWriteAccess<'a> {
     pub(crate) fn new(
-        writer: &'a FlowWriterInstance,
+        writer: &'a FlowWriterResource,
         buffer_slice: mxl_sys::MutableWrappedMultiBufferSlice,
     ) -> Self {
         Self {

--- a/rust/mxl/src/samples/write_access.rs
+++ b/rust/mxl/src/samples/write_access.rs
@@ -1,11 +1,11 @@
 // SPDX-FileCopyrightText: 2025 2025 Contributors to the Media eXchange Layer project.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{marker::PhantomData, sync::Arc};
+use std::sync::Arc;
 
 use tracing::error;
 
-use crate::{Error, instance::InstanceContext};
+use crate::{Error, instance::InstanceContext, writer::FlowWriterInstance};
 
 /// RAII samples writing session
 ///
@@ -15,17 +15,16 @@ use crate::{Error, instance::InstanceContext};
 /// either directly to the slices or to individual samples by index inside the batch.
 pub struct SamplesWriteAccess<'a> {
     context: Arc<InstanceContext>,
-    writer: mxl_sys::FlowWriter,
+    writer: &'a FlowWriterInstance,
     buffer_slice: mxl_sys::MutableWrappedMultiBufferSlice,
     /// Serves as a flag to know whether to cancel the samples on drop.
     committed_or_canceled: bool,
-    phantom: PhantomData<&'a ()>,
 }
 
 impl<'a> SamplesWriteAccess<'a> {
     pub(crate) fn new(
         context: Arc<InstanceContext>,
-        writer: mxl_sys::FlowWriter,
+        writer: &'a FlowWriterInstance,
         buffer_slice: mxl_sys::MutableWrappedMultiBufferSlice,
     ) -> Self {
         Self {
@@ -33,14 +32,19 @@ impl<'a> SamplesWriteAccess<'a> {
             writer,
             buffer_slice,
             committed_or_canceled: false,
-            phantom: PhantomData,
         }
     }
 
     pub fn commit(mut self) -> crate::Result<()> {
         self.committed_or_canceled = true;
 
-        unsafe { Error::from_status(self.context.api.flow_writer_commit_samples(self.writer)) }
+        unsafe {
+            Error::from_status(
+                self.context
+                    .api
+                    .flow_writer_commit_samples(self.writer.as_ptr()),
+            )
+        }
     }
 
     /// Please note that the behavior of canceling samples writing is dependent on the behavior
@@ -50,7 +54,13 @@ impl<'a> SamplesWriteAccess<'a> {
     pub fn cancel(mut self) -> crate::Result<()> {
         self.committed_or_canceled = true;
 
-        unsafe { Error::from_status(self.context.api.flow_writer_cancel_samples(self.writer)) }
+        unsafe {
+            Error::from_status(
+                self.context
+                    .api
+                    .flow_writer_cancel_samples(self.writer.as_ptr()),
+            )
+        }
     }
 
     pub fn channels(&self) -> usize {
@@ -87,7 +97,11 @@ impl<'a> Drop for SamplesWriteAccess<'a> {
     fn drop(&mut self) {
         if !self.committed_or_canceled
             && let Err(error) = unsafe {
-                Error::from_status(self.context.api.flow_writer_cancel_samples(self.writer))
+                Error::from_status(
+                    self.context
+                        .api
+                        .flow_writer_cancel_samples(self.writer.as_ptr()),
+                )
             }
         {
             error!("Failed to cancel grain write on drop: {:?}", error);

--- a/rust/mxl/src/samples/write_access.rs
+++ b/rust/mxl/src/samples/write_access.rs
@@ -1,11 +1,9 @@
 // SPDX-FileCopyrightText: 2025 2025 Contributors to the Media eXchange Layer project.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
-
 use tracing::error;
 
-use crate::{Error, instance::InstanceContext, writer::FlowWriterInstance};
+use crate::{Error, writer::FlowWriterInstance};
 
 /// RAII samples writing session
 ///
@@ -14,7 +12,6 @@ use crate::{Error, instance::InstanceContext, writer::FlowWriterInstance};
 /// The data may be split into 2 different buffer slices in case of a wrapped ring. Provides access
 /// either directly to the slices or to individual samples by index inside the batch.
 pub struct SamplesWriteAccess<'a> {
-    context: Arc<InstanceContext>,
     writer: &'a FlowWriterInstance,
     buffer_slice: mxl_sys::MutableWrappedMultiBufferSlice,
     /// Serves as a flag to know whether to cancel the samples on drop.
@@ -23,12 +20,10 @@ pub struct SamplesWriteAccess<'a> {
 
 impl<'a> SamplesWriteAccess<'a> {
     pub(crate) fn new(
-        context: Arc<InstanceContext>,
         writer: &'a FlowWriterInstance,
         buffer_slice: mxl_sys::MutableWrappedMultiBufferSlice,
     ) -> Self {
         Self {
-            context,
             writer,
             buffer_slice,
             committed_or_canceled: false,
@@ -40,7 +35,8 @@ impl<'a> SamplesWriteAccess<'a> {
 
         unsafe {
             Error::from_status(
-                self.context
+                self.writer
+                    .context
                     .api
                     .flow_writer_commit_samples(self.writer.as_ptr()),
             )
@@ -56,7 +52,8 @@ impl<'a> SamplesWriteAccess<'a> {
 
         unsafe {
             Error::from_status(
-                self.context
+                self.writer
+                    .context
                     .api
                     .flow_writer_cancel_samples(self.writer.as_ptr()),
             )
@@ -98,7 +95,8 @@ impl<'a> Drop for SamplesWriteAccess<'a> {
         if !self.committed_or_canceled
             && let Err(error) = unsafe {
                 Error::from_status(
-                    self.context
+                    self.writer
+                        .context
                         .api
                         .flow_writer_cancel_samples(self.writer.as_ptr()),
                 )

--- a/rust/mxl/src/samples/writer.rs
+++ b/rust/mxl/src/samples/writer.rs
@@ -3,13 +3,10 @@
 
 use std::sync::Arc;
 
-use crate::{
-    Error, Result, SamplesWriteAccess, instance::InstanceContext, writer::FlowWriterInstance,
-};
+use crate::{Error, Result, SamplesWriteAccess, writer::FlowWriterInstance};
 
 /// MXL Flow Writer for continuous flows (samples-based data like audio)
 pub struct SamplesWriter {
-    context: Arc<InstanceContext>,
     writer: Arc<FlowWriterInstance>,
 }
 
@@ -18,12 +15,12 @@ pub struct SamplesWriter {
 unsafe impl Send for SamplesWriter {}
 
 impl SamplesWriter {
-    pub(crate) fn new(context: Arc<InstanceContext>, writer: Arc<FlowWriterInstance>) -> Self {
-        Self { context, writer }
+    pub(crate) fn new(writer: Arc<FlowWriterInstance>) -> Self {
+        Self { writer }
     }
     #[deprecated(
         since = "0.2.0",
-        note = "The MXL FlowWriter lifetime is now automatically managed internally. You should not be calling destroy() on it anymore. This function is a no-op and will be removed in a future version."
+        note = "Flow writer lifetimes are now managed automatically. This method only consumes the handle and always returns `Ok(())`; the underlying writer is released when the last related handle is dropped."
     )]
     pub fn destroy(self) -> Result<()> {
         Ok(())
@@ -33,17 +30,13 @@ impl SamplesWriter {
         let mut buffer_slice: mxl_sys::MutableWrappedMultiBufferSlice =
             unsafe { std::mem::zeroed() };
         unsafe {
-            Error::from_status(self.context.api.flow_writer_open_samples(
+            Error::from_status(self.writer.context.api.flow_writer_open_samples(
                 self.writer.as_ptr(),
                 index,
                 count,
                 &mut buffer_slice,
             ))?;
         }
-        Ok(SamplesWriteAccess::new(
-            self.context.clone(),
-            self.writer.as_ref(),
-            buffer_slice,
-        ))
+        Ok(SamplesWriteAccess::new(self.writer.as_ref(), buffer_slice))
     }
 }

--- a/rust/mxl/src/samples/writer.rs
+++ b/rust/mxl/src/samples/writer.rs
@@ -1,23 +1,33 @@
 // SPDX-FileCopyrightText: 2025 2025 Contributors to the Media eXchange Layer project.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
+use std::{cell::Cell, marker::PhantomData, sync::Arc};
 
-use crate::{Error, Result, SamplesWriteAccess, writer::FlowWriterInstance};
+use crate::{
+    Error, Result, SamplesWriteAccess,
+    writer::{FlowWriterResource, FlowWriterResourceKeepAlive},
+};
 
 /// MXL Flow Writer for continuous flows (samples-based data like audio)
 pub struct SamplesWriter {
-    writer: Arc<FlowWriterInstance>,
+    writer: Arc<FlowWriterResource>,
+    _not_sync: PhantomData<Cell<()>>, // Prevent Sync implementation, as the underlying MXL writer
+                                      // is not thread-safe
 }
 
-/// The MXL readers and writers are not thread-safe, so we do not implement `Sync` for them, but
-/// there is no reason to not implement `Send`.
-unsafe impl Send for SamplesWriter {}
-
 impl SamplesWriter {
-    pub(crate) fn new(writer: Arc<FlowWriterInstance>) -> Self {
-        Self { writer }
+    pub(crate) fn new(writer: Arc<FlowWriterResource>) -> Self {
+        Self {
+            writer,
+            _not_sync: PhantomData,
+        }
     }
+
+    #[allow(dead_code)]
+    pub(crate) fn keep_alive(&self) -> FlowWriterResourceKeepAlive {
+        self.writer.keep_alive()
+    }
+
     #[deprecated(
         since = "0.2.0",
         note = "Flow writer lifetimes are now managed automatically. This method only consumes the handle and always returns `Ok(())`; the underlying writer is released when the last related handle is dropped."

--- a/rust/mxl/src/samples/writer.rs
+++ b/rust/mxl/src/samples/writer.rs
@@ -3,12 +3,14 @@
 
 use std::sync::Arc;
 
-use crate::{Error, Result, SamplesWriteAccess, instance::InstanceContext};
+use crate::{
+    Error, Result, SamplesWriteAccess, instance::InstanceContext, writer::FlowWriterInstance,
+};
 
 /// MXL Flow Writer for continuous flows (samples-based data like audio)
 pub struct SamplesWriter {
     context: Arc<InstanceContext>,
-    writer: mxl_sys::FlowWriter,
+    writer: Arc<FlowWriterInstance>,
 }
 
 /// The MXL readers and writers are not thread-safe, so we do not implement `Sync` for them, but
@@ -16,12 +18,15 @@ pub struct SamplesWriter {
 unsafe impl Send for SamplesWriter {}
 
 impl SamplesWriter {
-    pub(crate) fn new(context: Arc<InstanceContext>, writer: mxl_sys::FlowWriter) -> Self {
+    pub(crate) fn new(context: Arc<InstanceContext>, writer: Arc<FlowWriterInstance>) -> Self {
         Self { context, writer }
     }
-
-    pub fn destroy(mut self) -> Result<()> {
-        self.destroy_inner()
+    #[deprecated(
+        since = "0.2.0",
+        note = "The MXL FlowWriter lifetime is now automatically managed internally. You should not be calling destroy() on it anymore. This function is a no-op and will be removed in a future version."
+    )]
+    pub fn destroy(self) -> Result<()> {
+        Ok(())
     }
 
     pub fn open_samples<'a>(&'a self, index: u64, count: usize) -> Result<SamplesWriteAccess<'a>> {
@@ -29,7 +34,7 @@ impl SamplesWriter {
             unsafe { std::mem::zeroed() };
         unsafe {
             Error::from_status(self.context.api.flow_writer_open_samples(
-                self.writer,
+                self.writer.as_ptr(),
                 index,
                 count,
                 &mut buffer_slice,
@@ -37,33 +42,8 @@ impl SamplesWriter {
         }
         Ok(SamplesWriteAccess::new(
             self.context.clone(),
-            self.writer,
+            self.writer.as_ref(),
             buffer_slice,
         ))
-    }
-
-    fn destroy_inner(&mut self) -> Result<()> {
-        if self.writer.is_null() {
-            return Err(Error::InvalidArg);
-        }
-
-        let mut writer = std::ptr::null_mut();
-        std::mem::swap(&mut self.writer, &mut writer);
-
-        Error::from_status(unsafe {
-            self.context
-                .api
-                .release_flow_writer(self.context.instance, writer)
-        })
-    }
-}
-
-impl Drop for SamplesWriter {
-    fn drop(&mut self) {
-        if !self.writer.is_null()
-            && let Err(err) = self.destroy_inner()
-        {
-            tracing::error!("Failed to release MXL flow writer (continuous): {:?}", err);
-        }
     }
 }

--- a/rust/mxl/tests/basic_tests.rs
+++ b/rust/mxl/tests/basic_tests.rs
@@ -107,9 +107,6 @@ fn basic_mxl_grain_writing_reading() {
         .unwrap();
     let grain_data: OwnedGrainData = grain_data.into();
     info!("Grain data len: {:?}", grain_data.payload.len());
-    grain_reader.destroy().unwrap();
-    grain_writer.destroy().unwrap();
-    mxl_instance.destroy().unwrap();
 }
 
 #[test]
@@ -139,9 +136,6 @@ fn basic_mxl_samples_writing_reading() {
         samples_data.payload.len(),
         samples_data.payload[0].len()
     );
-    samples_reader.destroy().unwrap();
-    samples_writer.destroy().unwrap();
-    mxl_instance.destroy().unwrap();
 }
 
 #[test]
@@ -156,7 +150,6 @@ fn get_flow_def() {
     let retrieved_flow_def = mxl_instance.get_flow_def(flow_id.as_str()).unwrap();
     assert_eq!(flow_def, retrieved_flow_def);
     drop(flow_writer);
-    mxl_instance.destroy().unwrap();
 }
 
 #[test]
@@ -167,5 +160,4 @@ fn garbage_collect_flows_succeeds() {
     // without crashing and propagates a successful status.
     let (mxl_instance, _domain_guard) = setup_test("garbage_collect_flows");
     mxl_instance.garbage_collect_flows().unwrap();
-    mxl_instance.destroy().unwrap();
 }


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2026 Contributors to the Media eXchange Layer project. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- Before submitting a pull request, please check that:
- it has a suitably descriptive title
- it mentions any issue(s) that it addresses
- you have considered whether it should be backported (specify how far back below)
- any required regression tests have run successfully
- all commits are signed-off: see [here](https://github.com/dmf-mxl/mxl/blob/main/CONTRIBUTING.md#commit-sign-off) for more information
-->

# Details

Add shared wrappers around the native flow reader and writer handles to manage their lifetimes automatically. These wrappers can also be shared with future Fabric API objects, such as Target and Initiator, ensuring that the underlying handles remain valid for as long as they are needed.

This change deprecates the explicit destroy() methods and changes their behavior. Calling destroy() now consumes only the current Rust handle and always returns Ok(()); it does not necessarily release the underlying native handle immediately because other related objects may still reference it. The native handle is released automatically when its last owner is dropped.


# Backport requirements

v1.1