### PR TITLE
[Backport to release/v1.0] Fix discrete reader/writer tail conflict

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -49,6 +49,12 @@ See [timing model](./Timing.md)
 
 The MXL SDK provides two ringbuffer types: Discrete and Continuous.  Discrete ringbuffers are used for granular data types such as video and ancillary data.  Continuous ringbuffers are used for audio. 
 
+### Ring buffer access model
+
+Continuous: the tail half of the ring buffer is reserved for the writer, and readers can access the remaining half.
+
+Discrete: the tail entry of the ring buffer is reserved for the writer, and readers can access the remaining entries.
+
 ## Discrete Grain I/O
 
 Grain I/O can be 'partial'. In other words, a FlowWriter can write the bytes of a grain progressively (as slices for example).

--- a/lib/internal/src/PosixDiscreteFlowReader.cpp
+++ b/lib/internal/src/PosixDiscreteFlowReader.cpp
@@ -167,7 +167,14 @@ namespace mxl::lib
         if (auto const headIndex = flow->info.runtime.headIndex; in_index <= headIndex)
         {
             auto const grainCount = flow->info.config.discrete.grainCount;
-            auto const minIndex = (headIndex >= grainCount) ? (headIndex - grainCount + 1U) : std::uint64_t{0};
+
+            // Reserve the tail position for the writer. The +2U advances
+            // minIndex one position past the tail. Since the tail and
+            // headIndex+1 alias the same physical ring-buffer position,
+            // this hides uncommitted headIndex+1 write state from
+            // readers.
+            auto const minIndex = (headIndex >= grainCount) ? (headIndex - grainCount + 2U) : std::uint64_t{0};
+
             if (in_index >= minIndex)
             {
                 auto const offset = in_index % grainCount;

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ target_sources(mxl-tests
             test_flows_timing.cpp
             test_instance.cpp
             test_time.cpp
+            test_read_write_conflict.cpp
     )
 
 target_link_libraries(mxl-tests

--- a/lib/tests/test_read_write_conflict.cpp
+++ b/lib/tests/test_read_write_conflict.cpp
@@ -1,0 +1,335 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include <limits>
+#include <string>
+#include <catch2/catch_test_macros.hpp>
+#include <mxl/flow.h>
+#include <mxl/mxl.h>
+#include <mxl/time.h>
+#include "Utils.hpp"
+
+/*
+  This test verifies that a read request for the ring buffer's
+  tailIndex grain returns TOO_LATE when the writer has a write
+  operation open at headIndex+1.
+
+  +-----------+-- --+-------------+-----------+-------------+--
+  | index  0  |     | index N-2   | index N-1 |  index 0    |
+  | tailIndex | ... | headIndex-1 | headIndex | headIndex+1 | ...
+  +-----------+-- --+-------------+-----------+-------------+--
+                                              ^
+                                              ring wrap
+
+   N = grainCount
+
+   The diagram illustrates that tailIndex and headIndex+1 address the
+   same ring-buffer index.
+
+   Note: index 0 is used here for illustration. The actual ring-buffer
+   starting index is tailIndex % grainCount.
+*/
+TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Video Flow : tail read during open write", "[mxl flows]")
+{
+    auto const flowId = "5fbec3b1-1b0f-417d-9059-8b94a47197ed";
+    auto const flowDef = mxl::tests::readFile("data/v210_flow.json");
+
+    // Init the domain instance.
+    auto instance = mxlCreateInstance(domain.string().c_str(), "");
+    REQUIRE(instance != nullptr);
+
+    // Init a flow writer.
+    auto writer = mxlFlowWriter{};
+    auto configInfo = mxlFlowConfigInfo{};
+    auto flowWasCreated = false;
+
+    REQUIRE(mxlCreateFlowWriter(instance, flowDef.c_str(), "", &writer, &configInfo, &flowWasCreated) == MXL_STATUS_OK);
+    REQUIRE(flowWasCreated);
+
+    // Init headIndex from the current MXL time.
+    auto const now = mxlGetTime();
+    auto headIndex = mxlTimestampToIndex(&configInfo.common.grainRate, now);
+    REQUIRE(headIndex != MXL_UNDEFINED_INDEX);
+
+    auto const grainCount = static_cast<std::uint64_t>(configInfo.discrete.grainCount);
+
+    REQUIRE(grainCount > 1U);
+    REQUIRE(headIndex > grainCount);
+
+    // Init each grain in the ring buffer.
+    auto tailIndex = headIndex - grainCount + 1;
+    for (auto i = std::uint64_t{0}; i < grainCount; ++i)
+    {
+        auto grainInfo = mxlGrainInfo{};
+        std::uint8_t* buffer = nullptr;
+
+        REQUIRE(mxlFlowWriterOpenGrain(writer, tailIndex + i, &grainInfo, &buffer) == MXL_STATUS_OK);
+
+        buffer[0] = 0xCA;
+        buffer[grainInfo.grainSize - 1] = 0xFE;
+        grainInfo.validSlices = grainInfo.totalSlices;
+
+        REQUIRE(mxlFlowWriterCommitGrain(writer, &grainInfo) == MXL_STATUS_OK);
+    }
+
+    // Init a reader and sanity check the flow's headIndex.
+    auto reader = mxlFlowReader{};
+    REQUIRE(mxlCreateFlowReader(instance, flowId, "", &reader) == MXL_STATUS_OK);
+
+    auto runtimeInfo = mxlFlowRuntimeInfo{};
+    REQUIRE(mxlFlowReaderGetRuntimeInfo(reader, &runtimeInfo) == MXL_STATUS_OK);
+    REQUIRE(runtimeInfo.headIndex == headIndex);
+
+    // Reading the tailIndex grain should be TOO_LATE when write is
+    // not in progress.
+    auto readGrainInfo = mxlGrainInfo{};
+    std::uint8_t* readBuffer = nullptr;
+    auto const grainReadStatusOutsideWrite = mxlFlowReaderGetGrainNonBlocking(reader, tailIndex, &readGrainInfo, &readBuffer);
+    {
+        INFO("The tailIndex grain read should return TOO_LATE even when no write "
+             "is in progress because the tail grain is reserved for the writer.");
+        CHECK(grainReadStatusOutsideWrite == MXL_ERR_OUT_OF_RANGE_TOO_LATE);
+    }
+
+    // Reading the tailIndex grain through the slice API should be
+    // TOO_LATE when write is not in progress.
+    readBuffer = nullptr;
+    readGrainInfo = {};
+    auto const sliceReadStatusOutsideWrite = mxlFlowReaderGetGrainSliceNonBlocking(reader, tailIndex, std::uint16_t{0}, &readGrainInfo, &readBuffer);
+    {
+        INFO("The tailIndex slice read should return TOO_LATE even when no write "
+             "is in progress because the tail grain is reserved for the writer.");
+        CHECK(sliceReadStatusOutsideWrite == MXL_ERR_OUT_OF_RANGE_TOO_LATE);
+    }
+
+    // Open a write to the next sequential grain at headIndex+1. This
+    // grain shares a ring-buffer position with the tailIndex grain.
+    auto writeGrainInfo = mxlGrainInfo{};
+    std::uint8_t* writeBuffer = nullptr;
+    {
+        REQUIRE(mxlFlowWriterOpenGrain(writer, headIndex + 1, &writeGrainInfo, &writeBuffer) == MXL_STATUS_OK);
+
+        INFO("The newly opened grain should identify headIndex+1.");
+        CAPTURE(writeGrainInfo.index, headIndex + 1, writeGrainInfo.validSlices, writeGrainInfo.totalSlices);
+        CHECK(writeGrainInfo.index == headIndex + 1);
+    }
+
+    // Sanity check: verify that headIndex has not yet moved.
+    REQUIRE(mxlFlowReaderGetRuntimeInfo(reader, &runtimeInfo) == MXL_STATUS_OK);
+    REQUIRE(runtimeInfo.headIndex == headIndex);
+
+    // Reading a grain at tailIndex during an open write of
+    // headIndex+1 should return TOO_LATE to prevent reader/writer
+    // conflict during the writer's open/commit interval.
+    constexpr auto NOT_CHANGED_INDEX_SENTINEL_VALUE = std::numeric_limits<decltype(readGrainInfo.index)>::max();
+    readBuffer = nullptr;
+    readGrainInfo = {};
+    readGrainInfo.index = NOT_CHANGED_INDEX_SENTINEL_VALUE;
+    auto const grainReadStatusInsideWrite = mxlFlowReaderGetGrainNonBlocking(reader, tailIndex, &readGrainInfo, &readBuffer);
+    {
+        INFO("A tailIndex read should return TOO_LATE while a write of "
+             "headIndex+1 is open because both logical grains alias the "
+             "same physical ring-buffer position."
+
+        );
+        CHECK(grainReadStatusInsideWrite == MXL_ERR_OUT_OF_RANGE_TOO_LATE);
+    }
+    {
+        INFO("Because the tailIndex grain read is expected to return TOO_LATE, "
+             "it should not return a payload or modify the grain index.");
+        CHECK(readBuffer == nullptr);
+        CHECK(readGrainInfo.index == NOT_CHANGED_INDEX_SENTINEL_VALUE);
+    }
+
+    // Reading tailIndex through the slice API during an open write of
+    // headIndex+1 should return TOO_LATE, should not return a payload,
+    // and should not modify readGrainInfo.validSlices.
+    constexpr auto NOT_CHANGED_SLICE_SENTINEL_VALUE = std::numeric_limits<decltype(readGrainInfo.validSlices)>::max();
+    readBuffer = nullptr;
+    readGrainInfo = {};
+    readGrainInfo.validSlices = NOT_CHANGED_SLICE_SENTINEL_VALUE;
+    auto const sliceReadStatus = mxlFlowReaderGetGrainSliceNonBlocking(reader, tailIndex, std::uint16_t{0}, &readGrainInfo, &readBuffer);
+    {
+        INFO("A tailIndex slice read should return TOO_LATE while a write of "
+             "headIndex+1 is open because both logical grains alias the "
+             "same physical ring-buffer position.");
+        CHECK(sliceReadStatus == MXL_ERR_OUT_OF_RANGE_TOO_LATE);
+    }
+    {
+        INFO("Because the tailIndex slice read is expected to return TOO_LATE, "
+             "it should not return a payload or modify validSlices.");
+        CHECK(readBuffer == nullptr);
+        CHECK(readGrainInfo.validSlices == NOT_CHANGED_SLICE_SENTINEL_VALUE);
+    }
+
+    // Commit the write and update local headIndex.
+    writeBuffer[0] = 0xCA;
+    writeBuffer[writeGrainInfo.grainSize - 1] = 0xFE;
+    writeGrainInfo.validSlices = writeGrainInfo.totalSlices;
+    REQUIRE(mxlFlowWriterCommitGrain(writer, &writeGrainInfo) == MXL_STATUS_OK);
+
+    headIndex = headIndex + 1;
+    tailIndex = headIndex - grainCount + 1;
+
+    // Sanity check local headIndex matches flow's headIndex.
+    REQUIRE(mxlFlowReaderGetRuntimeInfo(reader, &runtimeInfo) == MXL_STATUS_OK);
+    REQUIRE(runtimeInfo.headIndex == headIndex);
+
+    // Post commit read of the tailIndex grain should continue to be
+    // TOO_LATE.
+    readBuffer = nullptr;
+    readGrainInfo = {};
+    auto const grainReadStatusPostCommit = mxlFlowReaderGetGrainNonBlocking(reader, tailIndex, &readGrainInfo, &readBuffer);
+    {
+        INFO("A post commit tailIndex read should return TOO_LATE after a "
+             "write of headIndex+1 is committed because both logical grains "
+             "alias the same physical ring-buffer position.");
+        CHECK(grainReadStatusPostCommit == MXL_ERR_OUT_OF_RANGE_TOO_LATE);
+    }
+
+    // Tear down.
+    REQUIRE(mxlReleaseFlowReader(instance, reader) == MXL_STATUS_OK);
+
+    REQUIRE(mxlReleaseFlowWriter(instance, writer) == MXL_STATUS_OK);
+
+    REQUIRE(mxlDestroyInstance(instance) == MXL_STATUS_OK);
+}
+
+/*
+  This test verifies that the audio reader boundary between the
+  writer's half-ring and the reader's half-ring is enforced regardless
+  of whether the writer has a write operation open.
+
+  +--------------------------+--------------------------+--------------------------+--
+  | physical half 0          | physical half 1          | physical half 0          |
+  | writer's half-ring       | reader's half-ring       | writer's half-ring       | ...
+  +--------------------------+--------------------------+--------------------------+--
+  ^                          ^                          ^
+  ringTailIndex              boundaryIndex              headIndex
+                                                        ring wrap
+
+  ringTailIndex = headIndex - bufferLength + 1
+  boundaryIndex = headIndex - bufferLength/2 + 1
+
+  Reads at boundaryIndex are allowed. Reads at boundaryIndex-1 and
+  earlier are TOO_LATE.
+
+  Note: physical half 0/1 are used here to illustrate the two
+  half-ring regions and their reuse after ring wrap.
+*/
+TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Audio Flow : tail read during open write", "[mxl flows]")
+{
+    auto const flowId = "b3bb5be7-9fe9-4324-a5bb-4c70e1084449";
+    auto const flowDef = mxl::tests::readFile("data/audio_flow.json");
+
+    // Init the domain instance.
+    auto instance = mxlCreateInstance(domain.string().c_str(), "");
+    REQUIRE(instance != nullptr);
+
+    // Init a flow writer.
+    auto writer = mxlFlowWriter{};
+    auto configInfo = mxlFlowConfigInfo{};
+    auto flowWasCreated = false;
+
+    REQUIRE(mxlCreateFlowWriter(instance, flowDef.c_str(), "", &writer, &configInfo, &flowWasCreated) == MXL_STATUS_OK);
+    REQUIRE(flowWasCreated);
+
+    // Init headIndex from the current MXL time.
+    auto const now = mxlGetTime();
+    auto headIndex = mxlTimestampToIndex(&configInfo.common.grainRate, now);
+    REQUIRE(headIndex != MXL_UNDEFINED_INDEX);
+
+    auto const bufferLength = static_cast<std::uint64_t>(configInfo.continuous.bufferLength);
+    auto const halfBufferLength = bufferLength / 2U;
+
+    REQUIRE(halfBufferLength > 0U);
+    REQUIRE(headIndex > bufferLength);
+
+    // Init the full ring buffer using two sequential half-buffer
+    // writes ending at headIndex. Each write respects the writer's
+    // half-ring limit.
+    {
+        auto const boundaryIndex = headIndex - halfBufferLength + 1;
+        auto tmpWriteIndex = boundaryIndex - 1;
+        for (auto i = std::uint64_t{0}; i < 2U; ++i)
+        {
+            auto writeBuffer = mxlMutableWrappedMultiBufferSlice{};
+
+            REQUIRE(mxlFlowWriterOpenSamples(writer, tmpWriteIndex, halfBufferLength, &writeBuffer) == MXL_STATUS_OK);
+
+            REQUIRE(mxlFlowWriterCommitSamples(writer) == MXL_STATUS_OK);
+
+            tmpWriteIndex += halfBufferLength;
+        }
+    }
+
+    // Init a reader and sanity check the flow's headIndex.
+    auto reader = mxlFlowReader{};
+    REQUIRE(mxlCreateFlowReader(instance, flowId, "", &reader) == MXL_STATUS_OK);
+
+    auto runtimeInfo = mxlFlowRuntimeInfo{};
+    REQUIRE(mxlFlowReaderGetRuntimeInfo(reader, &runtimeInfo) == MXL_STATUS_OK);
+    REQUIRE(runtimeInfo.headIndex == headIndex);
+
+    // boundaryIndex separates the writer's half-ring from the reader's
+    // half-ring.
+    auto const boundaryIndex = headIndex - halfBufferLength + 1;
+    auto const ringTailIndex = headIndex - bufferLength + 1;
+
+    auto readBuffer = mxlWrappedMultiBufferSlice{};
+
+    // Reading at boundaryIndex is OK.
+    REQUIRE(mxlFlowReaderGetSamplesNonBlocking(reader, boundaryIndex, 1U, &readBuffer) == MXL_STATUS_OK);
+
+    // Reading one index before boundaryIndex is TOO_LATE.
+    readBuffer = {};
+    REQUIRE(mxlFlowReaderGetSamplesNonBlocking(reader, boundaryIndex - 1, 1U, &readBuffer) == MXL_ERR_OUT_OF_RANGE_TOO_LATE);
+
+    // Open a write to the next sequential half-buffer at
+    // headIndex+halfBufferLength. This does *not* overlap the
+    // reader's half-ring.
+    auto writeBuffer = mxlMutableWrappedMultiBufferSlice{};
+    REQUIRE(mxlFlowWriterOpenSamples(writer, headIndex + halfBufferLength, halfBufferLength, &writeBuffer) == MXL_STATUS_OK);
+
+    // Sanity check: verify that headIndex has not yet moved.
+    REQUIRE(mxlFlowReaderGetRuntimeInfo(reader, &runtimeInfo) == MXL_STATUS_OK);
+    REQUIRE(runtimeInfo.headIndex == headIndex);
+
+    // The reader boundary is unchanged while the write is open.
+    readBuffer = {};
+    REQUIRE(mxlFlowReaderGetSamplesNonBlocking(reader, boundaryIndex, 1U, &readBuffer) == MXL_STATUS_OK);
+
+    // A read at the tail is also in the writer's half-ring and should
+    // fail with TOO_LATE.
+    readBuffer = {};
+    REQUIRE(mxlFlowReaderGetSamplesNonBlocking(reader, ringTailIndex, 1U, &readBuffer) == MXL_ERR_OUT_OF_RANGE_TOO_LATE);
+
+    // A read just before boundaryIndex should also fail with
+    // TOO_LATE.
+    readBuffer = {};
+    REQUIRE(mxlFlowReaderGetSamplesNonBlocking(reader, boundaryIndex - 1, 1U, &readBuffer) == MXL_ERR_OUT_OF_RANGE_TOO_LATE);
+
+    // Commit the write and update local headIndex.
+    REQUIRE(mxlFlowWriterCommitSamples(writer) == MXL_STATUS_OK);
+
+    headIndex = headIndex + halfBufferLength;
+
+    // Sanity check that the local headIndex matches the flow's
+    // headIndex.
+    REQUIRE(mxlFlowReaderGetRuntimeInfo(reader, &runtimeInfo) == MXL_STATUS_OK);
+    REQUIRE(runtimeInfo.headIndex == headIndex);
+
+    // Post commit read at the new boundaryIndex is OK.
+    auto const newBoundaryIndex = headIndex - halfBufferLength + 1;
+    readBuffer = {};
+
+    REQUIRE(mxlFlowReaderGetSamplesNonBlocking(reader, newBoundaryIndex, 1U, &readBuffer) == MXL_STATUS_OK);
+
+    // Tear down.
+    REQUIRE(mxlReleaseFlowReader(instance, reader) == MXL_STATUS_OK);
+
+    REQUIRE(mxlReleaseFlowWriter(instance, writer) == MXL_STATUS_OK);
+
+    REQUIRE(mxlDestroyInstance(instance) == MXL_STATUS_OK);
+}


### PR DESCRIPTION
Reserve the tail entry of a discrete flow's ring buffer for the writer by advancing the discrete reader's minimum readable index by one entry. This prevents a reader from accessing the aliased tail entry while headIndex+1 is open for writing and aligns discrete ring-buffer behavior with continuous ring-buffer behavior.

Backport of #692 to `release/v1.0`.

This backport required two branch-specific changes: the Rust timing change was omitted because that code is not present on `release/v1.0`, and the test uses `std::uint16_t{0}` in place of `MXL_GRAIN_VALID_SLICES_ANY`.

(cherry picked from commit 646d7d8263244f3caf2d6ce10eca9bff401847b0)

<!-- SPDX-FileCopyrightText: 2026 Contributors to the Media eXchange Layer project. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- Before submitting a pull request, please check that:
- it has a suitably descriptive title
- it mentions any issue(s) that it addresses
- you have considered whether it should be backported (specify how far back below)
- any required regression tests have run successfully
- all commits are signed-off: see [here](https://github.com/dmf-mxl/mxl/blob/main/CONTRIBUTING.md#commit-sign-off) for more information
-->

# Details

# Backport requirements
