### PR TITLE
Internal: Fix reader reordering in FlowSynchronizationGroup::waitForDataAt

### DIFF
--- a/lib/internal/src/FlowSynchronizationGroup.cpp
+++ b/lib/internal/src/FlowSynchronizationGroup.cpp
@@ -76,6 +76,7 @@ namespace mxl::lib
 
     mxlStatus FlowSynchronizationGroup::waitForDataAt(Timepoint originTime, Timepoint deadline) const
     {
+        auto prev = _readers.before_begin();
         for (auto it = _readers.begin(); it != _readers.end(); /* Nothing */)
         {
             auto const current = it++;
@@ -99,7 +100,7 @@ namespace mxl::lib
 
                 if (result == MXL_STATUS_OK)
                 {
-                    // If the current source delay of this flow exceeds any previosuly observed source delay of
+                    // If the current source delay of this flow exceeds any previously observed source delay of
                     // this flow we update the cached maximum and if this new maximum turns out to be bigger than
                     // the maximum source delay observed for the flow at the head of the list, we move this flow
                     // to the front, hoping that we can save blocking waits in the future.
@@ -113,7 +114,9 @@ namespace mxl::lib
                             current->maxObservedSourceDelay = sourceDelay;
                             if (current->maxObservedSourceDelay > _readers.begin()->maxObservedSourceDelay)
                             {
-                                _readers.splice_after(_readers.before_begin(), _readers, current);
+                                // `splice_after` moves the element *following* the iterator it is given.
+                                _readers.splice_after(_readers.before_begin(), _readers, prev);
+                                continue; // `prev` already precedes `it` after the splice.
                             }
                         }
                     }
@@ -123,6 +126,7 @@ namespace mxl::lib
                     return result;
                 }
             }
+            prev = current;
         }
         return MXL_STATUS_OK;
     }

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ set_target_properties(mxl-tests
 
 target_sources(mxl-tests
         PRIVATE
+            test_flow_sync_groups.cpp
             test_flows.cpp
             test_flows_timing.cpp
             test_instance.cpp

--- a/lib/tests/test_flow_sync_groups.cpp
+++ b/lib/tests/test_flow_sync_groups.cpp
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <chrono>
+#include <cstdint>
+#include <thread>
+#include <catch2/catch_test_macros.hpp>
+#include <mxl/flow.h>
+#include <mxl/mxl.h>
+#include <mxl/time.h>
+#include "Utils.hpp"
+
+namespace
+{
+    constexpr auto VIDEO_FLOW_ID = "5fbec3b1-1b0f-417d-9059-8b94a47197ed";
+    constexpr auto DATA_FLOW_ID = "db3bd465-2772-484f-8fac-830b0471258b";
+
+    /// Both test flows share this grain rate, so a given timestamp maps to the same
+    /// grain index and expected arrival time on either of them.
+    constexpr auto GRAIN_RATE = mxlRational{30000, 1001};
+
+    /// Commit the grain with the given index after `delay`, so that a reader waiting on
+    /// it observes a source delay of at least `delay`.
+    mxlStatus commitGrainAfter(mxlFlowWriter writer, std::uint64_t index, std::chrono::milliseconds delay)
+    {
+        std::this_thread::sleep_for(delay);
+
+        mxlGrainInfo info;
+        std::uint8_t* buffer = nullptr;
+        if (auto const status = mxlFlowWriterOpenGrain(writer, index, &info, &buffer); status != MXL_STATUS_OK)
+        {
+            return status;
+        }
+        info.validSlices = info.totalSlices;
+        return mxlFlowWriterCommitGrain(writer, &info);
+    }
+}
+
+///
+/// A synchronization group must keep synchronizing for as long as it exists.
+///
+/// `FlowSynchronizationGroup::waitForDataAt` opportunistically moves the flow with the
+/// largest observed source delay to the front of its reader list. This test makes the
+/// *second* member the slower one, so that the reordering is triggered, and then checks
+/// that the group still waits on its members afterwards.
+///
+TEST_CASE_PERSISTENT_FIXTURE(mxl::tests::mxlDomainFixture, "Synchronization group : Repeated waits", "[mxl sync groups]")
+{
+    auto const opts = "{}";
+
+    auto instance = mxlCreateInstance(domain.string().c_str(), opts);
+    REQUIRE(instance != nullptr);
+
+    // Two discrete flows sharing a grain rate. The data flow is written late on purpose.
+    mxlFlowWriter videoWriter;
+    mxlFlowWriter dataWriter;
+    mxlFlowConfigInfo configInfo;
+    bool created = false;
+    REQUIRE(
+        mxlCreateFlowWriter(instance, mxl::tests::readFile("data/v210_flow.json").c_str(), "", &videoWriter, &configInfo, &created) == MXL_STATUS_OK);
+    REQUIRE(
+        mxlCreateFlowWriter(instance, mxl::tests::readFile("data/data_flow.json").c_str(), "", &dataWriter, &configInfo, &created) == MXL_STATUS_OK);
+
+    mxlFlowReader videoReader;
+    mxlFlowReader dataReader;
+    REQUIRE(mxlCreateFlowReader(instance, VIDEO_FLOW_ID, "", &videoReader) == MXL_STATUS_OK);
+    REQUIRE(mxlCreateFlowReader(instance, DATA_FLOW_ID, "", &dataReader) == MXL_STATUS_OK);
+
+    mxlFlowSynchronizationGroup group;
+    REQUIRE(mxlCreateFlowSynchronizationGroup(instance, &group) == MXL_STATUS_OK);
+    REQUIRE(mxlFlowSynchronizationGroupAddReader(group, videoReader) == MXL_STATUS_OK);
+    REQUIRE(mxlFlowSynchronizationGroupAddReader(group, dataReader) == MXL_STATUS_OK);
+
+    // First wait: both grains arrive, the second member later than the first.
+    auto const firstIndex = mxlTimestampToIndex(&GRAIN_RATE, mxlGetTime()) + 1;
+    auto const firstTimestamp = mxlIndexToTimestamp(&GRAIN_RATE, firstIndex);
+
+    auto videoStatus = MXL_ERR_UNKNOWN;
+    auto dataStatus = MXL_ERR_UNKNOWN;
+    auto videoThread = std::thread{[&]
+        {
+            videoStatus = commitGrainAfter(videoWriter, firstIndex, std::chrono::milliseconds{50});
+        }};
+    auto dataThread = std::thread{[&]
+        {
+            dataStatus = commitGrainAfter(dataWriter, firstIndex, std::chrono::milliseconds{250});
+        }};
+
+    auto const firstWaitStatus = mxlFlowSynchronizationGroupWaitForDataAt(group, firstTimestamp, 2'000'000'000ULL);
+
+    videoThread.join();
+    dataThread.join();
+
+    REQUIRE(videoStatus == MXL_STATUS_OK);
+    REQUIRE(dataStatus == MXL_STATUS_OK);
+    REQUIRE(firstWaitStatus == MXL_STATUS_OK);
+
+    // Second wait, on the same group, for a grain that nobody will ever write. The group
+    // must block until the timeout expires instead of reporting the data as available.
+    auto const missingTimestamp = mxlIndexToTimestamp(&GRAIN_RATE, firstIndex + 1000);
+
+    auto const start = std::chrono::steady_clock::now();
+    auto const secondWaitStatus = mxlFlowSynchronizationGroupWaitForDataAt(group, missingTimestamp, 200'000'000ULL);
+    auto const elapsed = std::chrono::steady_clock::now() - start;
+
+    CHECK(secondWaitStatus != MXL_STATUS_OK);
+    CHECK(elapsed >= std::chrono::milliseconds{150});
+
+    REQUIRE(mxlReleaseFlowSynchronizationGroup(instance, group) == MXL_STATUS_OK);
+    REQUIRE(mxlReleaseFlowReader(instance, videoReader) == MXL_STATUS_OK);
+    REQUIRE(mxlReleaseFlowReader(instance, dataReader) == MXL_STATUS_OK);
+    REQUIRE(mxlReleaseFlowWriter(instance, videoWriter) == MXL_STATUS_OK);
+    REQUIRE(mxlReleaseFlowWriter(instance, dataWriter) == MXL_STATUS_OK);
+    mxlDestroyInstance(instance);
+}


### PR DESCRIPTION
## What's broken

A `FlowSynchronizationGroup` with two or more readers silently stops synchronizing after its first internal reordering. From that point on, `mxlFlowSynchronizationGroupWaitForDataAt` returns `MXL_STATUS_OK` in microseconds regardless of whether the data is actually there.

It fails by looking like success: no error code, no log line, no crash. A consumer keeps calling the API and keeps being told the data is ready, and simply reads whatever happens to be in the ring.

## Why

`waitForDataAt` opportunistically promotes the flow with the largest observed source delay to the front of `_readers`, so that later calls block on the slowest source first. The promotion was written as:

```cpp
_reader.splice_after(_readers.before_begin(), _readers, current);
```

`std::forward_list::splice_after(pos, other, it)` moves the element **following** `it`, not `*it` - a singly-linked list can only unlink an element through its predecessor. So passing the iterator of the entry to be promoted moves that entry's *successor* instead.

Two failure shapes:
- **Entry in the middle of the list:** the wrong entry is promoted. A bad heuristic decision, but harmless.
- **Entry at then end of the list:** `std::next(current)` is the end iterator and the call is undefined behavior. With libstdc++ the list's head pointer is nulled - the list becomes **empty** and its nodes are leaked. `waitForDataAt` then iterates over nothing and returns `MXL_STATUS_OK` immediately, forever.

A standalone reproducer of just the list operation, under ASan/UBSan:

```
before                       [ video audio ]
after splice_after(current)  [ ]
SUMMARY: AddressSanitizer: 80 byte(s) leaked in 2 allocation(s)
```

## When it triggers

It fires the first time a non-head member's observed source delay exceeds the head's record - in practice almost immediately whenever one source is consistently later than another, which is the normal use case for sync-group.

## The fix

Track the predecessor of the entry being examined and pass that to `splice_after`. After the splice the predecessor already precedes the loop cursor, so it must not be advanced -  hence the `continue`.

The promotion condition can only hold for an entry that is not the head, so the tracked predecessor is always a real element and never `before_begin()`.

## Testing

Adds `lib/tests/test_flow_sync_groups.cpp` -
`Synchronization group : Repeated waits`. Two discrete flows sharing a grain rate are added to one group; the second member's grain is committed deliberately late sot that the reordering is triggered on the first wait. A second wait on the same group then asks for a grain nobody will ever write and must time out. The reordering logic is independent of reader type - variant only selects which wait function is called - so the test uses two discrete flows for determinism.

Before the fix that second wait returns `MXL_STATUS_OK` instantly instead of blocking for its 200 ms timeout. After the fix it times out correctly.

Built and tested locally on Linux x86_64 *with both the `Linux-GCC-Release` and `Linux-Clang-Release` presets: `all` builds warning-free and `ctest` reports 60/60 passing on each. `clang-format --dry-run --Werror` over `lib` and `tools` is clean.*