### PR TITLE
gst-mxl-rs: wait for a missing flow in create(), not negotiate()

### DIFF
--- a/rust/gst-mxl-rs/src/mxlsrc/imp.rs
+++ b/rust/gst-mxl-rs/src/mxlsrc/imp.rs
@@ -327,9 +327,8 @@ impl BaseSrcImpl for MxlSrc {
         }
 
         // `start()` does not attach the MXL reader (so PLAYING is reachable
-        // before the producer creates the flow). Attach here on the streaming
-        // thread. `init_mxl_reader` polls until the flow exists; `unlock()` sets
-        // `clock_wait.flushing` so teardown can interrupt that wait.
+        // before the producer creates the flow). Do not wait here; `create()`
+        // attaches the reader.
         let need_init = {
             let context = self
                 .context
@@ -341,32 +340,13 @@ impl BaseSrcImpl for MxlSrc {
                 .is_none_or(|s| s.flow_state.is_none())
         };
         if need_init {
-            mxl_helper::init(self)
-                .map_err(|e| gst::loggable_error!(CAT, "Failed to attach flow: {}", e))?;
-            // The flow's grain rate (hence our live latency) is only known after
-            // attach; ask the pipeline to recompute latency with the real value.
-            let _ = self
-                .obj()
-                .post_message(gst::message::Latency::builder().src(&*self.obj()).build());
+            // Succeed without caps so BaseSrc proceeds to create(), where we
+            // wait for the flow. Err here would be not-negotiated and create()
+            // would never run.
+            return Ok(());
         }
 
-        let settings = self
-            .settings
-            .lock()
-            .map_err(|e| gst::loggable_error!(CAT, "Failed to lock settings mutex {}", e))?;
-        let context = self
-            .context
-            .lock()
-            .map_err(|e| gst::loggable_error!(CAT, "Failed to lock context mutex {}", e))?;
-        let instance = &context
-            .state
-            .as_ref()
-            .ok_or(gst::loggable_error!(CAT, "Failed to get state"))?
-            .instance;
-        let flow_id = mxl_helper::get_flow_type_id(&settings)?;
-        let json_flow_description = mxl_helper::get_mxl_flow_json(instance, flow_id)?;
-        let flow_description = mxl_helper::get_flow_def(self, json_flow_description)?;
-        mxl_helper::set_json_caps(self, flow_description)
+        self.set_flow_caps()
     }
 
     fn set_caps(&self, caps: &gst::Caps) -> Result<(), gst::LoggableError> {
@@ -467,8 +447,8 @@ impl BaseSrcImpl for MxlSrc {
         // when the pipeline selects one. This is non-blocking — unlike the
         // reader attach (which can wait for `FlowNotFound`), creating the
         // instance never waits for the flow, so it is safe on the state-change
-        // thread. The reader attach still runs from `negotiate()`. If the domain
-        // was unset here, `negotiate()` → `init()` calls `ensure_instance()` once
+        // thread. The reader attach runs from `create()`. If the domain was
+        // unset here, `create()` → `init()` calls `ensure_instance()` once
         // domain and flow-id are ready. No race: `ensure_instance` caches under
         // `context` lock and concurrent callers reuse the winner.
         let have_domain = {
@@ -555,6 +535,44 @@ impl PushSrcImpl for MxlSrc {
         _buffer: Option<&mut gst::BufferRef>,
     ) -> Result<CreateSuccess, gst::FlowError> {
         loop {
+            if mxl_helper::is_flushing(self) {
+                return Err(gst::FlowError::Flushing);
+            }
+            let need_init = {
+                let context = self.context.lock().map_err(|_| gst::FlowError::Error)?;
+                context
+                    .state
+                    .as_ref()
+                    .is_none_or(|s| s.flow_state.is_none())
+            };
+            if need_init {
+                match mxl_helper::init(self) {
+                    Ok(mxl_helper::Init::Attached) => {
+                        if let Err(e) = self.set_flow_caps() {
+                            gst::element_imp_error!(
+                                self,
+                                gst::CoreError::Failed,
+                                ["Failed to set caps after attach: {}", e]
+                            );
+                            return Err(gst::FlowError::NotNegotiated);
+                        }
+                        let _ = self.obj().post_message(
+                            gst::message::Latency::builder().src(&*self.obj()).build(),
+                        );
+                    }
+                    Ok(mxl_helper::Init::Flushing) => {
+                        return Err(gst::FlowError::Flushing);
+                    }
+                    Err(e) => {
+                        gst::element_imp_error!(
+                            self,
+                            gst::CoreError::Failed,
+                            ["Failed to attach flow: {}", e]
+                        );
+                        return Err(gst::FlowError::Error);
+                    }
+                }
+            }
             // Establish the pipeline-shared `D` before `try_create` takes the
             // context lock. `None` means no clock yet: wait like NoDataCreated.
             let offset = match self.resolve_clock_offset() {
@@ -601,6 +619,26 @@ impl PushSrcImpl for MxlSrc {
 }
 
 impl MxlSrc {
+    fn set_flow_caps(&self) -> Result<(), gst::LoggableError> {
+        let settings = self
+            .settings
+            .lock()
+            .map_err(|e| gst::loggable_error!(CAT, "Failed to lock settings mutex {}", e))?;
+        let context = self
+            .context
+            .lock()
+            .map_err(|e| gst::loggable_error!(CAT, "Failed to lock context mutex {}", e))?;
+        let instance = &context
+            .state
+            .as_ref()
+            .ok_or(gst::loggable_error!(CAT, "Failed to get state"))?
+            .instance;
+        let flow_id = mxl_helper::get_flow_type_id(&settings)?;
+        let json_flow_description = mxl_helper::get_mxl_flow_json(instance, flow_id)?;
+        let flow_description = mxl_helper::get_flow_def(self, json_flow_description)?;
+        mxl_helper::set_json_caps(self, flow_description)
+    }
+
     /// Live latency to advertise: one grain period of the attached discrete flow.
     ///
     /// A grain becomes readable only once the producer has committed it, and this
@@ -623,7 +661,13 @@ impl MxlSrc {
         match &state.flow_state {
             Some(FlowState::Discrete(_)) => create_discrete(self, state, offset),
             Some(FlowState::Continuous(_)) => create_continuous(self, state, offset),
-            None => Err(gst::FlowError::Error),
+            None => {
+                if mxl_helper::is_flushing(self) {
+                    Err(gst::FlowError::Flushing)
+                } else {
+                    Err(gst::FlowError::Error)
+                }
+            }
         }
     }
 }

--- a/rust/gst-mxl-rs/src/mxlsrc/mxl_helper.rs
+++ b/rust/gst-mxl-rs/src/mxlsrc/mxl_helper.rs
@@ -161,10 +161,23 @@ enum FlowKind {
     Data,
 }
 
+/// How long the `FlowNotFound` wait sleeps between attempts, and so how often
+/// it rechecks `is_flushing`.
+pub(crate) const FLOW_NOT_FOUND_RETRY: Duration = Duration::from_millis(50);
+
+/// Successful return of [`init`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum Init {
+    /// Reader stored in `flow_state`.
+    Attached,
+    /// `is_flushing` became true during the `FlowNotFound` wait; no reader yet.
+    Flushing,
+}
+
 /// Blocks until `create_flow_reader` succeeds, sleeping briefly and retrying
 /// while MXL returns `FlowNotFound`.
 ///
-/// Before each attempt, checks `is_flushing` and returns an error if so, to
+/// Before each attempt, checks `is_flushing` and returns `Ok(None)` if so, to
 /// avoid blocking teardown via `unlock` if the flow has not yet been created.
 ///
 /// `flow_id` is passed in by the caller (typically cloned under a short
@@ -174,23 +187,31 @@ fn init_mxl_reader(
     mxlsrc: &MxlSrc,
     instance: &MxlInstance,
     flow_id: &str,
-) -> Result<FlowReader, gst::ErrorMessage> {
+) -> Result<Option<FlowReader>, gst::ErrorMessage> {
     let mut warned = false;
     loop {
         if is_flushing(mxlsrc) {
-            return Err(gst::error_msg!(
-                gst::CoreError::Failed,
-                ["Aborted waiting for flow"]
-            ));
+            gst::debug!(
+                CAT,
+                imp = mxlsrc,
+                "Flushing; stop waiting for flow {}",
+                flow_id
+            );
+            return Ok(None);
         }
         match instance.create_flow_reader(flow_id) {
-            Ok(reader) => break Ok(reader),
+            Ok(reader) => break Ok(Some(reader)),
             Err(mxl::Error::FlowNotFound) => {
                 if !warned {
-                    eprintln!("Waiting for flow to be created...");
+                    gst::info!(
+                        CAT,
+                        imp = mxlsrc,
+                        "Waiting for flow {} to be created",
+                        flow_id
+                    );
                     warned = true;
                 }
-                std::thread::sleep(Duration::from_millis(50));
+                std::thread::sleep(FLOW_NOT_FOUND_RETRY);
                 continue;
             }
             Err(err) => {
@@ -255,7 +276,9 @@ pub(crate) fn ensure_instance(mxlsrc: &MxlSrc) -> Result<MxlInstance, gst::Error
     Ok(instance)
 }
 
-pub(crate) fn init(mxlsrc: &MxlSrc) -> Result<(), gst::ErrorMessage> {
+/// Attach a flow reader. `Ok(Init::Flushing)` means `unlock()` broke the
+/// `FlowNotFound` wait; the caller should return `FlowError::Flushing`.
+pub(crate) fn init(mxlsrc: &MxlSrc) -> Result<Init, gst::ErrorMessage> {
     let (flow_kind, flow_id) = {
         let settings = mxlsrc
             .settings
@@ -279,7 +302,9 @@ pub(crate) fn init(mxlsrc: &MxlSrc) -> Result<(), gst::ErrorMessage> {
 
     // Wait for the flow to be created without holding `settings` or `context` mutexes
     // across the poll/sleep loop.
-    let reader = init_mxl_reader(mxlsrc, &instance, flow_id.as_str())?;
+    let Some(reader) = init_mxl_reader(mxlsrc, &instance, flow_id.as_str())? else {
+        return Ok(Init::Flushing);
+    };
     let binding = reader.get_info();
     let reader_info = binding.as_ref();
 
@@ -328,7 +353,9 @@ pub(crate) fn init(mxlsrc: &MxlSrc) -> Result<(), gst::ErrorMessage> {
             });
         }
         FlowKind::Audio => {
-            let reader_samples = init_mxl_reader(mxlsrc, &instance, flow_id.as_str())?;
+            let Some(reader_samples) = init_mxl_reader(mxlsrc, &instance, flow_id.as_str())? else {
+                return Ok(Init::Flushing);
+            };
             let samples_reader = reader_samples.to_samples_reader().map_err(|e| {
                 gst::error_msg!(
                     gst::CoreError::Failed,
@@ -383,7 +410,7 @@ pub(crate) fn init(mxlsrc: &MxlSrc) -> Result<(), gst::ErrorMessage> {
             });
         }
     }
-    Ok(())
+    Ok(Init::Attached)
 }
 
 fn init_mxl_instance(domain: &str) -> Result<MxlInstance, gst::ErrorMessage> {

--- a/rust/gst-mxl-rs/src/mxlsrc/src_tests.rs
+++ b/rust/gst-mxl-rs/src/mxlsrc/src_tests.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 2025 Contributors to the Media eXchange Layer project.
+// SPDX-FileCopyrightText: 2025-2026 Contributors to the Media eXchange Layer project.
 // SPDX-License-Identifier: Apache-2.0
 
 #[cfg(test)]
@@ -10,6 +10,67 @@ mod tests {
     use std::{thread, time::Duration};
 
     use crate::mxlsrc::imp::*;
+    use crate::mxlsrc::mxl_helper;
+    use std::path::PathBuf;
+
+    const SHM_MXL_HINT: &str = "MXL uses mkdtemp(3) under /dev/shm; run integration tests \
+        on Linux with tmpfs (/dev/shm)";
+
+    /// Per-test MXL domain under `/dev/shm`, removed on drop.
+    struct TestDomainGuard {
+        dir: PathBuf,
+    }
+
+    impl TestDomainGuard {
+        fn new(test: &str) -> Self {
+            let dir = PathBuf::from(format!(
+                "/dev/shm/mxl_gst_test_domain_{test}_{}",
+                uuid::Uuid::new_v4()
+            ));
+            std::fs::create_dir_all(&dir).unwrap_or_else(|e| {
+                panic!("create test domain {}: {e}\n{SHM_MXL_HINT}", dir.display())
+            });
+            Self { dir }
+        }
+
+        fn domain(&self) -> String {
+            self.dir.to_string_lossy().into_owned()
+        }
+    }
+
+    impl Drop for TestDomainGuard {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.dir);
+        }
+    }
+
+    /// Fail if the pipeline posts an ERROR within `wait`.
+    fn assert_no_bus_error(bus: &gst::Bus, wait: gst::ClockTime, what: &str) {
+        if let Some(msg) = bus.timed_pop_filtered(wait, &[gst::MessageType::Error]) {
+            panic!("{what}: {msg:?}");
+        }
+    }
+
+    /// Block until the source's streaming thread has entered its task, so that
+    /// `create()` is running.
+    fn wait_for_streaming_thread(bus: &gst::Bus) {
+        let timeout = gst::ClockTime::from_seconds(5);
+        while let Some(msg) = bus.timed_pop_filtered(
+            timeout,
+            &[gst::MessageType::StreamStatus, gst::MessageType::Error],
+        ) {
+            match msg.view() {
+                gst::MessageView::StreamStatus(s) if s.get().0 == gst::StreamStatusType::Enter => {
+                    return;
+                }
+                gst::MessageView::Error(_) => {
+                    panic!("ERROR while starting the streaming thread: {msg:?}")
+                }
+                _ => {}
+            }
+        }
+        panic!("streaming thread did not start within {timeout}");
+    }
 
     #[test]
     fn set_properties() -> Result<(), glib::Error> {
@@ -112,6 +173,62 @@ mod tests {
             .set_state(gst::State::Null)
             .map_err(|_| glib::Error::new(CoreError::Failed, "Consumer state change failed"))?;
 
+        Ok(())
+    }
+
+    #[test]
+    fn pause_while_waiting_for_missing_flow_does_not_error() -> Result<(), glib::Error> {
+        gst::init()?;
+        gst::Element::register(None, "mxlsrc", gst::Rank::NONE, MxlSrc::type_())
+            .map_err(|e| glib::Error::new(CoreError::Failed, &e.message))?;
+
+        let domain = TestDomainGuard::new("pause_wait");
+        let src = gst::ElementFactory::make("mxlsrc")
+            .property("video-flow-id", "55555555-aaaa-5555-a555-555555555555")
+            .property("domain", domain.domain())
+            .build()
+            .map_err(|e| glib::Error::new(CoreError::Failed, &e.message))?;
+        let sink = gst::ElementFactory::make("fakesink")
+            .property("sync", false)
+            .build()
+            .map_err(|e| glib::Error::new(CoreError::Failed, &e.message))?;
+
+        let pipeline = gst::Pipeline::new();
+        pipeline
+            .add_many([&src, &sink])
+            .map_err(|e| glib::Error::new(CoreError::Failed, &e.message))?;
+        gst::Element::link_many([&src, &sink])
+            .map_err(|e| glib::Error::new(CoreError::Failed, &e.message))?;
+
+        let bus = pipeline
+            .bus()
+            .ok_or_else(|| glib::Error::new(CoreError::Failed, "pipeline has no bus"))?;
+        pipeline
+            .set_state(gst::State::Playing)
+            .map_err(|_| glib::Error::new(CoreError::Failed, "Playing state change failed"))?;
+        // Live source: PLAYING returns before create() reaches the wait, and
+        // ENTER is posted in the same moment the task starts, so wait across
+        // a couple of FlowNotFound retries before interrupting.
+        wait_for_streaming_thread(&bus);
+        thread::sleep(mxl_helper::FLOW_NOT_FOUND_RETRY * 2);
+
+        // PAUSED calls unlock() on the source, interrupting the wait.
+        pipeline
+            .set_state(gst::State::Paused)
+            .map_err(|_| glib::Error::new(CoreError::Failed, "Paused state change failed"))?;
+        pipeline
+            .set_state(gst::State::Playing)
+            .map_err(|_| glib::Error::new(CoreError::Failed, "Playing state change failed"))?;
+
+        // An interrupted wait posts not-negotiated within a few milliseconds.
+        assert_no_bus_error(
+            &bus,
+            gst::ClockTime::from_mseconds(mxl_helper::FLOW_NOT_FOUND_RETRY.as_millis() as u64),
+            "pausing while waiting for a missing flow posted ERROR",
+        );
+        pipeline
+            .set_state(gst::State::Null)
+            .map_err(|_| glib::Error::new(CoreError::Failed, "Null state change failed"))?;
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary

- Move the `FlowNotFound` wait out of `negotiate()` into `create()`, so a live `mxlsrc` can reach PLAYING before the producer creates the flow. Reaching PLAYING first is existing behaviour (`set_live(true)`, `start()` does not attach the reader, and `start_valid_pipeline` starts the consumer first); the bug is that `negotiate()` was the wrong place to block.
- When `unlock()` interrupts that wait, `create()` now returns `FlowError::Flushing` rather than failing negotiation. Previously the interrupted wait made `negotiate()` fail, which basesrc reported as `streaming stopped, reason not-negotiated (-4)` — a bus ERROR that kills the pipeline. `unlock()` is called on FLUSH_START and also on PLAYING to PAUSED, so a consumer waiting for a flow that did not exist yet died as soon as anything paused or flushed it.

## Test plan

New unit test `pause_while_waiting_for_missing_flow_does_not_error`: put `mxlsrc` in PLAYING with a flow id that does not exist, wait until the streaming thread is inside the `FlowNotFound` wait, cycle PAUSED then PLAYING, and assert nothing posts an ERROR on the bus.

- [x] `cargo test -p gst-mxl-rs --lib`, with default parallelism and with `--test-threads=1`
- [x] The new test fails 10 out of 10 runs against the code before this change (`not-negotiated (-4)`), and passes 10 out of 10 with it
- [x] CI `gst-mxl-rs` job

# Backport requirements

Should be backported to `release/v1.1` — labelled `backport/v1.1`.
